### PR TITLE
feat: channel unread counts with new-message divider (#14)

### DIFF
--- a/drizzle/0006_mighty_dazzler.sql
+++ b/drizzle/0006_mighty_dazzler.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `channel_reads` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`channel_id` integer NOT NULL,
+	`last_read_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `channel_reads_user_channel_idx` ON `channel_reads` (`user_id`,`channel_id`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,667 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "73c2822e-2f8e-49f9-90f8-94b4d20ce018",
+  "prevId": "551f0ef3-067a-4648-9368-f3c9cedf163e",
+  "tables": {
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1776999388018,
       "tag": "0005_lively_robbie_robertson",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1777000235422,
+      "tag": "0006_mighty_dazzler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -65,12 +65,15 @@ export default function EventFeed({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [searchInput, setSearchInput] = useState(search ?? "");
+  const [lastReadDate, setLastReadDate] = useState<Date | null>(null);
 
   const eventIdsRef = useRef<Set<number>>(new Set());
   const eventsRef = useRef<EventWithChannelName[]>([]);
   const loadingMoreRef = useRef(false);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
+  const dividerRef = useRef<HTMLDivElement>(null);
+  const didScrollToDivider = useRef(false);
 
   // Parse tags from URL param
   const parsedTags: TagFilter[] = tags ? JSON.parse(tags) : [];
@@ -281,6 +284,10 @@ export default function EventFeed({
       establishStream(maxId);
     });
 
+    // Reset scroll flag and last read date when channel changes
+    didScrollToDivider.current = false;
+    setLastReadDate(null);
+
     // Cleanup: close EventSource when dependencies change or component unmounts
     return () => {
       if (eventSource) {
@@ -288,6 +295,45 @@ export default function EventFeed({
       }
     };
   }, [projectID, channel, search, startDate, endDate, tags, sortBy, sortOrder]);
+
+  // Mark channel as read on mount, capture previous lastReadAt for divider
+  useEffect(() => {
+    if (type !== "channel" || !channel) return;
+
+    fetch("/api/unread", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelId: channel.id }),
+    })
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.lastReadAt) {
+          setLastReadDate(new Date(data.lastReadAt));
+        }
+        // Tell the sidebar to clear this channel's badge
+        window.dispatchEvent(
+          new CustomEvent("channel:read", {
+            detail: { channelId: channel.id },
+          }),
+        );
+      })
+      .catch(() => {});
+  }, [channel?.id]);
+
+  // Scroll to the unread divider once after initial load
+  useEffect(() => {
+    if (
+      loading ||
+      didScrollToDivider.current ||
+      !lastReadDate ||
+      !dividerRef.current ||
+      !scrollContainerRef.current
+    )
+      return;
+
+    didScrollToDivider.current = true;
+    dividerRef.current.scrollIntoView({ behavior: "instant", block: "center" });
+  }, [loading, events]);
 
   // Infinite scroll effect
   useEffect(() => {
@@ -341,6 +387,9 @@ export default function EventFeed({
   };
 
   const hasActiveFilters = startDate || endDate || parsedTags.length > 0;
+  const hasNewEvents =
+    lastReadDate != null &&
+    events.some((e) => new Date(e.createdAt) > lastReadDate);
 
   if (loading) {
     return (
@@ -466,18 +515,38 @@ export default function EventFeed({
               </h2>
             </div>
           ) : (
-            events.map((event) => (
-              <motion.div
-                key={event.id}
-                layout
-                initial={{ opacity: 0, y: 20 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -20 }}
-                transition={{ duration: 0.3, ease: "easeOut" }}
-              >
-                <EventCard event={event} />
-              </motion.div>
-            ))
+            events.map((event, i) => {
+              const isFirstOld =
+                hasNewEvents &&
+                new Date(event.createdAt) <= lastReadDate! &&
+                (i === 0 || new Date(events[i - 1].createdAt) > lastReadDate!);
+
+              return (
+                <div key={event.id}>
+                  {isFirstOld && (
+                    <div
+                      ref={dividerRef}
+                      className="flex items-center gap-3 py-1"
+                    >
+                      <div className="flex-1 border-t border-primary/40" />
+                      <span className="text-xs font-medium text-primary/70 shrink-0">
+                        New
+                      </span>
+                      <div className="flex-1 border-t border-primary/40" />
+                    </div>
+                  )}
+                  <motion.div
+                    layout
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                    transition={{ duration: 0.3, ease: "easeOut" }}
+                  >
+                    <EventCard event={event} />
+                  </motion.div>
+                </div>
+              );
+            })
           )}
           <div ref={bottomRef} style={{ height: "1px" }} />
         </div>

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -70,12 +70,14 @@ function SortableChannel({
   isActive,
   onNavigate,
   indent = false,
+  unreadCount = 0,
 }: {
   channel: Channel;
   projectId: number;
   isActive: boolean;
   onNavigate?: () => void;
   indent?: boolean;
+  unreadCount?: number;
 }) {
   const {
     attributes,
@@ -101,13 +103,18 @@ function SortableChannel({
         href={`/dashboard/${projectId}/channels/${channel.id}`}
         onClick={() => onNavigate?.()}
         draggable={false}
-        className={`flex text-lg items-center ${indent ? "pl-5 pr-3" : "px-3"} py-2 hover:font-medium cursor-grab active:cursor-grabbing ${
+        className={`flex text-lg items-center justify-between ${indent ? "pl-5 pr-3" : "px-3"} py-2 hover:font-medium cursor-grab active:cursor-grabbing ${
           isActive
             ? "bg-gray-100 dark:bg-white/8 rounded font-medium"
             : "hover:bg-gray-100 dark:hover:bg-white/8 hover:rounded"
         }`}
       >
-        # {channel.name}
+        <span className="truncate"># {channel.name}</span>
+        {unreadCount > 0 && !isActive && (
+          <span className="ml-2 shrink-0 text-xs font-semibold bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center leading-tight">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
       </a>
     </div>
   );
@@ -127,6 +134,7 @@ function SortableGroup({
   channelItems,
   dimChannels,
   canEdit,
+  unreadCounts,
 }: {
   group: ChannelGroupWithChannels;
   collapsed: boolean;
@@ -140,6 +148,7 @@ function SortableGroup({
   channelItems: UniqueIdentifier[];
   dimChannels?: boolean;
   canEdit: boolean;
+  unreadCounts: Record<number, number>;
 }) {
   const {
     attributes,
@@ -218,6 +227,7 @@ function SortableGroup({
                 isActive={isChannelActive(ch.id)}
                 onNavigate={onNavigate}
                 indent
+                unreadCount={unreadCounts[ch.id] ?? 0}
               />
             ))}
           </div>
@@ -287,6 +297,7 @@ function ChannelGroups({
   triggerCreate,
   onTriggerCreateDone,
   canEdit,
+  unreadCounts,
 }: {
   initialUngrouped: Channel[];
   initialGroups: ChannelGroupWithChannels[];
@@ -296,6 +307,7 @@ function ChannelGroups({
   triggerCreate: boolean;
   onTriggerCreateDone: () => void;
   canEdit: boolean;
+  unreadCounts: Record<number, number>;
 }) {
   const [ungrouped, setUngrouped] = useState<Channel[]>(initialUngrouped);
   const [groups, setGroups] =
@@ -630,6 +642,7 @@ function ChannelGroups({
             projectId={projectId}
             isActive={isChannelActive(ch.id)}
             onNavigate={onNavigate}
+            unreadCount={unreadCounts[ch.id] ?? 0}
           />
         ))}
       </SortableContext>
@@ -674,6 +687,7 @@ function ChannelGroups({
               channelItems={group.channels.map((c) => chId(c.id))}
               dimChannels={isDraggingGroup}
               canEdit={canEdit}
+              unreadCounts={unreadCounts}
             />
           );
         })}
@@ -727,7 +741,38 @@ function PanelContent({
 }) {
   const [projects] = useState<Project[]>(currentProjects);
   const [triggerCreateGroup, setTriggerCreateGroup] = useState(false);
+  const [unreadCounts, setUnreadCounts] = useState<Record<number, number>>({});
   const { user, signOut } = useAuth();
+
+  useEffect(() => {
+    const fetchUnread = async () => {
+      try {
+        const res = await fetch(`/api/unread?projectId=${currentProject.id}`);
+        if (res.ok) {
+          const data = await res.json();
+          setUnreadCounts(data.counts);
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    fetchUnread();
+    const interval = setInterval(fetchUnread, 5_000);
+
+    const handleChannelRead = (e: CustomEvent<{ channelId: number }>) => {
+      setUnreadCounts((prev) => ({ ...prev, [e.detail.channelId]: 0 }));
+    };
+
+    window.addEventListener("channel:read", handleChannelRead as EventListener);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener(
+        "channel:read",
+        handleChannelRead as EventListener,
+      );
+    };
+  }, [currentProject.id, pathname]);
 
   const canEdit = userRole === "owner" || userRole === "maintainer";
   const isOwner = userRole === "owner";
@@ -883,6 +928,7 @@ function PanelContent({
         triggerCreate={triggerCreateGroup}
         onTriggerCreateDone={() => setTriggerCreateGroup(false)}
         canEdit={canEdit}
+        unreadCounts={unreadCounts}
       />
 
       {/* Theme */}

--- a/src/lib/beaver/channel-read.ts
+++ b/src/lib/beaver/channel-read.ts
@@ -1,0 +1,65 @@
+import { db } from "../db/db";
+import { channelReads, channels, events } from "../db/schema";
+import { eq, and, sql, count } from "drizzle-orm";
+
+// Mark a channel as read for a user. Returns the previous lastReadAt (or null
+// if the user has never read this channel before).
+export async function markChannelRead(
+  userId: number,
+  channelId: number,
+): Promise<Date | null> {
+  const existing = await db
+    .select({ lastReadAt: channelReads.lastReadAt })
+    .from(channelReads)
+    .where(
+      and(
+        eq(channelReads.userId, userId),
+        eq(channelReads.channelId, channelId),
+      ),
+    )
+    .limit(1);
+
+  const previousLastReadAt = existing[0]?.lastReadAt ?? null;
+  const now = new Date();
+
+  await db
+    .insert(channelReads)
+    .values({ userId, channelId, lastReadAt: now })
+    .onConflictDoUpdate({
+      target: [channelReads.userId, channelReads.channelId],
+      set: { lastReadAt: now },
+    });
+
+  return previousLastReadAt;
+}
+
+// Returns unread event counts keyed by channel ID for all channels in a project.
+export async function getUnreadCounts(
+  userId: number,
+  projectId: number,
+): Promise<Record<number, number>> {
+  const rows = await db
+    .select({
+      channelId: channels.id,
+      unreadCount: count(events.id),
+    })
+    .from(channels)
+    .leftJoin(
+      channelReads,
+      and(
+        eq(channelReads.channelId, channels.id),
+        eq(channelReads.userId, userId),
+      ),
+    )
+    .leftJoin(
+      events,
+      and(
+        eq(events.channelId, channels.id),
+        sql`${events.createdAt} > COALESCE(${channelReads.lastReadAt}, 0)`,
+      ),
+    )
+    .where(eq(channels.projectId, projectId))
+    .groupBy(channels.id);
+
+  return Object.fromEntries(rows.map((r) => [r.channelId, r.unreadCount]));
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,11 @@
 // src/db/schema.ts
-import { sqliteTable, text, integer, index } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
 import { relations, sql } from "drizzle-orm";
 
 // ---- PROJECTS ----
@@ -159,6 +165,27 @@ export const projectMembers = sqliteTable(
   }),
 );
 
+// --- CHANNEL READS ---
+export const channelReads = sqliteTable(
+  "channel_reads",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    channelId: integer("channel_id")
+      .notNull()
+      .references(() => channels.id, { onDelete: "cascade" }),
+    lastReadAt: integer("last_read_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    userChannelIdx: uniqueIndex("channel_reads_user_channel_idx").on(
+      table.userId,
+      table.channelId,
+    ),
+  }),
+);
+
 // --- SESSIONS ----
 export const sessions = sqliteTable("sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -238,5 +265,16 @@ export const sessionRelations = relations(sessions, ({ one }) => ({
   user: one(users, {
     fields: [sessions.userId],
     references: [users.id],
+  }),
+}));
+
+export const channelReadRelations = relations(channelReads, ({ one }) => ({
+  user: one(users, {
+    fields: [channelReads.userId],
+    references: [users.id],
+  }),
+  channel: one(channels, {
+    fields: [channelReads.channelId],
+    references: [channels.id],
   }),
 }));

--- a/src/pages/api/unread.ts
+++ b/src/pages/api/unread.ts
@@ -1,0 +1,45 @@
+import { markChannelRead, getUnreadCounts } from "@/lib/beaver/channel-read";
+import type { APIContext } from "astro";
+
+export async function GET({ locals, url }: APIContext) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+    });
+  }
+
+  const projectId = url.searchParams.get("projectId");
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), {
+      status: 400,
+    });
+  }
+
+  const counts = await getUnreadCounts(user.id, parseInt(projectId));
+  return new Response(JSON.stringify({ counts }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export async function POST({ locals, request }: APIContext) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+    });
+  }
+
+  const { channelId } = await request.json();
+  if (!channelId) {
+    return new Response(JSON.stringify({ error: "channelId is required" }), {
+      status: 400,
+    });
+  }
+
+  const lastReadAt = await markChannelRead(user.id, channelId);
+  return new Response(
+    JSON.stringify({ lastReadAt: lastReadAt?.toISOString() ?? null }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}

--- a/src/pages/dashboard/[projectID]/channels/[channelID].astro
+++ b/src/pages/dashboard/[projectID]/channels/[channelID].astro
@@ -16,7 +16,6 @@ const sortBy = searchParams.get("sortBy");
 const sortOrder = searchParams.get("sortOrder");
 
 const channel = await getChannel(parseInt(channelID!));
-
 ---
 
 <Layout projectID={projectID!}>


### PR DESCRIPTION
## Summary
- Adds `channel_reads` table tracking `last_read_at` per user/channel
- Sidebar shows unread badge counts per channel, polled every 5 seconds and cleared instantly on open via `channel:read` custom event
- Event feed shows a \"New\" divider between unread and already-read events on channel open, and scrolls to it automatically
- Badge and divider are hidden when there are no unread events

## Test plan
- [ ] Navigate to a channel with unread events — badge should appear in sidebar
- [ ] Open the channel — badge clears, \"New\" divider appears above previously-read events, feed scrolls to it
- [ ] Navigate away — badge stays clear
- [ ] Post new events — badge reappears within 5 seconds without navigation
- [ ] Open channel with no unread events — no divider shown