### PR TITLE
feat: add API key rotation

### DIFF
--- a/src/components/api-key.tsx
+++ b/src/components/api-key.tsx
@@ -1,35 +1,148 @@
 import type { Project } from "@/lib/beaver/project";
-import { Clipboard, ClipboardCheck } from "lucide-react";
+import { CheckIcon, ClipboardIcon, RefreshCwIcon } from "lucide-react";
 import { useState } from "react";
+import { Button } from "./ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "./ui/dialog";
+import { Input } from "./ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
+
+const CONFIRM_PHRASE = "rotate api key";
 
 export default function APIKey({ project }: { project: Project }) {
+  const [apiKey, setApiKey] = useState(project.apiKey);
   const [copied, setCopied] = useState(false);
+  const [rotateOpen, setRotateOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [rotating, setRotating] = useState(false);
+  const [error, setError] = useState("");
 
   const handleCopy = () => {
+    navigator.clipboard.writeText(apiKey);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleRotate = async () => {
+    setRotating(true);
+    setError("");
     try {
-      setCopied(false);
-      navigator.clipboard.writeText(project.apiKey);
-      setCopied(true);
-    } catch (error) {
-      console.error(error);
+      const res = await fetch("/api/project", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectID: project.id }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? "Failed to rotate API key.");
+        return;
+      }
+      setApiKey(data.apiKey);
+      setRotateOpen(false);
+      setConfirmText("");
+    } finally {
+      setRotating(false);
     }
   };
 
-  // TODO: add the ability to create a new api key
-
   return (
-    <div className="border px-1 rounded flex items-center justify-center">
-      <p className="font-mono tracking-wider">{project.apiKey}</p>
-      <button onClick={handleCopy} className="hover:cursor-pointer">
-        {copied ? (
-          <ClipboardCheck
-            color="gray"
-            className="bg-gray-200 rounded p-0.5 m-1"
-          />
-        ) : (
-          <Clipboard color="gray" className="bg-gray-200 rounded p-0.5 m-1" />
-        )}
-      </button>
-    </div>
+    <TooltipProvider delayDuration={300}>
+      <div className="flex items-center gap-2">
+        <div className="border px-3 py-1.5 rounded flex items-center gap-2">
+          <p className="font-mono text-sm tracking-wider">{apiKey}</p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={handleCopy}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {copied ? <CheckIcon size={14} /> : <ClipboardIcon size={14} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{copied ? "Copied!" : "Copy"}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setRotateOpen(true)}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <RefreshCwIcon size={14} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Rotate API key</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      <Dialog
+        open={rotateOpen}
+        onOpenChange={(open) => {
+          setRotateOpen(open);
+          if (!open) {
+            setConfirmText("");
+            setError("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Rotate API key</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <p className="text-sm text-muted-foreground">
+              This will immediately invalidate your current API key. Any
+              integrations using the old key will stop working until updated.
+            </p>
+            <div className="space-y-2">
+              <label className="text-sm font-medium">
+                Type{" "}
+                <span className="font-mono text-foreground bg-muted px-2 py-1 rounded text-xs">
+                  {CONFIRM_PHRASE}
+                </span>{" "}
+                to confirm
+              </label>
+              <Input
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder={CONFIRM_PHRASE}
+                onKeyDown={(e) => {
+                  if (
+                    e.key === "Enter" &&
+                    confirmText === CONFIRM_PHRASE &&
+                    !rotating
+                  ) {
+                    handleRotate();
+                  }
+                }}
+              />
+            </div>
+            {error && <p className="text-sm text-destructive">{error}</p>}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRotateOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleRotate}
+              disabled={confirmText !== CONFIRM_PHRASE || rotating}
+            >
+              {rotating ? "Rotating…" : "Rotate key"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </TooltipProvider>
   );
 }

--- a/src/components/channel-settings.tsx
+++ b/src/components/channel-settings.tsx
@@ -14,6 +14,12 @@ import { Trash2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Label } from "./ui/label";
 import type { Project } from "@/lib/beaver/project";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 export default function ChannelSettings({
   channels,
@@ -73,7 +79,7 @@ export default function ChannelSettings({
   }, []);
 
   return (
-    <>
+    <TooltipProvider delayDuration={300}>
       {clientChannels.map((channel) => (
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen} key={channel.id}>
           <div className="rounded border p-2 md:p-4 mt-4 flex justify-between items-center">
@@ -92,9 +98,16 @@ export default function ChannelSettings({
               <p className="font-light text-xs">{channel.description}</p>
             </div>
             <div>
-              <DialogTrigger asChild>
-                <Trash2Icon className="hover:cursor-pointer" />
-              </DialogTrigger>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DialogTrigger asChild>
+                    <button className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors">
+                      <Trash2Icon size={15} />
+                    </button>
+                  </DialogTrigger>
+                </TooltipTrigger>
+                <TooltipContent>Delete channel</TooltipContent>
+              </Tooltip>
             </div>
           </div>
           {/* Delete channel dialog */}
@@ -136,6 +149,6 @@ export default function ChannelSettings({
           </DialogContent>
         </Dialog>
       ))}
-    </>
+    </TooltipProvider>
   );
 }

--- a/src/components/project-rename.tsx
+++ b/src/components/project-rename.tsx
@@ -3,6 +3,12 @@ import { Pencil } from "lucide-react";
 import { useState } from "react";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 export default function ProjectRename({ project }: { project: Project }) {
   const [editing, setEditing] = useState(false);
@@ -89,14 +95,21 @@ export default function ProjectRename({ project }: { project: Project }) {
   }
 
   return (
-    <div className="flex items-center gap-2">
-      <p>{project.name}</p>
-      <button
-        onClick={() => setEditing(true)}
-        className="hover:cursor-pointer text-muted-foreground hover:text-foreground transition-colors"
-      >
-        <Pencil size={14} />
-      </button>
-    </div>
+    <TooltipProvider delayDuration={300}>
+      <div className="flex items-center gap-2">
+        <p>{project.name}</p>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => setEditing(true)}
+              className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <Pencil size={14} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Rename project</TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
   );
 }

--- a/src/lib/beaver/project.ts
+++ b/src/lib/beaver/project.ts
@@ -72,3 +72,12 @@ export async function deleteProject(projectId: number) {
 
   return res[0];
 }
+
+export async function rotateApiKey(projectId: number): Promise<string> {
+  const newKey = crypto.randomUUID();
+  await db
+    .update(projects)
+    .set({ apiKey: newKey })
+    .where(eq(projects.id, projectId));
+  return newKey;
+}

--- a/src/pages/api/project.ts
+++ b/src/pages/api/project.ts
@@ -4,6 +4,7 @@ import {
   deleteProject,
   getProject,
   renameProject,
+  rotateApiKey,
 } from "@/lib/beaver/project";
 import {
   getUserProjectRole,
@@ -197,6 +198,59 @@ export const DELETE: APIRoute = async (context: APIContext) => {
     );
 
     return new Response(JSON.stringify({ projects: remainingProjects }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    if (err instanceof Error) {
+      return new Response(JSON.stringify({ error: err.message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(
+      JSON.stringify({ error: "An unknown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
+    );
+  }
+};
+
+export const PUT: APIRoute = async (context: APIContext) => {
+  if (!context.locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { projectID } = await context.request.json();
+
+    if (!projectID) {
+      return new Response(JSON.stringify({ error: "projectID is required." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const role = await getUserProjectRole(
+      parseInt(projectID),
+      context.locals.user.id,
+    );
+    if (!context.locals.user.isAdmin && role !== "owner") {
+      return new Response(
+        JSON.stringify({
+          error: "Only the project owner can rotate the API key.",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }
+
+    const newKey = await rotateApiKey(parseInt(projectID));
+    return new Response(JSON.stringify({ apiKey: newKey }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
## Summary
- Rotate button next to copy in the API key section of project settings
- Confirmation dialog warns the old key will be immediately invalidated
- User must type `rotate api key` to enable the confirm button
- `PUT /api/project` handles rotation, owner/admin only
- Added tooltips and consistent hover styling to rename and channel delete buttons

## Test plan
- [ ] Rotate button appears next to copy in settings
- [ ] Dialog requires typing `rotate api key` exactly
- [ ] New key appears in UI after rotation
- [ ] Old key no longer works for ingestion
- [ ] Guest/maintainer gets 403
- [ ] Rename pencil and channel trash icons have tooltips