### PR TITLE
feat: implement project roles

### DIFF
--- a/drizzle/0004_project_roles.sql
+++ b/drizzle/0004_project_roles.sql
@@ -1,0 +1,9 @@
+ALTER TABLE `users` ADD COLUMN `can_create_projects` integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+CREATE TABLE `project_members` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `project_id` integer NOT NULL REFERENCES `projects`(`id`) ON DELETE CASCADE,
+  `user_id` integer NOT NULL REFERENCES `users`(`id`) ON DELETE CASCADE,
+  `role` text NOT NULL DEFAULT 'guest',
+  `created_at` integer NOT NULL DEFAULT (unixepoch() * 1000)
+);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1775705530353,
       "tag": "0003_user_accounts",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1775705530354,
+      "tag": "0004_project_roles",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -20,6 +20,8 @@ import {
   ArrowLeftIcon,
   CheckIcon,
   ClipboardIcon,
+  FolderIcon,
+  FolderPlusIcon,
   PlusIcon,
   RefreshCwIcon,
   ShieldIcon,
@@ -70,6 +72,7 @@ export default function AdminUsersView({
   // Create
   const [createOpen, setCreateOpen] = useState(false);
   const [newUsername, setNewUsername] = useState("");
+  const [newCanCreateProjects, setNewCanCreateProjects] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
 
@@ -89,7 +92,10 @@ export default function AdminUsersView({
       const res = await fetch("/api/users", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ userName: newUsername.trim() }),
+        body: JSON.stringify({
+          userName: newUsername.trim(),
+          canCreateProjects: newCanCreateProjects,
+        }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -98,6 +104,7 @@ export default function AdminUsersView({
       }
       setUsers((prev) => [...prev, data]);
       setNewUsername("");
+      setNewCanCreateProjects(false);
       setCreateOpen(false);
     } finally {
       setCreating(false);
@@ -131,6 +138,22 @@ export default function AdminUsersView({
     if (res.ok) {
       setUsers((prev) =>
         prev.map((u) => (u.id === id ? { ...u, isAdmin } : u)),
+      );
+    }
+  };
+
+  const handleToggleCanCreateProjects = async (
+    id: number,
+    canCreateProjects: boolean,
+  ) => {
+    const res = await fetch("/api/users", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id, canCreateProjects }),
+    });
+    if (res.ok) {
+      setUsers((prev) =>
+        prev.map((u) => (u.id === id ? { ...u, canCreateProjects } : u)),
       );
     }
   };
@@ -203,6 +226,20 @@ export default function AdminUsersView({
                         required
                       />
                     </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id="canCreateProjects"
+                        checked={newCanCreateProjects}
+                        onChange={(e) =>
+                          setNewCanCreateProjects(e.target.checked)
+                        }
+                        className="h-4 w-4"
+                      />
+                      <Label htmlFor="canCreateProjects">
+                        Can create projects
+                      </Label>
+                    </div>
                     <p className="text-sm text-muted-foreground">
                       A temporary password will be generated. Share it with the
                       user — they'll be prompted to set a new one on first
@@ -270,6 +307,32 @@ export default function AdminUsersView({
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
+                        {user.id !== currentUserId && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <button
+                                onClick={() =>
+                                  handleToggleCanCreateProjects(
+                                    user.id,
+                                    !user.canCreateProjects,
+                                  )
+                                }
+                                className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                              >
+                                {user.canCreateProjects ? (
+                                  <FolderPlusIcon size={15} />
+                                ) : (
+                                  <FolderIcon size={15} />
+                                )}
+                              </button>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {user.canCreateProjects
+                                ? "Revoke project creation"
+                                : "Allow project creation"}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                         {user.id !== currentUserId && (
                           <Tooltip>
                             <TooltipTrigger asChild>

--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -133,6 +133,7 @@ function MethodBadge({ method }: { method: string }) {
 }
 
 export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
+  const displayKey = apiKey;
   const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
 
   const sections = [
@@ -253,12 +254,12 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 <Badge variant="warning">Keep this secret</Badge>
               </div>
               <code className="block font-mono text-amber-900 dark:text-amber-300 bg-white/60 dark:bg-white/10 px-4 py-3 rounded-lg text-sm break-all">
-                {apiKey}
+                {displayKey}
               </code>
             </div>
             <div className="bg-gray-900 rounded-xl p-4">
               <code className="text-gray-100 font-mono text-sm">
-                X-API-Key: {apiKey}
+                X-API-Key: {displayKey}
               </code>
             </div>
           </section>
@@ -460,7 +461,7 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 language="bash"
                 code={`curl -X POST ${baseUrl}/api/event \\
   -H "Content-Type: application/json" \\
-  -H "X-API-Key: ${apiKey}" \\
+  -H "X-API-Key: ${displayKey}" \\
   -d '{
     "name": "User Signed Up",
     "channel": "signups",
@@ -562,7 +563,7 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 <CodeBlock
                   title="sendEvent.js"
                   language="javascript"
-                  code={`const API_KEY = '${apiKey}';
+                  code={`const API_KEY = '${displayKey}';
 
 async function sendEvent(eventData) {
   const response = await fetch('${baseUrl}/api/event', {
@@ -606,7 +607,7 @@ await sendEvent({
                   language="python"
                   code={`import requests
 
-API_KEY = '${apiKey}'
+API_KEY = '${displayKey}'
 
 def send_event(name, channel, description=None, icon=None, tags=None):
     response = requests.post(
@@ -651,7 +652,7 @@ import (
     "net/http"
 )
 
-const apiKey = "${apiKey}"
+const apiKey = "${displayKey}"
 
 type Event struct {
     Name        string            \`json:"name"\`

--- a/src/components/create-project-view.tsx
+++ b/src/components/create-project-view.tsx
@@ -28,7 +28,7 @@ function CreateProjectForm() {
       const res = await fetch("/api/project", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: projectName, ownerId: user.id }),
+        body: JSON.stringify({ name: projectName }),
       });
 
       const data = await res.json();

--- a/src/components/project-members.tsx
+++ b/src/components/project-members.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState } from "react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "./ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+import { UserMinusIcon, UserPlusIcon } from "lucide-react";
+
+type Role = "owner" | "maintainer" | "guest";
+
+type Member = {
+  id: number;
+  userId: number;
+  userName: string;
+  role: Role;
+};
+
+type NonMember = {
+  id: number;
+  userName: string;
+};
+
+export default function ProjectMembers({
+  projectId,
+  currentUserId,
+}: {
+  projectId: number;
+  currentUserId: number;
+}) {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [nonMembers, setNonMembers] = useState<NonMember[]>([]);
+  const [addOpen, setAddOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<Member | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string>("");
+  const [selectedRole, setSelectedRole] = useState<Role>("guest");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const fetchMembers = async () => {
+    const res = await fetch(`/api/project-members?projectId=${projectId}`);
+    if (res.ok) {
+      const data = await res.json();
+      setMembers(data.members);
+      setNonMembers(data.nonMembers);
+    }
+  };
+
+  useEffect(() => {
+    fetchMembers();
+  }, [projectId]);
+
+  const handleAddMember = async () => {
+    if (!selectedUserId) return;
+    setLoading(true);
+    setError("");
+    const res = await fetch("/api/project-members", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        projectId,
+        userId: parseInt(selectedUserId),
+        role: selectedRole,
+      }),
+    });
+    setLoading(false);
+    if (res.ok) {
+      setAddOpen(false);
+      setSelectedUserId("");
+      setSelectedRole("guest");
+      await fetchMembers();
+    } else {
+      const data = await res.json();
+      setError(data.error ?? "Failed to add member.");
+    }
+  };
+
+  const handleRoleChange = async (userId: number, role: Role) => {
+    const res = await fetch("/api/project-members", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId, userId, role }),
+    });
+    if (res.ok) {
+      setMembers((prev) =>
+        prev.map((m) => (m.userId === userId ? { ...m, role } : m)),
+      );
+    } else {
+      const data = await res.json();
+      alert(data.error ?? "Failed to update role.");
+    }
+  };
+
+  const handleRemoveMember = async () => {
+    if (!removeTarget) return;
+    setLoading(true);
+    const res = await fetch("/api/project-members", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId, userId: removeTarget.userId }),
+    });
+    setLoading(false);
+    if (res.ok) {
+      setRemoveTarget(null);
+      await fetchMembers();
+    } else {
+      const data = await res.json();
+      alert(data.error ?? "Failed to remove member.");
+    }
+  };
+
+  return (
+    <TooltipProvider>
+      <div className="flex flex-col space-y-2">
+        {members.map((member) => (
+          <div
+            key={member.id}
+            className="flex items-center justify-between py-2 border-b last:border-0"
+          >
+            <span className="font-medium">@{member.userName}</span>
+            <div className="flex items-center gap-2">
+              <Select
+                value={member.role}
+                onValueChange={(val) =>
+                  handleRoleChange(member.userId, val as Role)
+                }
+                disabled={member.userId === currentUserId}
+              >
+                <SelectTrigger className="w-32 h-8 text-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="owner">Owner</SelectItem>
+                  <SelectItem value="maintainer">Maintainer</SelectItem>
+                  <SelectItem value="guest">Guest</SelectItem>
+                </SelectContent>
+              </Select>
+              {member.userId !== currentUserId && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-8 w-8 text-destructive hover:text-destructive"
+                      onClick={() => setRemoveTarget(member)}
+                    >
+                      <UserMinusIcon size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Remove member</TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {nonMembers.length > 0 && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 self-start"
+            onClick={() => setAddOpen(true)}
+          >
+            <UserPlusIcon size={14} className="mr-1" />
+            Add Member
+          </Button>
+        )}
+      </div>
+
+      {/* Add member dialog */}
+      <Dialog open={addOpen} onOpenChange={setAddOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add Member</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">User</label>
+              <Select value={selectedUserId} onValueChange={setSelectedUserId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a user…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {nonMembers.map((u) => (
+                    <SelectItem key={u.id} value={String(u.id)}>
+                      @{u.userName}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Role</label>
+              <Select
+                value={selectedRole}
+                onValueChange={(val) => setSelectedRole(val as Role)}
+              >
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="owner">Owner</SelectItem>
+                  <SelectItem value="maintainer">Maintainer</SelectItem>
+                  <SelectItem value="guest">Guest</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setAddOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAddMember}
+              disabled={loading || !selectedUserId}
+            >
+              Add
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Remove confirmation dialog */}
+      <Dialog open={!!removeTarget} onOpenChange={() => setRemoveTarget(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Remove Member</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground py-2">
+            Remove <strong>@{removeTarget?.userName}</strong> from this project?
+          </p>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRemoveTarget(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRemoveMember}
+              disabled={loading}
+            >
+              Remove
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
+  );
+}

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -126,6 +126,7 @@ function SortableGroup({
   onNavigate,
   channelItems,
   dimChannels,
+  canEdit,
 }: {
   group: ChannelGroupWithChannels;
   collapsed: boolean;
@@ -138,6 +139,7 @@ function SortableGroup({
   onNavigate?: () => void;
   channelItems: UniqueIdentifier[];
   dimChannels?: boolean;
+  canEdit: boolean;
 }) {
   const {
     attributes,
@@ -146,10 +148,25 @@ function SortableGroup({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: grpId(group.id) });
+  } = useSortable({ id: grpId(group.id), disabled: !canEdit });
 
   const isChannelActive = (id: number) =>
     pathname === `/dashboard/${projectId}/channels/${id}`;
+
+  const headerButton = (
+    <button
+      {...(canEdit ? { ...attributes, ...listeners } : {})}
+      onClick={onToggle}
+      className={`flex w-full items-center gap-1 px-1 py-0.5 text-xs font-semibold capitalize text-muted-foreground hover:text-foreground rounded hover:bg-gray-100 dark:hover:bg-white/8 transition-colors select-none ${canEdit ? "cursor-grab active:cursor-grabbing" : "cursor-pointer"}`}
+    >
+      {collapsed ? (
+        <ChevronRightIcon size={12} className="shrink-0" />
+      ) : (
+        <ChevronDownIcon size={12} className="shrink-0" />
+      )}
+      <span className="truncate">{group.name}</span>
+    </button>
+  );
 
   return (
     <div
@@ -161,37 +178,29 @@ function SortableGroup({
       }}
       className="mt-2"
     >
-      <ContextMenu>
-        <ContextMenuTrigger asChild>
-          <button
-            {...attributes}
-            {...listeners}
-            onClick={onToggle}
-            className="flex w-full items-center gap-1 px-1 py-0.5 text-xs font-semibold capitalize text-muted-foreground hover:text-foreground rounded hover:bg-gray-100 dark:hover:bg-white/8 cursor-grab active:cursor-grabbing transition-colors select-none"
-          >
-            {collapsed ? (
-              <ChevronRightIcon size={12} className="shrink-0" />
-            ) : (
-              <ChevronDownIcon size={12} className="shrink-0" />
-            )}
-            <span className="truncate">{group.name}</span>
-          </button>
-        </ContextMenuTrigger>
-        <ContextMenuContent>
-          <ContextMenuItem onSelect={() => onRename(group.id)}>
-            Rename
-          </ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem onSelect={onNewGroup}>Add New Group</ContextMenuItem>
-          <ContextMenuSeparator />
-          <ContextMenuItem
-            onSelect={() => onDelete(group.id)}
-            className="text-destructive focus:text-destructive"
-          >
-            Delete Group
-          </ContextMenuItem>
-        </ContextMenuContent>
-      </ContextMenu>
+      {canEdit ? (
+        <ContextMenu>
+          <ContextMenuTrigger asChild>{headerButton}</ContextMenuTrigger>
+          <ContextMenuContent>
+            <ContextMenuItem onSelect={() => onRename(group.id)}>
+              Rename
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem onSelect={onNewGroup}>
+              Add New Group
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem
+              onSelect={() => onDelete(group.id)}
+              className="text-destructive focus:text-destructive"
+            >
+              Delete Group
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ) : (
+        headerButton
+      )}
 
       {!collapsed && (
         <SortableContext
@@ -277,6 +286,7 @@ function ChannelGroups({
   onNavigate,
   triggerCreate,
   onTriggerCreateDone,
+  canEdit,
 }: {
   initialUngrouped: Channel[];
   initialGroups: ChannelGroupWithChannels[];
@@ -285,6 +295,7 @@ function ChannelGroups({
   onNavigate?: () => void;
   triggerCreate: boolean;
   onTriggerCreateDone: () => void;
+  canEdit: boolean;
 }) {
   const [ungrouped, setUngrouped] = useState<Channel[]>(initialUngrouped);
   const [groups, setGroups] =
@@ -343,7 +354,9 @@ function ChannelGroups({
   }, []);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(PointerSensor, {
+      activationConstraint: canEdit ? { distance: 6 } : { distance: 999999 },
+    }),
   );
 
   // ── Container lookup ───────────────────────────────────────────────────────
@@ -660,6 +673,7 @@ function ChannelGroups({
               onNavigate={onNavigate}
               channelItems={group.channels.map((c) => chId(c.id))}
               dimChannels={isDraggingGroup}
+              canEdit={canEdit}
             />
           );
         })}
@@ -701,6 +715,7 @@ function PanelContent({
   currentGroups,
   pathname,
   onNavigate,
+  userRole,
 }: {
   currentProject: Project;
   currentProjects: Project[];
@@ -708,10 +723,14 @@ function PanelContent({
   currentGroups: ChannelGroupWithChannels[];
   pathname: string;
   onNavigate?: () => void;
+  userRole: "owner" | "maintainer" | "guest";
 }) {
   const [projects] = useState<Project[]>(currentProjects);
   const [triggerCreateGroup, setTriggerCreateGroup] = useState(false);
   const { user, signOut } = useAuth();
+
+  const canEdit = userRole === "owner" || userRole === "maintainer";
+  const isOwner = userRole === "owner";
 
   const handleSignout = async () => {
     await signOut();
@@ -757,12 +776,14 @@ function PanelContent({
       {/* Project */}
       <div className="flex space-x-2 w-full items-center justify-between mt-4">
         <h1 className="text-sm font-mono">Project</h1>
-        <a href="/dashboard/create-project">
-          <PlusIcon
-            size={20}
-            className="hover:cursor-pointer hover:text-black/50"
-          />
-        </a>
+        {(user?.isAdmin || user?.canCreateProjects) && (
+          <a href="/dashboard/create-project">
+            <PlusIcon
+              size={20}
+              className="hover:cursor-pointer hover:text-black/50"
+            />
+          </a>
+        )}
       </div>
       <Select
         defaultValue={String(currentProject.id)}
@@ -797,22 +818,26 @@ function PanelContent({
           <InboxIcon size={20} />
           <p>Feed</p>
         </a>
-        <a
-          className={isSettingsActive() ? activeNavCss : navCss}
-          href={`/dashboard/${project.id}/settings`}
-          onClick={() => onNavigate?.()}
-        >
-          <Settings size={20} />
-          <p>Settings</p>
-        </a>
-        <a
-          className={isApiDocsActive() ? activeNavCss : navCss}
-          href={`/dashboard/${project.id}/api-docs`}
-          onClick={() => onNavigate?.()}
-        >
-          <BookOpenIcon size={20} />
-          <p>API Docs</p>
-        </a>
+        {canEdit && (
+          <a
+            className={isSettingsActive() ? activeNavCss : navCss}
+            href={`/dashboard/${project.id}/settings`}
+            onClick={() => onNavigate?.()}
+          >
+            <Settings size={20} />
+            <p>Settings</p>
+          </a>
+        )}
+        {canEdit && (
+          <a
+            className={isApiDocsActive() ? activeNavCss : navCss}
+            href={`/dashboard/${project.id}/api-docs`}
+            onClick={() => onNavigate?.()}
+          >
+            <BookOpenIcon size={20} />
+            <p>API Docs</p>
+          </a>
+        )}
         {user?.isAdmin && (
           <a
             className={pathname === "/admin/users" ? activeNavCss : navCss}
@@ -828,23 +853,25 @@ function PanelContent({
       {/* Channels header */}
       <div className="flex w-full items-center justify-between mt-4 mb-1">
         <h1 className="text-sm font-mono">Channels</h1>
-        <div className="flex items-center gap-1.5">
-          <button
-            onClick={() => setTriggerCreateGroup(true)}
-            title="New group"
-            className="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-white/8 text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <FolderPlusIcon size={15} />
-          </button>
-          <a
-            href={`/dashboard/${project.id}/create-channel`}
-            onClick={() => onNavigate?.()}
-            title="New channel"
-            className="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-white/8 text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <PlusIcon size={15} />
-          </a>
-        </div>
+        {canEdit && (
+          <div className="flex items-center gap-1.5">
+            <button
+              onClick={() => setTriggerCreateGroup(true)}
+              title="New group"
+              className="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-white/8 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <FolderPlusIcon size={15} />
+            </button>
+            <a
+              href={`/dashboard/${project.id}/create-channel`}
+              onClick={() => onNavigate?.()}
+              title="New channel"
+              className="p-0.5 rounded hover:bg-gray-100 dark:hover:bg-white/8 text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <PlusIcon size={15} />
+            </a>
+          </div>
+        )}
       </div>
 
       <ChannelGroups
@@ -855,6 +882,7 @@ function PanelContent({
         onNavigate={onNavigate}
         triggerCreate={triggerCreateGroup}
         onTriggerCreateDone={() => setTriggerCreateGroup(false)}
+        canEdit={canEdit}
       />
 
       {/* Theme */}
@@ -873,12 +901,14 @@ function SidePanelContent({
   currentChannels,
   currentGroups,
   currentPath,
+  userRole,
 }: {
   currentProject: Project;
   currentProjects: Project[];
   currentChannels: Channel[];
   currentGroups: ChannelGroupWithChannels[];
   currentPath: string;
+  userRole: "owner" | "maintainer" | "guest";
 }) {
   const [pathname, setPathname] = useState(currentPath);
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -915,6 +945,7 @@ function SidePanelContent({
     currentChannels,
     currentGroups,
     pathname,
+    userRole,
   };
 
   return (

--- a/src/context/user-context.tsx
+++ b/src/context/user-context.tsx
@@ -13,6 +13,7 @@ export interface User {
   id: number;
   userName: string;
   isAdmin: boolean;
+  canCreateProjects: boolean;
 }
 
 interface AuthState {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -6,6 +6,7 @@ declare namespace App {
       id: number;
       userName: string;
       isAdmin: boolean;
+      canCreateProjects: boolean;
     };
   }
 }

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -4,6 +4,10 @@ import SidePanel from "@/components/side-panel";
 import { getProject, getProjects } from "@/lib/beaver/project";
 import { getChannels } from "@/lib/beaver/channel";
 import { getChannelGroups } from "@/lib/beaver/channel-group";
+import {
+  getProjectsForUser,
+  getUserProjectRole,
+} from "@/lib/beaver/project-member";
 import { ClientRouter } from "astro:transitions";
 
 interface Props {
@@ -11,12 +15,20 @@ interface Props {
 }
 
 const { projectID } = Astro.props;
+const user = Astro.locals.user!;
 
 const project = await getProject(parseInt(projectID));
 
-const projects = await getProjects();
+const projects = user.isAdmin
+  ? await getProjects()
+  : await getProjectsForUser(user.id);
+
 const channels = await getChannels(project.id);
 const channelGroupsData = await getChannelGroups(project.id);
+
+const userRole = user.isAdmin
+  ? "owner"
+  : await getUserProjectRole(project.id, user.id);
 ---
 
 <html lang="en">
@@ -49,6 +61,7 @@ const channelGroupsData = await getChannelGroups(project.id);
         currentChannels={channels}
         currentGroups={channelGroupsData}
         currentPath={Astro.url.pathname}
+        userRole={userRole ?? "guest"}
         transition:persist
       />
       <div class="flex-1 min-w-0">

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -11,6 +11,7 @@ export interface JWTPayload {
   userId: number;
   userName: string;
   isAdmin: boolean;
+  canCreateProjects: boolean;
   mustChangePassword: boolean;
 }
 
@@ -37,6 +38,7 @@ export async function verifyToken(token: string): Promise<JWTPayload | null> {
       userId: payload.userId as number,
       userName: payload.userName as string,
       isAdmin: payload.isAdmin as boolean,
+      canCreateProjects: (payload.canCreateProjects as boolean) ?? false,
       mustChangePassword: (payload.mustChangePassword as boolean) ?? false,
     };
   } catch {

--- a/src/lib/beaver/project-member.ts
+++ b/src/lib/beaver/project-member.ts
@@ -1,0 +1,156 @@
+import { db } from "../db/db";
+import { projectMembers, users, projects } from "../db/schema";
+import { eq, and } from "drizzle-orm";
+
+export type Role = "owner" | "maintainer" | "guest";
+
+export type ProjectMember = {
+  id: number;
+  projectId: number;
+  userId: number;
+  role: Role;
+  createdAt: Date | null;
+};
+
+export type ProjectMemberWithUser = ProjectMember & {
+  userName: string;
+};
+
+export async function getProjectMembers(
+  projectId: number,
+): Promise<ProjectMemberWithUser[]> {
+  const rows = await db
+    .select({
+      id: projectMembers.id,
+      projectId: projectMembers.projectId,
+      userId: projectMembers.userId,
+      role: projectMembers.role,
+      createdAt: projectMembers.createdAt,
+      userName: users.userName,
+    })
+    .from(projectMembers)
+    .innerJoin(users, eq(projectMembers.userId, users.id))
+    .where(eq(projectMembers.projectId, projectId));
+
+  return rows as ProjectMemberWithUser[];
+}
+
+export async function getUserProjectRole(
+  projectId: number,
+  userId: number,
+): Promise<Role | null> {
+  const rows = await db
+    .select({ role: projectMembers.role })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  return rows[0]?.role ?? null;
+}
+
+export async function addProjectMember(
+  projectId: number,
+  userId: number,
+  role: Role,
+): Promise<ProjectMember> {
+  const [row] = await db
+    .insert(projectMembers)
+    .values({ projectId, userId, role })
+    .returning();
+  return row as ProjectMember;
+}
+
+export async function updateMemberRole(
+  projectId: number,
+  userId: number,
+  role: Role,
+): Promise<void> {
+  if (role !== "owner") {
+    // Ensure at least one owner remains
+    const owners = await db
+      .select({ userId: projectMembers.userId })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.role, "owner"),
+        ),
+      );
+    if (owners.length === 1 && owners[0].userId === userId) {
+      throw new Error("Project must have at least one owner.");
+    }
+  }
+
+  await db
+    .update(projectMembers)
+    .set({ role })
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, userId),
+      ),
+    );
+}
+
+export async function removeProjectMember(
+  projectId: number,
+  userId: number,
+): Promise<void> {
+  // Ensure at least one owner remains
+  const member = await db
+    .select({ role: projectMembers.role })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  if (member[0]?.role === "owner") {
+    const owners = await db
+      .select({ userId: projectMembers.userId })
+      .from(projectMembers)
+      .where(
+        and(
+          eq(projectMembers.projectId, projectId),
+          eq(projectMembers.role, "owner"),
+        ),
+      );
+    if (owners.length <= 1) {
+      throw new Error("Project must have at least one owner.");
+    }
+  }
+
+  await db
+    .delete(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, userId),
+      ),
+    );
+}
+
+export async function getProjectsForUser(userId: number) {
+  const rows = await db
+    .select({
+      id: projects.id,
+      name: projects.name,
+      apiKey: projects.apiKey,
+      createdAt: projects.createdAt,
+      ownerId: projects.ownerId,
+      role: projectMembers.role,
+    })
+    .from(projectMembers)
+    .innerJoin(projects, eq(projectMembers.projectId, projects.id))
+    .where(eq(projectMembers.userId, userId));
+
+  return rows;
+}

--- a/src/lib/beaver/project.ts
+++ b/src/lib/beaver/project.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { projects } from "../db/schema";
+import { projects, projectMembers } from "../db/schema";
 import { eq } from "drizzle-orm";
 
 export type Project = {
@@ -7,6 +7,7 @@ export type Project = {
   name: string;
   apiKey: string;
   createdAt: Date | null;
+  ownerId: number;
 };
 
 export async function getProjects() {
@@ -20,12 +21,19 @@ export async function createProject(
   apiKey: string,
   ownerId: number,
 ) {
-  const res = await db
+  const [project] = await db
     .insert(projects)
     .values({ name, apiKey, ownerId })
     .returning();
 
-  return res[0];
+  // Creator is automatically an owner
+  await db.insert(projectMembers).values({
+    projectId: project.id,
+    userId: ownerId,
+    role: "owner",
+  });
+
+  return project;
 }
 
 export async function getProject(project_id: number) {

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -6,6 +6,7 @@ export type DatabaseUser = {
   id: number;
   userName: string;
   isAdmin: boolean;
+  canCreateProjects: boolean;
   password: string;
   mustChangePassword: boolean;
   tempPassword: string | null;
@@ -16,6 +17,7 @@ export type User = {
   id: number;
   userName: string;
   isAdmin: boolean;
+  canCreateProjects: boolean;
   mustChangePassword: boolean;
   tempPassword: string | null;
   createdAt: Date | null;
@@ -27,6 +29,7 @@ export async function getAllUsers(): Promise<User[]> {
       id: users.id,
       userName: users.userName,
       isAdmin: users.isAdmin,
+      canCreateProjects: users.canCreateProjects,
       mustChangePassword: users.mustChangePassword,
       tempPassword: users.tempPassword,
       createdAt: users.createdAt,
@@ -41,6 +44,7 @@ export async function getAdminUsers(): Promise<User[]> {
       id: users.id,
       userName: users.userName,
       isAdmin: users.isAdmin,
+      canCreateProjects: users.canCreateProjects,
       mustChangePassword: users.mustChangePassword,
       tempPassword: users.tempPassword,
       createdAt: users.createdAt,
@@ -91,6 +95,7 @@ export async function createUser(
       id: users.id,
       userName: users.userName,
       isAdmin: users.isAdmin,
+      canCreateProjects: users.canCreateProjects,
       mustChangePassword: users.mustChangePassword,
       tempPassword: users.tempPassword,
       createdAt: users.createdAt,
@@ -101,6 +106,7 @@ export async function createUser(
 
 export async function createUserAccount(
   userName: string,
+  canCreateProjects = false,
 ): Promise<User & { tempPassword: string }> {
   const tempPassword = generateTempPassword();
   const hashedPassword = await Bun.password.hash(tempPassword);
@@ -111,6 +117,7 @@ export async function createUserAccount(
       userName,
       password: hashedPassword,
       isAdmin: false,
+      canCreateProjects,
       mustChangePassword: true,
       tempPassword,
     })
@@ -118,12 +125,20 @@ export async function createUserAccount(
       id: users.id,
       userName: users.userName,
       isAdmin: users.isAdmin,
+      canCreateProjects: users.canCreateProjects,
       mustChangePassword: users.mustChangePassword,
       tempPassword: users.tempPassword,
       createdAt: users.createdAt,
     });
 
   return { ...user, tempPassword };
+}
+
+export async function setCanCreateProjects(
+  id: number,
+  canCreateProjects: boolean,
+): Promise<void> {
+  await db.update(users).set({ canCreateProjects }).where(eq(users.id, id));
 }
 
 export async function deleteUser(id: number): Promise<void> {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -81,12 +81,32 @@ export const eventTags = sqliteTable("event_tags", {
 export const users = sqliteTable("users", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   isAdmin: integer("is_admin", { mode: "boolean" }).notNull().default(false),
+  canCreateProjects: integer("can_create_projects", { mode: "boolean" })
+    .notNull()
+    .default(false),
   userName: text("username").notNull(),
   password: text("password").notNull(),
   mustChangePassword: integer("must_change_password", { mode: "boolean" })
     .notNull()
     .default(false),
   tempPassword: text("temp_password"),
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(unixepoch() * 1000)`)
+    .notNull(),
+});
+
+// --- PROJECT MEMBERS ---
+export const projectMembers = sqliteTable("project_members", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  projectId: integer("project_id")
+    .notNull()
+    .references(() => projects.id, { onDelete: "cascade" }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  role: text("role", { enum: ["owner", "maintainer", "guest"] })
+    .notNull()
+    .default("guest"),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),
@@ -109,6 +129,7 @@ export const sessions = sqliteTable("sessions", {
 export const projectRelations = relations(projects, ({ many }) => ({
   channels: many(channels),
   channelGroups: many(channelGroups),
+  members: many(projectMembers),
 }));
 
 export const channelGroupRelations = relations(
@@ -152,6 +173,18 @@ export const eventTagRelations = relations(eventTags, ({ one }) => ({
 export const userRelations = relations(users, ({ many }) => ({
   projects: many(projects),
   sessions: many(sessions),
+  projectMemberships: many(projectMembers),
+}));
+
+export const projectMemberRelations = relations(projectMembers, ({ one }) => ({
+  project: one(projects, {
+    fields: [projectMembers.projectId],
+    references: [projects.id],
+  }),
+  user: one(users, {
+    fields: [projectMembers.userId],
+    references: [users.id],
+  }),
 }));
 
 export const sessionRelations = relations(sessions, ({ one }) => ({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { defineMiddleware } from "astro:middleware";
 import { getAdminUsers } from "./lib/beaver/user";
 import { verifyToken } from "./lib/auth/jwt";
 import { getSessionByToken } from "./lib/auth/session";
-import { getProjects } from "./lib/beaver/project";
+import { getProjectsForUser } from "./lib/beaver/project-member";
 
 // Routes that don't require authentication
 const PUBLIC_ROUTES = ["/login", "/onboarding"];
@@ -44,12 +44,24 @@ async function getAuthedRedirect(
   const session = await getSessionByToken(refreshToken);
   if (!session || new Date(session.expiresAt) < new Date()) return null;
 
-  const projects = await getProjects();
+  if (payload.isAdmin) {
+    const { getProjects } = await import("./lib/beaver/project");
+    const projects = await getProjects();
+    if (projects.length > 0) return `/dashboard/${projects[0].id}/feed`;
+    return "/";
+  }
+
+  const projects = await getProjectsForUser(payload.userId);
   if (projects.length > 0) {
     return `/dashboard/${projects[0].id}/feed`;
   }
 
-  return null;
+  // Authenticated but no projects
+  if (payload.canCreateProjects) {
+    return "/dashboard/create-project";
+  }
+
+  return "/no-projects";
 }
 
 export const onRequest = defineMiddleware(async (context, next) => {
@@ -110,6 +122,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
     id: payload.userId,
     userName: payload.userName,
     isAdmin: payload.isAdmin,
+    canCreateProjects: payload.canCreateProjects ?? false,
   };
 
   // If user must change password, redirect to the change-password page

--- a/src/pages/api/auth/refresh.ts
+++ b/src/pages/api/auth/refresh.ts
@@ -69,6 +69,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       userId: payload.userId,
       userName: payload.userName,
       isAdmin: payload.isAdmin,
+      canCreateProjects: payload.canCreateProjects,
       mustChangePassword: payload.mustChangePassword,
     };
 
@@ -96,6 +97,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
           id: payload.userId,
           userName: payload.userName,
           isAdmin: payload.isAdmin,
+          canCreateProjects: payload.canCreateProjects,
           mustChangePassword: payload.mustChangePassword,
         },
       }),

--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -39,6 +39,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       userId: user.id,
       userName: user.userName,
       isAdmin: user.isAdmin,
+      canCreateProjects: user.canCreateProjects,
       mustChangePassword: user.mustChangePassword,
     };
 
@@ -65,6 +66,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
           id: user.id,
           userName: user.userName,
           isAdmin: user.isAdmin,
+          canCreateProjects: user.canCreateProjects,
           mustChangePassword: user.mustChangePassword,
         },
       }),

--- a/src/pages/api/project-members.ts
+++ b/src/pages/api/project-members.ts
@@ -1,0 +1,187 @@
+import type { APIContext, APIRoute } from "astro";
+import {
+  getProjectMembers,
+  addProjectMember,
+  updateMemberRole,
+  removeProjectMember,
+  getUserProjectRole,
+  type Role,
+} from "@/lib/beaver/project-member";
+import { getAllUsers } from "@/lib/beaver/user";
+
+function canManage(userRole: Role | null, isAdmin: boolean): boolean {
+  return isAdmin || userRole === "owner";
+}
+
+export const GET: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const url = new URL(context.request.url);
+  const projectId = parseInt(url.searchParams.get("projectId") ?? "");
+
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required." }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const [members, allUsers] = await Promise.all([
+      getProjectMembers(projectId),
+      getAllUsers(),
+    ]);
+
+    const memberUserIds = new Set(members.map((m) => m.userId));
+    const nonMembers = allUsers.filter((u) => !memberUserIds.has(u.id));
+
+    return new Response(JSON.stringify({ members, nonMembers }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "Failed to fetch members." }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const POST: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { projectId, userId, role } = await context.request.json();
+
+    if (!projectId || !userId || !role) {
+      return new Response(
+        JSON.stringify({ error: "projectId, userId, and role are required." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const userRole = await getUserProjectRole(
+      projectId,
+      context.locals.user.id,
+    );
+    if (!canManage(userRole, context.locals.user.isAdmin)) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const member = await addProjectMember(projectId, userId, role as Role);
+    return new Response(JSON.stringify(member), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to add member.";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const PATCH: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { projectId, userId, role } = await context.request.json();
+
+    if (!projectId || !userId || !role) {
+      return new Response(
+        JSON.stringify({ error: "projectId, userId, and role are required." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const userRole = await getUserProjectRole(
+      projectId,
+      context.locals.user.id,
+    );
+    if (!canManage(userRole, context.locals.user.isAdmin)) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    await updateMemberRole(projectId, userId, role as Role);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to update role.";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const DELETE: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { projectId, userId } = await context.request.json();
+
+    if (!projectId || !userId) {
+      return new Response(
+        JSON.stringify({ error: "projectId and userId are required." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const userRole = await getUserProjectRole(
+      projectId,
+      context.locals.user.id,
+    );
+    if (!canManage(userRole, context.locals.user.isAdmin)) {
+      return new Response(JSON.stringify({ error: "Forbidden" }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    await removeProjectMember(projectId, userId);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to remove member.";
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const prerender = false;

--- a/src/pages/api/project.ts
+++ b/src/pages/api/project.ts
@@ -1,44 +1,72 @@
-import type { APIRoute } from "astro";
+import type { APIContext, APIRoute } from "astro";
 import {
   createProject,
   deleteProject,
   getProject,
-  getProjects,
-  getProjectsByOwner,
   renameProject,
 } from "@/lib/beaver/project";
+import {
+  getUserProjectRole,
+  getProjectsForUser,
+} from "@/lib/beaver/project-member";
 
-export const GET: APIRoute = async () => {
+export const GET: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   try {
-    const projects = await getProjects();
+    const projects = context.locals.user.isAdmin
+      ? await (await import("@/lib/beaver/project")).getProjects()
+      : await getProjectsForUser(context.locals.user.id);
 
     return new Response(JSON.stringify(projects), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
-    if (err instanceof Error) {
-      return new Response(JSON.stringify({ error: err.message }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    console.error(err);
     return new Response(
-      JSON.stringify({ error: "An unkown error has occurred." }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
+      JSON.stringify({ error: "An unknown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
     );
   }
 };
 
-export const POST: APIRoute = async ({ request }) => {
-  try {
-    const { name, ownerId } = await request.json();
+export const POST: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
 
-    const project = await createProject(name, crypto.randomUUID(), ownerId);
+  if (!context.locals.user.isAdmin && !context.locals.user.canCreateProjects) {
+    return new Response(
+      JSON.stringify({
+        error: "You do not have permission to create projects.",
+      }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  try {
+    const { name } = await context.request.json();
+
+    if (!name?.trim()) {
+      return new Response(JSON.stringify({ error: "name is required." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const project = await createProject(
+      name.trim(),
+      crypto.randomUUID(),
+      context.locals.user.id,
+    );
 
     return new Response(JSON.stringify(project), {
       status: 200,
@@ -51,20 +79,23 @@ export const POST: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
-    console.error(err);
     return new Response(
-      JSON.stringify({ error: "An unkown error has occurred." }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
+      JSON.stringify({ error: "An unknown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
     );
   }
 };
 
-export const PATCH: APIRoute = async ({ request, locals }) => {
+export const PATCH: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   try {
-    const { projectID, name } = await request.json();
+    const { projectID, name } = await context.request.json();
 
     if (!projectID || !name?.trim()) {
       return new Response(
@@ -74,7 +105,6 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
     }
 
     const project = await getProject(parseInt(projectID));
-
     if (!project) {
       return new Response(JSON.stringify({ error: "Project not found." }), {
         status: 404,
@@ -82,15 +112,18 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
       });
     }
 
-    if (project.ownerId !== locals.user!.id) {
+    const role = await getUserProjectRole(
+      parseInt(projectID),
+      context.locals.user.id,
+    );
+    if (!context.locals.user.isAdmin && role !== "owner") {
       return new Response(
-        JSON.stringify({ error: "You do not own this project." }),
+        JSON.stringify({ error: "Only the project owner can rename it." }),
         { status: 403, headers: { "Content-Type": "application/json" } },
       );
     }
 
     const updated = await renameProject(parseInt(projectID), name.trim());
-
     return new Response(JSON.stringify(updated), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -102,20 +135,23 @@ export const PATCH: APIRoute = async ({ request, locals }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
-    console.error(err);
     return new Response(
-      JSON.stringify({ error: "An unkown error has occurred." }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
+      JSON.stringify({ error: "An unknown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
     );
   }
 };
 
-export const DELETE: APIRoute = async ({ request, locals }) => {
+export const DELETE: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   try {
-    const { projectID } = await request.json();
+    const { projectID } = await context.request.json();
 
     if (!projectID) {
       return new Response(JSON.stringify({ error: "projectID is required." }), {
@@ -125,7 +161,6 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
     }
 
     const project = await getProject(parseInt(projectID));
-
     if (!project) {
       return new Response(JSON.stringify({ error: "Project not found." }), {
         status: 404,
@@ -133,15 +168,18 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
       });
     }
 
-    if (project.ownerId !== locals.user!.id) {
+    const role = await getUserProjectRole(
+      parseInt(projectID),
+      context.locals.user.id,
+    );
+    if (!context.locals.user.isAdmin && role !== "owner") {
       return new Response(
-        JSON.stringify({ error: "You do not own this project." }),
+        JSON.stringify({ error: "Only the project owner can delete it." }),
         { status: 403, headers: { "Content-Type": "application/json" } },
       );
     }
 
-    const userProjects = await getProjectsByOwner(locals.user!.id);
-
+    const userProjects = await getProjectsForUser(context.locals.user.id);
     if (userProjects.length <= 1) {
       return new Response(
         JSON.stringify({
@@ -169,13 +207,9 @@ export const DELETE: APIRoute = async ({ request, locals }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
-    console.error(err);
     return new Response(
-      JSON.stringify({ error: "An unkown error has occurred." }),
-      {
-        status: 500,
-        headers: { "Content-Type": "application/json" },
-      },
+      JSON.stringify({ error: "An unknown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
     );
   }
 };

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -4,6 +4,7 @@ import {
   createUserAccount,
   deleteUser,
   setUserAdmin,
+  setCanCreateProjects,
 } from "@/lib/beaver/user";
 
 function requireAdmin(context: APIContext): Response | null {
@@ -39,7 +40,7 @@ export const POST: APIRoute = async (context) => {
   if (denied) return denied;
 
   try {
-    const { userName } = await context.request.json();
+    const { userName, canCreateProjects } = await context.request.json();
 
     if (!userName?.trim()) {
       return new Response(JSON.stringify({ error: "userName is required." }), {
@@ -48,7 +49,10 @@ export const POST: APIRoute = async (context) => {
       });
     }
 
-    const user = await createUserAccount(userName.trim());
+    const user = await createUserAccount(
+      userName.trim(),
+      canCreateProjects ?? false,
+    );
     return new Response(JSON.stringify(user), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -67,33 +71,36 @@ export const POST: APIRoute = async (context) => {
   }
 };
 
-// Toggle admin status
+// Toggle admin status or canCreateProjects
 export const PATCH: APIRoute = async (context) => {
   const denied = requireAdmin(context);
   if (denied) return denied;
 
   try {
-    const { id, isAdmin } = await context.request.json();
+    const { id, isAdmin, canCreateProjects } = await context.request.json();
 
-    if (id === undefined || isAdmin === undefined) {
-      return new Response(
-        JSON.stringify({ error: "id and isAdmin are required." }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      );
+    if (id === undefined) {
+      return new Response(JSON.stringify({ error: "id is required." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
     }
 
-    // Prevent admin from removing their own admin status
-    if (id === context.locals.user?.id && !isAdmin) {
-      return new Response(
-        JSON.stringify({ error: "You cannot remove your own admin status." }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+    if (isAdmin !== undefined) {
+      // Prevent admin from removing their own admin status
+      if (id === context.locals.user?.id && !isAdmin) {
+        return new Response(
+          JSON.stringify({ error: "You cannot remove your own admin status." }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      await setUserAdmin(id, isAdmin);
     }
 
-    await setUserAdmin(id, isAdmin);
+    if (canCreateProjects !== undefined) {
+      await setCanCreateProjects(id, canCreateProjects);
+    }
+
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -3,15 +3,29 @@ import APIKey from "@/components/api-key";
 import ChannelSettings from "@/components/channel-settings";
 import ProjectDangerZone from "@/components/project-danger-zone";
 import ProjectRename from "@/components/project-rename";
+import ProjectMembers from "@/components/project-members";
 import Layout from "@/layouts/layout.astro";
 import { getChannels } from "@/lib/beaver/channel";
 import { getProject } from "@/lib/beaver/project";
+import { getUserProjectRole } from "@/lib/beaver/project-member";
 
 const { projectID } = Astro.params;
+const user = Astro.locals.user!;
 
 const project = await getProject(parseInt(projectID!));
 
+const userRole = user.isAdmin
+  ? "owner"
+  : await getUserProjectRole(project.id, user.id);
+
+// Guests cannot access settings
+if (userRole === "guest" || userRole === null) {
+  return Astro.redirect(`/dashboard/${projectID}/feed`);
+}
+
 const channels = await getChannels(parseInt(projectID!));
+
+const isOwner = userRole === "owner";
 
 const metaCss = "flex items-center w-full justify-between";
 const metaH3Css = "font-medium";
@@ -23,31 +37,45 @@ const metaH3Css = "font-medium";
       <h1>Project Settings</h1>
     </div>
     <div class="w-full flex flex-col items-center mt-8">
-      <div class="w-full px-4 md:w-3/4 md:px-0 flex flex-col space-y-4">
-        <h2 class="font-mono mb-2">Meta</h2>
-        <div class={metaCss}>
-          <h3 class={metaH3Css}>Project Name</h3>
-          <ProjectRename client:load project={project} />
+      {isOwner && (
+        <div class="w-full px-4 md:w-3/4 md:px-0 flex flex-col space-y-4">
+          <h2 class="font-mono mb-2">Meta</h2>
+          <div class={metaCss}>
+            <h3 class={metaH3Css}>Project Name</h3>
+            <ProjectRename client:load project={project} />
+          </div>
+          <div class={metaCss}>
+            <h3 class={metaH3Css}>Created</h3>
+            <p>{project.createdAt?.toLocaleDateString()}</p>
+          </div>
+          <div class={metaCss}>
+            <h3 class={metaH3Css}>API Key</h3>
+            <APIKey client:load project={project} />
+          </div>
         </div>
-        <div class={metaCss}>
-          <h3 class={metaH3Css}>Created</h3>
-          <p>{project.createdAt?.toLocaleDateString()}</p>
-        </div>
-        <div class={metaCss}>
-          <h3 class={metaH3Css}>API Key</h3>
-          <APIKey client:load project={project} />
-        </div>
-      </div>
+      )}
       <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
         <h2 class="font-mono">Channels</h2>
         <div class="flex flex-col">
           <ChannelSettings client:load channels={channels} project={project} />
         </div>
       </div>
-      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-        <h2 class="font-mono">Danger Zone</h2>
-        <ProjectDangerZone client:load project={project} />
-      </div>
+      {isOwner && (
+        <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
+          <h2 class="font-mono mb-4">Members</h2>
+          <ProjectMembers
+            client:load
+            projectId={project.id}
+            currentUserId={user.id}
+          />
+        </div>
+      )}
+      {isOwner && (
+        <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
+          <h2 class="font-mono">Danger Zone</h2>
+          <ProjectDangerZone client:load project={project} />
+        </div>
+      )}
     </div>
   </div>
 </Layout>

--- a/src/pages/dashboard/create-project.astro
+++ b/src/pages/dashboard/create-project.astro
@@ -1,6 +1,14 @@
 ---
 import "@/styles/global.css";
 import CreateProjectView from "@/components/create-project-view";
+
+const user = Astro.locals.user;
+if (!user?.isAdmin && !user?.canCreateProjects) {
+  const { getProjectsForUser } = await import("@/lib/beaver/project-member");
+  const projects = await getProjectsForUser(user!.id);
+  const fallback = projects.length > 0 ? `/dashboard/${projects[0].id}/feed` : "/";
+  return Astro.redirect(fallback);
+}
 ---
 
 <html lang="en">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,15 +1,20 @@
 ---
 import "../styles/global.css";
 import { getProjects } from "../lib/beaver/project";
+import { getProjectsForUser } from "../lib/beaver/project-member";
 
-// Middleware handles auth check - if we reach here, user is authenticated
-// Get projects for the authenticated user and redirect to dashboard
-const projects = await getProjects();
+const user = Astro.locals.user!;
+
+const projects = user.isAdmin
+  ? await getProjects()
+  : await getProjectsForUser(user.id);
 
 if (projects.length === 0) {
-  // User is authenticated but has no projects - this shouldn't happen in normal flow
-  // but redirect to create a project (you may want to add a project creation page)
-  return Astro.redirect("/onboarding");
+  if (user.isAdmin || user.canCreateProjects) {
+    return Astro.redirect("/dashboard/create-project");
+  }
+  // Non-admin with no projects: show a placeholder (no projects assigned yet)
+  return Astro.redirect("/no-projects");
 } else {
   return Astro.redirect(`/dashboard/${projects[0].id}/feed`);
 }

--- a/src/pages/no-projects.astro
+++ b/src/pages/no-projects.astro
@@ -1,0 +1,35 @@
+---
+import "../styles/global.css";
+
+const user = Astro.locals.user;
+if (!user) return Astro.redirect("/login");
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/png" href="/beaver.png" />
+    <title>Beaver</title>
+    <script is:inline>
+      function applyStoredTheme() {
+        const stored = localStorage.getItem("theme") || "system";
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (stored === "dark" || (stored === "system" && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
+      }
+      applyStoredTheme();
+    </script>
+  </head>
+  <body>
+    <div class="min-h-screen flex flex-col items-center justify-center text-center px-4">
+      <h1 class="text-2xl font-semibold">No projects yet</h1>
+      <p class="text-muted-foreground mt-2 text-sm">
+        You haven't been added to any projects. Ask a project owner or admin to invite you.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add `project_members` table with `owner`, `maintainer`, and `guest` roles
- Add `can_create_projects` flag on users, toggleable from admin panel
- Project creators are automatically added as owner; owners can invite users and manage roles from project settings Members section
- Guests: view-only (no settings, no API docs, no channel/group editing)
- Maintainers: can manage channels and groups, see settings
- Owners: full project authority (rename, delete, API key, members)
- Admins bypass all role checks and see all projects
- Users with no project memberships land on `/no-projects` or `/dashboard/create-project` depending on their permissions

## Test plan
- [ ] Create a user with `canCreateProjects`, sign in, verify redirect to create-project
- [ ] Create a project, verify owner membership and full sidebar access
- [ ] Add another user as guest, verify no settings/API docs/channel controls
- [ ] Add user as maintainer, verify channel controls visible but no danger zone
- [ ] Toggle role changes take effect immediately
- [ ] Admin can see and access all projects regardless of membership
- [ ] Removing last owner is blocked