### PR TITLE
fix: mobile responsiveness and dark mode

### DIFF
--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -58,6 +58,107 @@ function TempPasswordCell({ tempPassword }: { tempPassword: string }) {
   );
 }
 
+function UserRoleBadge({ isAdmin }: { isAdmin: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ${
+        isAdmin
+          ? "bg-primary/10 text-primary"
+          : "bg-muted text-muted-foreground"
+      }`}
+    >
+      {isAdmin ? "Admin" : "User"}
+    </span>
+  );
+}
+
+function UserActions({
+  user,
+  currentUserId,
+  onToggleCanCreateProjects,
+  onToggleAdmin,
+  onReset,
+  onDelete,
+}: {
+  user: User;
+  currentUserId: number;
+  onToggleCanCreateProjects: (id: number, val: boolean) => void;
+  onToggleAdmin: (id: number, val: boolean) => void;
+  onReset: (user: User) => void;
+  onDelete: (user: User) => void;
+}) {
+  return (
+    <>
+      {user.id !== currentUserId && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() =>
+                onToggleCanCreateProjects(user.id, !user.canCreateProjects)
+              }
+              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {user.canCreateProjects ? (
+                <FolderPlusIcon size={15} />
+              ) : (
+                <FolderIcon size={15} />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {user.canCreateProjects
+              ? "Revoke project creation"
+              : "Allow project creation"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {user.id !== currentUserId && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => onToggleAdmin(user.id, !user.isAdmin)}
+              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              {user.isAdmin ? (
+                <ShieldOffIcon size={15} />
+              ) : (
+                <ShieldIcon size={15} />
+              )}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>
+            {user.isAdmin ? "Remove admin" : "Make admin"}
+          </TooltipContent>
+        </Tooltip>
+      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            onClick={() => onReset(user)}
+            className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <RefreshCwIcon size={15} />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Reset password</TooltipContent>
+      </Tooltip>
+      {user.id !== currentUserId && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => onDelete(user)}
+              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
+            >
+              <Trash2Icon size={15} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Delete user</TooltipContent>
+        </Tooltip>
+      )}
+    </>
+  );
+}
+
 export default function AdminUsersView({
   initialUsers,
   currentUserId,
@@ -186,7 +287,7 @@ export default function AdminUsersView({
   return (
     <TooltipProvider delayDuration={300}>
       <div className="min-h-screen bg-background text-foreground">
-        <div className="max-w-4xl mx-auto p-8">
+        <div className="max-w-4xl mx-auto p-4 md:p-8">
           {/* Header */}
           <div className="mb-8">
             <a
@@ -261,8 +362,8 @@ export default function AdminUsersView({
             </div>
           </div>
 
-          {/* User table */}
-          <div className="border rounded-lg overflow-hidden">
+          {/* Desktop table */}
+          <div className="hidden md:block border rounded-lg overflow-hidden">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b bg-muted/40">
@@ -288,15 +389,7 @@ export default function AdminUsersView({
                   >
                     <td className="px-4 py-3 font-mono">@{user.userName}</td>
                     <td className="px-4 py-3">
-                      <span
-                        className={`inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full font-medium ${
-                          user.isAdmin
-                            ? "bg-primary/10 text-primary"
-                            : "bg-muted text-muted-foreground"
-                        }`}
-                      >
-                        {user.isAdmin ? "Admin" : "User"}
-                      </span>
+                      <UserRoleBadge isAdmin={user.isAdmin} />
                     </td>
                     <td className="px-4 py-3">
                       {user.tempPassword ? (
@@ -307,83 +400,54 @@ export default function AdminUsersView({
                     </td>
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
-                        {user.id !== currentUserId && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() =>
-                                  handleToggleCanCreateProjects(
-                                    user.id,
-                                    !user.canCreateProjects,
-                                  )
-                                }
-                                className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                              >
-                                {user.canCreateProjects ? (
-                                  <FolderPlusIcon size={15} />
-                                ) : (
-                                  <FolderIcon size={15} />
-                                )}
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {user.canCreateProjects
-                                ? "Revoke project creation"
-                                : "Allow project creation"}
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                        {user.id !== currentUserId && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() =>
-                                  handleToggleAdmin(user.id, !user.isAdmin)
-                                }
-                                className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                              >
-                                {user.isAdmin ? (
-                                  <ShieldOffIcon size={15} />
-                                ) : (
-                                  <ShieldIcon size={15} />
-                                )}
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                              {user.isAdmin ? "Remove admin" : "Make admin"}
-                            </TooltipContent>
-                          </Tooltip>
-                        )}
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <button
-                              onClick={() => setResetTarget(user)}
-                              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              <RefreshCwIcon size={15} />
-                            </button>
-                          </TooltipTrigger>
-                          <TooltipContent>Reset password</TooltipContent>
-                        </Tooltip>
-                        {user.id !== currentUserId && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <button
-                                onClick={() => setDeleteTarget(user)}
-                                className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
-                              >
-                                <Trash2Icon size={15} />
-                              </button>
-                            </TooltipTrigger>
-                            <TooltipContent>Delete user</TooltipContent>
-                          </Tooltip>
-                        )}
+                        <UserActions
+                          user={user}
+                          currentUserId={currentUserId}
+                          onToggleCanCreateProjects={
+                            handleToggleCanCreateProjects
+                          }
+                          onToggleAdmin={handleToggleAdmin}
+                          onReset={setResetTarget}
+                          onDelete={setDeleteTarget}
+                        />
                       </div>
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="md:hidden flex flex-col gap-3">
+            {users.map((user) => (
+              <div key={user.id} className="border rounded-lg p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="font-mono font-medium">
+                    @{user.userName}
+                  </span>
+                  <UserRoleBadge isAdmin={user.isAdmin} />
+                </div>
+                {user.tempPassword && (
+                  <div>
+                    <p className="text-xs text-muted-foreground mb-1">
+                      Temp password
+                    </p>
+                    <TempPasswordCell tempPassword={user.tempPassword} />
+                  </div>
+                )}
+                <div className="flex items-center justify-end gap-1 pt-1 border-t">
+                  <UserActions
+                    user={user}
+                    currentUserId={currentUserId}
+                    onToggleCanCreateProjects={handleToggleCanCreateProjects}
+                    onToggleAdmin={handleToggleAdmin}
+                    onReset={setResetTarget}
+                    onDelete={setDeleteTarget}
+                  />
+                </div>
+              </div>
+            ))}
           </div>
         </div>
 

--- a/src/components/api-key.tsx
+++ b/src/components/api-key.tsx
@@ -57,9 +57,9 @@ export default function APIKey({ project }: { project: Project }) {
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div className="flex items-center gap-2">
-        <div className="border px-3 py-1.5 rounded flex items-center gap-2">
-          <p className="font-mono text-sm tracking-wider">{apiKey}</p>
+      <div className="flex items-center gap-2 min-w-0 max-w-full">
+        <div className="border px-3 py-1.5 rounded flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
+          <p className="font-mono text-sm truncate min-w-0">{apiKey}</p>
           <Tooltip>
             <TooltipTrigger asChild>
               <button

--- a/src/components/channel-settings.tsx
+++ b/src/components/channel-settings.tsx
@@ -82,20 +82,22 @@ export default function ChannelSettings({
     <TooltipProvider delayDuration={300}>
       {clientChannels.map((channel) => (
         <Dialog open={dialogOpen} onOpenChange={setDialogOpen} key={channel.id}>
-          <div className="rounded border p-2 md:p-4 mt-4 flex justify-between items-center">
-            <div>
-              <div className="flex flex-row space-x-4 items-center">
+          <div className="rounded border p-3 md:p-4 mt-4 flex justify-between items-center gap-2">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
                 <a
                   href={`/dashboard/${project.id}/channels/${channel.id}`}
-                  className="hover:text-black/50"
+                  className="hover:text-black/50 truncate"
                 >
                   <h3 className="font-medium text-lg"># {channel.name}</h3>
                 </a>
-                <p className="text-xs">
+                <p className="text-xs text-muted-foreground shrink-0">
                   {channel.createdAt?.toLocaleDateString()}
                 </p>
               </div>
-              <p className="font-light text-xs">{channel.description}</p>
+              <p className="font-light text-xs truncate">
+                {channel.description}
+              </p>
             </div>
             <div>
               <Tooltip>

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -388,7 +388,7 @@ export default function EventFeed({
             onApplyFilters={handleApplyFilters}
           />
           <Select value={currentSort} onValueChange={handleSortChange}>
-            <SelectTrigger className="w-[160px] gap-2">
+            <SelectTrigger className="w-full sm:w-[160px] gap-2">
               <ArrowUpDownIcon className="size-4 shrink-0" />
               <SelectValue />
             </SelectTrigger>

--- a/src/components/project-members.tsx
+++ b/src/components/project-members.tsx
@@ -130,7 +130,7 @@ export default function ProjectMembers({
         {members.map((member) => (
           <div
             key={member.id}
-            className="flex items-center justify-between py-2 border-b last:border-0"
+            className="flex flex-col sm:flex-row sm:items-center sm:justify-between py-2 border-b last:border-0 gap-2"
           >
             <span className="font-medium">@{member.userName}</span>
             <div className="flex items-center gap-2">
@@ -141,7 +141,7 @@ export default function ProjectMembers({
                 }
                 disabled={member.userId === currentUserId}
               >
-                <SelectTrigger className="w-32 h-8 text-sm">
+                <SelectTrigger className="w-full sm:w-32 h-8 text-sm">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -955,7 +955,7 @@ function SidePanelContent({
         <button
           onClick={() => setDrawerOpen(true)}
           aria-label="Open menu"
-          className="p-2 -ml-2 hover:bg-gray-100 rounded-md"
+          className="p-2 -ml-2 hover:bg-gray-100 dark:hover:bg-white/8 rounded-md"
         >
           <MenuIcon size={20} />
         </button>
@@ -969,7 +969,7 @@ function SidePanelContent({
       )}
 
       <div
-        className={`md:hidden fixed top-0 left-0 z-50 h-screen w-[300px] bg-white border-r overflow-y-auto p-6 transition-transform duration-200 ${
+        className={`md:hidden fixed top-0 left-0 z-50 h-screen w-[300px] bg-background border-r overflow-y-auto p-6 transition-transform duration-200 ${
           drawerOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >
@@ -977,7 +977,7 @@ function SidePanelContent({
           <button
             onClick={() => setDrawerOpen(false)}
             aria-label="Close menu"
-            className="p-2 hover:bg-gray-100 rounded"
+            className="p-2 hover:bg-gray-100 dark:hover:bg-white/8 rounded"
           >
             <XIcon size={20} />
           </button>

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -27,8 +27,8 @@ const channels = await getChannels(parseInt(projectID!));
 
 const isOwner = userRole === "owner";
 
-const metaCss = "flex items-center w-full justify-between";
-const metaH3Css = "font-medium";
+const metaCss = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
+const metaH3Css = "font-medium shrink-0";
 ---
 
 <Layout projectID={projectID!}>


### PR DESCRIPTION
## Summary
- Responsive layouts for settings, members, channel, event feed, and admin views
- API key no longer overflows on narrow screens (fixed truncation chain, removed `tracking-wider`)
- Mobile nav drawer background now respects dark mode (`bg-background` instead of `bg-white`)
- Mobile nav button hover states now have dark mode variants

## Test plan
- [ ] Open project settings on mobile — no horizontal scroll
- [ ] Toggle dark mode on mobile — nav drawer should be dark
- [ ] Check event feed sort selector, channel list, member list on mobile
- [ ] Check admin users page on mobile (card layout)