### PR TITLE
feat: better tag filtering with type-aware inputs (#40)

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -33,6 +33,16 @@ import {
 
 type SortOption = `${SortField}_${SortOrder}`;
 
+function tagFilterLabel(tag: TagFilter): string {
+  if (tag.type === "number") {
+    const op = tag.operator ?? "eq";
+    if (op === "between") return `${tag.key}: ${tag.value} – ${tag.value2}`;
+    const sym = op === "gt" ? ">" : op === "lt" ? "<" : "=";
+    return `${tag.key} ${sym} ${tag.value}`;
+  }
+  return `${tag.key}: ${tag.value}`;
+}
+
 const sortOptions: { value: SortOption; label: string }[] = [
   { value: "date_desc", label: "Newest first" },
   { value: "date_asc", label: "Oldest first" },
@@ -487,9 +497,7 @@ export default function EventFeed({
               key={i}
               className="flex items-center gap-1 rounded-md bg-white dark:bg-white/10 border dark:border-white/10 px-2.5 py-1 text-sm"
             >
-              <span className="font-medium">{tag.key}</span>
-              <span className="text-gray-400 dark:text-gray-500">=</span>
-              <span>{tag.value}</span>
+              <span>{tagFilterLabel(tag)}</span>
               <button
                 onClick={() => handleRemoveTag(i)}
                 className="ml-1 rounded hover:bg-gray-100 dark:hover:bg-white/10 p-0.5"

--- a/src/components/event-filter-dialog.tsx
+++ b/src/components/event-filter-dialog.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useState } from "react";
-import {
-  subHours,
-  subDays,
-  subWeeks,
-  subMonths,
-  subYears,
-  format,
-} from "date-fns";
-import { FilterIcon, XIcon } from "lucide-react";
+import { subHours, subDays, subWeeks, subMonths, subYears } from "date-fns";
+import { FilterIcon, PlusIcon, XIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import {
   Dialog,
@@ -26,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./ui/select";
+import { Input } from "./ui/input";
 import type { AvailableTag } from "@/lib/beaver/tags";
 import type { TagFilter } from "@/lib/beaver/event";
 
@@ -71,6 +65,23 @@ const timePresets = [
   },
 ];
 
+const numericOperators = [
+  { value: "eq", label: "=" },
+  { value: "gt", label: ">" },
+  { value: "lt", label: "<" },
+  { value: "between", label: "between" },
+] as const;
+
+function tagFilterLabel(tag: TagFilter): string {
+  if (tag.type === "number") {
+    const op = tag.operator ?? "eq";
+    if (op === "between") return `${tag.key}: ${tag.value} – ${tag.value2}`;
+    const sym = op === "gt" ? ">" : op === "lt" ? "<" : "=";
+    return `${tag.key} ${sym} ${tag.value}`;
+  }
+  return `${tag.key}: ${tag.value}`;
+}
+
 export default function EventFilterDialog({
   type,
   projectID,
@@ -90,7 +101,23 @@ export default function EventFilterDialog({
   const [tags, setTags] = useState<TagFilter[]>(currentTags);
   const [availableTags, setAvailableTags] = useState<AvailableTag[]>([]);
   const [loadingTags, setLoadingTags] = useState(false);
-  const [selectedTagKey, setSelectedTagKey] = useState<string>("");
+
+  // Tag input state
+  const [selectedKey, setSelectedKey] = useState("");
+  const [numericOperator, setNumericOperator] = useState<
+    "eq" | "gt" | "lt" | "between"
+  >("eq");
+  const [valueInput, setValueInput] = useState("");
+  const [value2Input, setValue2Input] = useState("");
+
+  const selectedTag = availableTags.find((t) => t.key === selectedKey);
+
+  const resetTagInput = () => {
+    setSelectedKey("");
+    setNumericOperator("eq");
+    setValueInput("");
+    setValue2Input("");
+  };
 
   // Sync with URL params when dialog opens
   useEffect(() => {
@@ -98,10 +125,17 @@ export default function EventFilterDialog({
       setStartDate(currentStartDate ? new Date(currentStartDate) : undefined);
       setEndDate(currentEndDate ? new Date(currentEndDate) : undefined);
       setTags(currentTags);
-      setSelectedTagKey("");
+      resetTagInput();
       fetchAvailableTags();
     }
   }, [open, currentStartDate, currentEndDate, currentTags]);
+
+  // Reset value inputs when key changes
+  useEffect(() => {
+    setNumericOperator("eq");
+    setValueInput("");
+    setValue2Input("");
+  }, [selectedKey]);
 
   const fetchAvailableTags = async () => {
     setLoadingTags(true);
@@ -137,11 +171,52 @@ export default function EventFilterDialog({
     }
   };
 
+  const addTag = (filter: TagFilter) => {
+    const duplicate = tags.some(
+      (t) =>
+        t.key === filter.key &&
+        t.value === filter.value &&
+        t.type === filter.type &&
+        (t as any).operator === (filter as any).operator,
+    );
+    if (!duplicate) setTags((prev) => [...prev, filter]);
+    resetTagInput();
+  };
+
+  // Auto-add for dropdown-based types (string with values, boolean)
+  const handleDropdownValueSelect = (value: string) => {
+    if (!selectedTag) return;
+    addTag({ key: selectedKey, type: selectedTag.type, value });
+  };
+
+  // Add for number or free-text string
+  const handleAddClick = () => {
+    if (!selectedTag || !valueInput.trim()) return;
+    if (selectedTag.type === "number") {
+      if (numericOperator === "between" && !value2Input.trim()) return;
+      addTag({
+        key: selectedKey,
+        type: "number",
+        operator: numericOperator,
+        value: valueInput.trim(),
+        ...(numericOperator === "between"
+          ? { value2: value2Input.trim() }
+          : {}),
+      });
+    } else {
+      addTag({
+        key: selectedKey,
+        type: selectedTag.type,
+        value: valueInput.trim(),
+      });
+    }
+  };
+
   const clearFilters = () => {
     setStartDate(undefined);
     setEndDate(undefined);
     setTags([]);
-    setSelectedTagKey("");
+    resetTagInput();
   };
 
   const handleApply = () => {
@@ -162,14 +237,10 @@ export default function EventFilterDialog({
   const filterCount =
     (currentStartDate || currentEndDate ? 1 : 0) + currentTags.length;
 
-  // Check if a preset matches current dates
   const getActivePreset = () => {
     if (!startDate || !endDate) return null;
-    // Simple check - not exact but good enough for UI feedback
     const now = new Date();
-    const diffMs = now.getTime() - startDate.getTime();
-    const diffHours = diffMs / (1000 * 60 * 60);
-
+    const diffHours = (now.getTime() - startDate.getTime()) / (1000 * 60 * 60);
     if (diffHours <= 1.1) return "1h";
     if (diffHours <= 25) return "day";
     if (diffHours <= 169) return "week";
@@ -179,6 +250,16 @@ export default function EventFilterDialog({
   };
 
   const activePreset = getActivePreset();
+
+  const canAddNumeric =
+    selectedTag?.type === "number" &&
+    valueInput.trim() !== "" &&
+    (numericOperator !== "between" || value2Input.trim() !== "");
+
+  const canAddFreeText =
+    selectedTag?.type === "string" &&
+    selectedTag.values.length === 0 &&
+    valueInput.trim() !== "";
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
@@ -219,8 +300,6 @@ export default function EventFilterDialog({
                 </Button>
               ))}
             </div>
-
-            {/* Custom Date Range */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-2">
               <div className="space-y-2">
                 <label className="text-sm text-muted-foreground">From</label>
@@ -251,68 +330,149 @@ export default function EventFilterDialog({
                 No tags available for this {type}
               </p>
             ) : (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {/* Key dropdown */}
+              <div className="space-y-3">
+                {/* Key selector */}
                 <div className="space-y-2">
                   <label className="text-sm text-muted-foreground">Key</label>
-                  <Select
-                    value={selectedTagKey}
-                    onValueChange={(value) => setSelectedTagKey(value)}
-                  >
+                  <Select value={selectedKey} onValueChange={setSelectedKey}>
                     <SelectTrigger className="w-full">
                       <SelectValue placeholder="Select key..." />
                     </SelectTrigger>
                     <SelectContent>
-                      {availableTags.map((tagGroup) => (
-                        <SelectItem key={tagGroup.key} value={tagGroup.key}>
-                          {tagGroup.key}
+                      {availableTags.map((tag) => (
+                        <SelectItem key={tag.key} value={tag.key}>
+                          <span>{tag.key}</span>
+                          <span className="ml-2 text-xs text-muted-foreground">
+                            {tag.type}
+                          </span>
                         </SelectItem>
                       ))}
                     </SelectContent>
                   </Select>
                 </div>
 
-                {/* Value dropdown */}
-                <div className="space-y-2">
-                  <label className="text-sm text-muted-foreground">Value</label>
-                  <Select
-                    value=""
-                    disabled={!selectedTagKey}
-                    onValueChange={(value) => {
-                      if (selectedTagKey && value) {
-                        // Add the tag filter if not already present
-                        const exists = tags.some(
-                          (t) => t.key === selectedTagKey && t.value === value,
-                        );
-                        if (!exists) {
-                          setTags([...tags, { key: selectedTagKey, value }]);
-                        }
-                        // Reset key selection
-                        setSelectedTagKey("");
-                      }
-                    }}
-                  >
-                    <SelectTrigger className="w-full">
-                      <SelectValue
-                        placeholder={
-                          selectedTagKey
-                            ? "Select value..."
-                            : "Select key first"
-                        }
-                      />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {selectedTagKey &&
-                        availableTags
-                          .find((t) => t.key === selectedTagKey)
-                          ?.values.map((value) => (
-                            <SelectItem key={value} value={value}>
-                              {value}
+                {/* Value input — varies by type */}
+                {selectedTag?.type === "boolean" && (
+                  <div className="space-y-2">
+                    <label className="text-sm text-muted-foreground">
+                      Value
+                    </label>
+                    <Select value="" onValueChange={handleDropdownValueSelect}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue placeholder="Select value..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="true">true</SelectItem>
+                        <SelectItem value="false">false</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+
+                {selectedTag?.type === "string" &&
+                  selectedTag.values.length > 0 && (
+                    <div className="space-y-2">
+                      <label className="text-sm text-muted-foreground">
+                        Value
+                      </label>
+                      <Select
+                        value=""
+                        onValueChange={handleDropdownValueSelect}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue placeholder="Select value..." />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {selectedTag.values.map((v) => (
+                            <SelectItem key={v} value={v}>
+                              {v}
                             </SelectItem>
                           ))}
-                    </SelectContent>
-                  </Select>
-                </div>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
+
+                {selectedTag?.type === "string" &&
+                  selectedTag.values.length === 0 && (
+                    <div className="flex gap-2">
+                      <div className="flex-1 space-y-2">
+                        <label className="text-sm text-muted-foreground">
+                          Value
+                        </label>
+                        <Input
+                          placeholder="Enter value..."
+                          value={valueInput}
+                          onChange={(e) => setValueInput(e.target.value)}
+                          onKeyDown={(e) =>
+                            e.key === "Enter" && handleAddClick()
+                          }
+                        />
+                      </div>
+                      <div className="flex items-end">
+                        <Button
+                          size="sm"
+                          onClick={handleAddClick}
+                          disabled={!canAddFreeText}
+                        >
+                          <PlusIcon className="size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                {selectedTag?.type === "number" && (
+                  <div className="space-y-2">
+                    <label className="text-sm text-muted-foreground">
+                      Condition
+                    </label>
+                    <div className="flex gap-2">
+                      <Select
+                        value={numericOperator}
+                        onValueChange={(v) =>
+                          setNumericOperator(v as typeof numericOperator)
+                        }
+                      >
+                        <SelectTrigger className="w-32 shrink-0">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {numericOperators.map((op) => (
+                            <SelectItem key={op.value} value={op.value}>
+                              {op.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        type="number"
+                        placeholder="Value"
+                        value={valueInput}
+                        onChange={(e) => setValueInput(e.target.value)}
+                        onKeyDown={(e) => e.key === "Enter" && handleAddClick()}
+                      />
+                      {numericOperator === "between" && (
+                        <Input
+                          type="number"
+                          placeholder="To"
+                          value={value2Input}
+                          onChange={(e) => setValue2Input(e.target.value)}
+                          onKeyDown={(e) =>
+                            e.key === "Enter" && handleAddClick()
+                          }
+                        />
+                      )}
+                      <Button
+                        size="sm"
+                        className="shrink-0"
+                        onClick={handleAddClick}
+                        disabled={!canAddNumeric}
+                      >
+                        <PlusIcon className="size-4" />
+                      </Button>
+                    </div>
+                  </div>
+                )}
               </div>
             )}
 
@@ -324,7 +484,7 @@ export default function EventFilterDialog({
                     key={i}
                     className="flex items-center gap-1 rounded-md bg-secondary px-2 py-1 text-sm"
                   >
-                    {tag.key}: {tag.value}
+                    {tagFilterLabel(tag)}
                     <button
                       onClick={() => removeTag(i)}
                       className="ml-1 rounded hover:bg-secondary-foreground/10"

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -14,6 +14,7 @@ import {
   lte,
   exists,
   max,
+  sql,
 } from "drizzle-orm";
 import { getProject } from "./project";
 
@@ -57,7 +58,10 @@ export type EventWithChannelName = {
 
 export type TagFilter = {
   key: string;
+  type: "string" | "number" | "boolean";
   value: string;
+  operator?: "eq" | "gt" | "lt" | "between";
+  value2?: string;
 };
 
 export type SortField = "date" | "name";
@@ -74,6 +78,39 @@ type QueryOptions = {
   tags?: TagFilter[];
   sortBy?: SortField;
   sortOrder?: SortOrder;
+};
+
+const buildTagCondition = (tagFilter: TagFilter) => {
+  const base = [
+    eq(eventTags.eventId, events.id),
+    eq(eventTags.key, tagFilter.key),
+  ];
+
+  if (tagFilter.type === "number") {
+    const op = tagFilter.operator ?? "eq";
+    const v = parseFloat(tagFilter.value);
+    if (op === "gt") {
+      base.push(sql`CAST(${eventTags.value} AS REAL) > ${v}` as any);
+    } else if (op === "lt") {
+      base.push(sql`CAST(${eventTags.value} AS REAL) < ${v}` as any);
+    } else if (op === "between") {
+      const v2 = parseFloat(tagFilter.value2 ?? tagFilter.value);
+      base.push(
+        sql`CAST(${eventTags.value} AS REAL) BETWEEN ${v} AND ${v2}` as any,
+      );
+    } else {
+      base.push(sql`CAST(${eventTags.value} AS REAL) = ${v}` as any);
+    }
+  } else {
+    base.push(eq(eventTags.value, tagFilter.value));
+  }
+
+  return exists(
+    db
+      .select({ eventId: eventTags.eventId })
+      .from(eventTags)
+      .where(and(...base)),
+  );
 };
 
 // helper function to get tag primitive object from event tags
@@ -142,18 +179,7 @@ export async function getChannelEvents(
   // Tag filtering using EXISTS subquery
   if (options.tags && options.tags.length > 0) {
     for (const tagFilter of options.tags) {
-      const tagSubquery = db
-        .select({ eventId: eventTags.eventId })
-        .from(eventTags)
-        .where(
-          and(
-            eq(eventTags.eventId, events.id),
-            eq(eventTags.key, tagFilter.key),
-            eq(eventTags.value, tagFilter.value),
-          ),
-        );
-
-      conditions.push(exists(tagSubquery));
+      conditions.push(buildTagCondition(tagFilter));
     }
   }
 
@@ -172,7 +198,7 @@ export async function getChannelEvents(
       channelName: channels.name,
     })
     .from(events)
-    .leftJoin(channels, eq(events.channelId, channels.id))
+    .innerJoin(channels, eq(events.channelId, channels.id))
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
@@ -232,18 +258,7 @@ export async function getProjectEvents(
   // Tag filtering using EXISTS subquery
   if (options.tags && options.tags.length > 0) {
     for (const tagFilter of options.tags) {
-      const tagSubquery = db
-        .select({ eventId: eventTags.eventId })
-        .from(eventTags)
-        .where(
-          and(
-            eq(eventTags.eventId, events.id),
-            eq(eventTags.key, tagFilter.key),
-            eq(eventTags.value, tagFilter.value),
-          ),
-        );
-
-      conditions.push(exists(tagSubquery));
+      conditions.push(buildTagCondition(tagFilter));
     }
   }
 
@@ -262,7 +277,7 @@ export async function getProjectEvents(
       channelName: channels.name,
     })
     .from(events)
-    .leftJoin(
+    .innerJoin(
       channels,
       and(
         eq(events.channelId, channels.id),
@@ -305,7 +320,7 @@ export async function getEvent(
       channelName: channels.name,
     })
     .from(events)
-    .leftJoin(channels, eq(events.channelId, channels.id))
+    .innerJoin(channels, eq(events.channelId, channels.id))
     .where(eq(events.id, eventId))
     .limit(1);
 

--- a/src/lib/beaver/tags.ts
+++ b/src/lib/beaver/tags.ts
@@ -2,77 +2,69 @@ import { db } from "../db/db";
 import { eventTags, events } from "../db/schema";
 import { eq } from "drizzle-orm";
 
+const DISTINCT_VALUE_THRESHOLD = 20;
+
 export interface AvailableTag {
   key: string;
+  type: "string" | "number" | "boolean";
   values: string[];
+}
+
+function groupTags(
+  rows: { key: string; type: string; value: string }[],
+): AvailableTag[] {
+  const tagMap = new Map<string, { type: string; values: Set<string> }>();
+
+  for (const row of rows) {
+    if (!tagMap.has(row.key)) {
+      tagMap.set(row.key, { type: row.type, values: new Set() });
+    }
+    tagMap.get(row.key)!.values.add(row.value);
+  }
+
+  const tags: AvailableTag[] = [];
+  for (const [key, { type, values }] of tagMap) {
+    const valuesArray = Array.from(values).sort();
+    const showValues =
+      type !== "number" && valuesArray.length <= DISTINCT_VALUE_THRESHOLD;
+    tags.push({
+      key,
+      type: type as "string" | "number" | "boolean",
+      values: showValues ? valuesArray : [],
+    });
+  }
+
+  return tags.sort((a, b) => a.key.localeCompare(b.key));
 }
 
 export async function getChannelAvailableTags(
   channelId: number,
 ): Promise<AvailableTag[]> {
-  // Get distinct key-value pairs for events in this channel
   const result = await db
     .selectDistinct({
       key: eventTags.key,
+      type: eventTags.type,
       value: eventTags.value,
     })
     .from(eventTags)
     .innerJoin(events, eq(eventTags.eventId, events.id))
     .where(eq(events.channelId, channelId));
 
-  // Group by key
-  const tagMap = new Map<string, Set<string>>();
-
-  for (const row of result) {
-    if (!tagMap.has(row.key)) {
-      tagMap.set(row.key, new Set());
-    }
-    tagMap.get(row.key)!.add(row.value);
-  }
-
-  // Convert to array format
-  const tags: AvailableTag[] = [];
-  for (const [key, values] of tagMap) {
-    tags.push({
-      key,
-      values: Array.from(values).sort(),
-    });
-  }
-
-  return tags.sort((a, b) => a.key.localeCompare(b.key));
+  return groupTags(result);
 }
 
 export async function getProjectAvailableTags(
   projectId: number,
 ): Promise<AvailableTag[]> {
-  // Get distinct key-value pairs for events in this project
   const result = await db
     .selectDistinct({
       key: eventTags.key,
+      type: eventTags.type,
       value: eventTags.value,
     })
     .from(eventTags)
     .innerJoin(events, eq(eventTags.eventId, events.id))
     .where(eq(events.projectId, projectId));
 
-  // Group by key
-  const tagMap = new Map<string, Set<string>>();
-
-  for (const row of result) {
-    if (!tagMap.has(row.key)) {
-      tagMap.set(row.key, new Set());
-    }
-    tagMap.get(row.key)!.add(row.value);
-  }
-
-  // Convert to array format
-  const tags: AvailableTag[] = [];
-  for (const [key, values] of tagMap) {
-    tags.push({
-      key,
-      values: Array.from(values).sort(),
-    });
-  }
-
-  return tags.sort((a, b) => a.key.localeCompare(b.key));
+  return groupTags(result);
 }

--- a/src/pages/api/admin.ts
+++ b/src/pages/api/admin.ts
@@ -31,6 +31,8 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       userId: user.id,
       userName: user.userName,
       isAdmin: user.isAdmin,
+      canCreateProjects: user.canCreateProjects,
+      mustChangePassword: user.mustChangePassword,
     };
 
     const accessToken = await createAccessToken(payload);


### PR DESCRIPTION
## Summary
- Tag keys now include their type (`string`, `number`, `boolean`) from the DB
- String tags with ≤ 20 distinct values show a dropdown; above threshold shows a free-text input
- Boolean tags show a true/false dropdown
- Number tags show an operator selector (`=`, `>`, `<`, `between`) with number input(s)
- Active filter pills in the feed correctly display numeric operators and ranges
- Fixed pre-existing bugs: `leftJoin` → `innerJoin` for channel joins in event queries (was causing a spurious `string | null` type error), and missing `canCreateProjects`/`mustChangePassword` fields in admin JWT payload

## Test plan
- [ ] Open filter dialog on a channel with string tags — dropdown appears for low-cardinality keys, text input for high-cardinality
- [ ] Filter by boolean tag — true/false dropdown, auto-adds on select
- [ ] Filter by number with `=`, `>`, `<` operators — correct results returned
- [ ] Filter by number with `between` — second input appears, pill shows `key: min – max`
- [ ] Active filter pills display correct labels for all types