### PR TITLE
feat: implement email notifications via Resend (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 JWT_SECRET=change-me-to-a-secure-random-string
 PORT=4321
 HOST=0.0.0.0
+
+# Email notifications (optional — powered by Resend)
+# Sign up at https://resend.com to get an API key
+RESEND_API_KEY=re_your_api_key_here
+RESEND_FROM_EMAIL=notifications@yourdomain.com

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,6 +13,9 @@ export default defineConfig({
   adapter: node({ mode: "standalone" }),
   vite: {
     plugins: [tailwindcss()],
+    ssr: {
+      external: ["bun:sqlite", "drizzle-orm/bun-sqlite"],
+    },
   },
   integrations: [
     react(),

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "react": "^19.2.0",
         "react-day-picker": "^9.13.0",
         "react-dom": "^19.2.0",
+        "resend": "^6.12.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.16",
       },
@@ -532,6 +533,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
@@ -857,6 +860,8 @@
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-sha256": ["fast-sha256@1.3.0", "", {}, "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ=="],
 
     "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
 
@@ -1286,6 +1291,8 @@
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
+    "postal-mime": ["postal-mime@2.7.4", "", {}, "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g=="],
+
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
@@ -1372,6 +1379,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "resend": ["resend@6.12.2", "", { "dependencies": { "postal-mime": "2.7.4", "svix": "1.90.0" }, "peerDependencies": { "@react-email/render": "*" }, "optionalPeers": ["@react-email/render"] }, "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw=="],
+
     "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
@@ -1452,6 +1461,8 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "standardwebhooks": ["standardwebhooks@1.0.0", "", { "dependencies": { "@stablelib/base64": "^1.0.0", "fast-sha256": "^1.3.0" } }, "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
@@ -1479,6 +1490,8 @@
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "svix": ["svix@1.90.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw=="],
 
     "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
 
@@ -1591,6 +1604,8 @@
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/drizzle/0007_small_colonel_america.sql
+++ b/drizzle/0007_small_colonel_america.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `project_members` ADD `notifications_enabled` integer DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE `users` ADD `email` text;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,682 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8a8784ee-21d0-40fd-83c2-eaddcd8be4ce",
+  "prevId": "73c2822e-2f8e-49f9-90f8-94b4d20ce018",
+  "tables": {
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777000235422,
       "tag": "0006_mighty_dazzler",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1777838882202,
+      "tag": "0007_small_colonel_america",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "format": "prettier --write .",
-    "dev": "astro dev",
+    "dev": "bunx --bun astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
@@ -40,6 +40,7 @@
     "react": "^19.2.0",
     "react-day-picker": "^9.13.0",
     "react-dom": "^19.2.0",
+    "resend": "^6.12.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.16"
   },

--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -151,6 +151,10 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
       ],
     },
     {
+      id: "notifications",
+      title: "Notifications",
+    },
+    {
       id: "tags",
       title: "Tags",
       children: [
@@ -460,6 +464,31 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                       .
                     </td>
                   </tr>
+                  <tr className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors">
+                    <td className="px-4 py-3">
+                      <code className="text-sm bg-gray-100 dark:bg-white/10 px-2 py-0.5 rounded text-pink-600 dark:text-pink-400">
+                        notify
+                      </code>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                      boolean
+                    </td>
+                    <td className="px-4 py-3">
+                      <Badge>Optional</Badge>
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">
+                      If <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">true</code>, sends an email notification to project members who have opted in. Requires{" "}
+                      <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">RESEND_API_KEY</code>{" "}
+                      to be configured. See{" "}
+                      <a
+                        href="#notifications"
+                        className="text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        Notifications
+                      </a>
+                      .
+                    </td>
+                  </tr>
                 </tbody>
               </table>
             </div>
@@ -555,6 +584,74 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
 }`}
               />
             </div>
+          </section>
+
+          {/* Notifications */}
+          <section id="notifications">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-4 flex items-center gap-2">
+              <span className="text-gray-400">#</span>
+              Notifications
+            </h2>
+            <p className="text-gray-600 dark:text-gray-400 mb-6 text-lg leading-relaxed">
+              Beaver can send email notifications when an event is posted with{" "}
+              <code className="bg-gray-100 dark:bg-white/10 px-2 py-0.5 rounded text-pink-600 dark:text-pink-400">
+                "notify": true
+              </code>
+              . Emails are sent only to project members who have opted in via
+              their notification settings.
+            </p>
+            <div className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-500/10 dark:to-indigo-500/10 border border-blue-200 dark:border-blue-500/20 rounded-xl p-6 mb-6">
+              <p className="text-blue-800 dark:text-blue-300 font-semibold mb-3">
+                Setup
+              </p>
+              <ol className="text-blue-700 dark:text-blue-400 text-sm space-y-2 list-decimal list-inside">
+                <li>
+                  Sign up at{" "}
+                  <span className="font-mono">resend.com</span> and create an API key
+                </li>
+                <li>
+                  Set{" "}
+                  <code className="bg-white/60 dark:bg-white/10 px-1 rounded">
+                    RESEND_API_KEY
+                  </code>{" "}
+                  in your environment
+                </li>
+                <li>
+                  Optionally set{" "}
+                  <code className="bg-white/60 dark:bg-white/10 px-1 rounded">
+                    RESEND_FROM_EMAIL
+                  </code>{" "}
+                  (defaults to{" "}
+                  <code className="bg-white/60 dark:bg-white/10 px-1 rounded">
+                    notifications@beaver.app
+                  </code>
+                  )
+                </li>
+                <li>
+                  Project members add an email and enable notifications in{" "}
+                  <a
+                    href="settings"
+                    className="underline underline-offset-2 hover:text-blue-900 dark:hover:text-blue-200"
+                  >
+                    Settings → Notifications
+                  </a>
+                </li>
+              </ol>
+            </div>
+            <CodeBlock
+              title="Triggering a notification"
+              language="bash"
+              code={`curl -X POST ${baseUrl}/api/event \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: ${displayKey}" \\
+  -d '{
+    "name": "Deployment Failed",
+    "channel": "alerts",
+    "description": "Production deploy failed on step 3",
+    "icon": "🚨",
+    "notify": true
+  }'`}
+            />
           </section>
 
           {/* Tags */}

--- a/src/components/notification-settings.tsx
+++ b/src/components/notification-settings.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { BellIcon, BellOffIcon } from "lucide-react";
+
+export default function NotificationSettings({
+  projectId,
+  initialEmail,
+  initialEnabled,
+}: {
+  projectId: number;
+  initialEmail: string | null;
+  initialEnabled: boolean;
+}) {
+  const [email, setEmail] = useState(initialEmail ?? "");
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [saving, setSaving] = useState(false);
+  const [savedEmail, setSavedEmail] = useState(initialEmail ?? "");
+  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+
+  const saveEmail = async () => {
+    setSaving(true);
+    setStatus("idle");
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim() || null }),
+      });
+      if (res.ok) {
+        setSavedEmail(email.trim());
+        setStatus("saved");
+        setTimeout(() => setStatus("idle"), 2000);
+      } else {
+        setStatus("error");
+      }
+    } catch {
+      setStatus("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const toggleNotifications = async (next: boolean) => {
+    if (next && !savedEmail) {
+      alert("Please save an email address before enabling notifications.");
+      return;
+    }
+    setEnabled(next);
+    await fetch("/api/notifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ projectId, enabled: next }),
+    }).catch(() => setEnabled(!next));
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Email */}
+      <div className="flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2">
+        <div>
+          <h3 className="font-medium shrink-0">Notification Email</h3>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Where event notifications will be sent
+          </p>
+        </div>
+        <div className="flex gap-2 items-center">
+          <Input
+            type="email"
+            placeholder="you@example.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && saveEmail()}
+            className="w-64"
+          />
+          <Button
+            variant="outline"
+            onClick={saveEmail}
+            disabled={saving || email.trim() === savedEmail}
+          >
+            {status === "saved"
+              ? "Saved!"
+              : status === "error"
+                ? "Error"
+                : "Save"}
+          </Button>
+        </div>
+      </div>
+
+      {/* Toggle */}
+      <div className="flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2">
+        <div>
+          <h3 className="font-medium shrink-0">Event Notifications</h3>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            Receive an email when an event is posted with{" "}
+            <code className="bg-muted px-1 rounded text-xs">
+              "notify": true
+            </code>
+          </p>
+        </div>
+        <Button
+          variant={enabled ? "default" : "outline"}
+          onClick={() => toggleNotifications(!enabled)}
+          className="gap-2 shrink-0"
+        >
+          {enabled ? (
+            <>
+              <BellIcon className="size-4" />
+              Enabled
+            </>
+          ) : (
+            <>
+              <BellOffIcon className="size-4" />
+              Disabled
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/beaver/project-member.ts
+++ b/src/lib/beaver/project-member.ts
@@ -53,6 +53,27 @@ export async function getUserProjectRole(
   return rows[0]?.role ?? null;
 }
 
+export async function getProjectMembership(
+  projectId: number,
+  userId: number,
+): Promise<{ role: Role; notificationsEnabled: boolean } | null> {
+  const rows = await db
+    .select({
+      role: projectMembers.role,
+      notificationsEnabled: projectMembers.notificationsEnabled,
+    })
+    .from(projectMembers)
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.userId, userId),
+      ),
+    )
+    .limit(1);
+
+  return rows[0] ?? null;
+}
+
 export async function addProjectMember(
   projectId: number,
   userId: number,

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -1,10 +1,11 @@
 import { db } from "../db/db";
-import { users, sessions } from "../db/schema";
-import { eq } from "drizzle-orm";
+import { users, sessions, projectMembers } from "../db/schema";
+import { eq, and } from "drizzle-orm";
 
 export type DatabaseUser = {
   id: number;
   userName: string;
+  email: string | null;
   isAdmin: boolean;
   canCreateProjects: boolean;
   password: string;
@@ -16,6 +17,7 @@ export type DatabaseUser = {
 export type User = {
   id: number;
   userName: string;
+  email: string | null;
   isAdmin: boolean;
   canCreateProjects: boolean;
   mustChangePassword: boolean;
@@ -23,34 +25,23 @@ export type User = {
   createdAt: Date | null;
 };
 
+const userSelect = {
+  id: users.id,
+  userName: users.userName,
+  email: users.email,
+  isAdmin: users.isAdmin,
+  canCreateProjects: users.canCreateProjects,
+  mustChangePassword: users.mustChangePassword,
+  tempPassword: users.tempPassword,
+  createdAt: users.createdAt,
+};
+
 export async function getAllUsers(): Promise<User[]> {
-  return await db
-    .select({
-      id: users.id,
-      userName: users.userName,
-      isAdmin: users.isAdmin,
-      canCreateProjects: users.canCreateProjects,
-      mustChangePassword: users.mustChangePassword,
-      tempPassword: users.tempPassword,
-      createdAt: users.createdAt,
-    })
-    .from(users)
-    .orderBy(users.createdAt);
+  return await db.select(userSelect).from(users).orderBy(users.createdAt);
 }
 
 export async function getAdminUsers(): Promise<User[]> {
-  return await db
-    .select({
-      id: users.id,
-      userName: users.userName,
-      isAdmin: users.isAdmin,
-      canCreateProjects: users.canCreateProjects,
-      mustChangePassword: users.mustChangePassword,
-      tempPassword: users.tempPassword,
-      createdAt: users.createdAt,
-    })
-    .from(users)
-    .where(eq(users.isAdmin, true));
+  return await db.select(userSelect).from(users).where(eq(users.isAdmin, true));
 }
 
 export async function getUserByUsername(
@@ -91,15 +82,7 @@ export async function createUser(
   const [user] = await db
     .insert(users)
     .values({ userName, password: hashedPassword, isAdmin })
-    .returning({
-      id: users.id,
-      userName: users.userName,
-      isAdmin: users.isAdmin,
-      canCreateProjects: users.canCreateProjects,
-      mustChangePassword: users.mustChangePassword,
-      tempPassword: users.tempPassword,
-      createdAt: users.createdAt,
-    });
+    .returning(userSelect);
 
   return user;
 }
@@ -121,15 +104,7 @@ export async function createUserAccount(
       mustChangePassword: true,
       tempPassword,
     })
-    .returning({
-      id: users.id,
-      userName: users.userName,
-      isAdmin: users.isAdmin,
-      canCreateProjects: users.canCreateProjects,
-      mustChangePassword: users.mustChangePassword,
-      tempPassword: users.tempPassword,
-      createdAt: users.createdAt,
-    });
+    .returning(userSelect);
 
   return { ...user, tempPassword };
 }
@@ -185,4 +160,44 @@ export async function changePassword(
 
   // Invalidate all sessions so user must re-login with new password
   await db.delete(sessions).where(eq(sessions.userId, id));
+}
+
+export async function updateUserEmail(
+  id: number,
+  email: string | null,
+): Promise<void> {
+  await db.update(users).set({ email }).where(eq(users.id, id));
+}
+
+export async function setProjectNotifications(
+  userId: number,
+  projectId: number,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .update(projectMembers)
+    .set({ notificationsEnabled: enabled })
+    .where(
+      and(
+        eq(projectMembers.userId, userId),
+        eq(projectMembers.projectId, projectId),
+      ),
+    );
+}
+
+export async function getNotificationEmails(
+  projectId: number,
+): Promise<string[]> {
+  const rows = await db
+    .select({ email: users.email })
+    .from(projectMembers)
+    .innerJoin(users, eq(projectMembers.userId, users.id))
+    .where(
+      and(
+        eq(projectMembers.projectId, projectId),
+        eq(projectMembers.notificationsEnabled, true),
+      ),
+    );
+
+  return rows.flatMap((r) => (r.email ? [r.email] : []));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -128,6 +128,7 @@ export const users = sqliteTable("users", {
     .notNull()
     .default(false),
   userName: text("username").notNull(),
+  email: text("email"),
   password: text("password").notNull(),
   mustChangePassword: integer("must_change_password", { mode: "boolean" })
     .notNull()
@@ -152,6 +153,9 @@ export const projectMembers = sqliteTable(
     role: text("role", { enum: ["owner", "maintainer", "guest"] })
       .notNull()
       .default("guest"),
+    notificationsEnabled: integer("notifications_enabled", { mode: "boolean" })
+      .notNull()
+      .default(false),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .default(sql`(unixepoch() * 1000)`)
       .notNull(),

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,0 +1,119 @@
+import { Resend } from "resend";
+import type { EventWithChannelName } from "../beaver/event";
+
+const apiKey = process.env.RESEND_API_KEY;
+const fromEmail = process.env.RESEND_FROM_EMAIL ?? "notifications@beaver.app";
+
+function buildEmailHtml(
+  event: EventWithChannelName,
+  projectName: string,
+): string {
+  const tags = Object.entries(event.tags ?? {});
+  const tagsHtml =
+    tags.length > 0
+      ? `<table style="width:100%;border-collapse:collapse;margin-top:16px;">
+          <thead>
+            <tr>
+              <th style="text-align:left;padding:8px 12px;background:#f4f4f5;font-size:12px;font-weight:600;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;border-radius:4px 0 0 0;">Key</th>
+              <th style="text-align:left;padding:8px 12px;background:#f4f4f5;font-size:12px;font-weight:600;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;border-radius:0 4px 0 0;">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${tags
+              .map(
+                ([k, v], i) => `
+              <tr style="background:${i % 2 === 0 ? "#ffffff" : "#fafafa"};">
+                <td style="padding:8px 12px;font-size:13px;color:#374151;border-bottom:1px solid #e5e7eb;font-family:monospace;">${k}</td>
+                <td style="padding:8px 12px;font-size:13px;color:#374151;border-bottom:1px solid #e5e7eb;font-family:monospace;">${v}</td>
+              </tr>`,
+              )
+              .join("")}
+          </tbody>
+        </table>`
+      : "";
+
+  const iconHtml = event.icon
+    ? `<span style="font-size:32px;line-height:1;display:block;margin-bottom:12px;">${event.icon}</span>`
+    : "";
+
+  const descHtml = event.description
+    ? `<p style="margin:8px 0 0;font-size:15px;color:#6b7280;line-height:1.6;">${event.description}</p>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${event.name}</title>
+</head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#171717;padding:24px 32px;border-radius:12px 12px 0 0;">
+              <p style="margin:0;font-size:13px;font-weight:600;color:#a1a1aa;letter-spacing:0.08em;text-transform:uppercase;">Beaver</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#71717a;">
+                ${projectName} &middot; #${event.channelName}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background:#ffffff;padding:32px;border-left:1px solid #e5e7eb;border-right:1px solid #e5e7eb;">
+              ${iconHtml}
+              <h1 style="margin:0;font-size:22px;font-weight:700;color:#111827;line-height:1.3;">${event.name}</h1>
+              ${descHtml}
+
+              ${tagsHtml}
+
+              <p style="margin:24px 0 0;font-size:12px;color:#9ca3af;">
+                ${new Date(event.createdAt).toUTCString()}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f4f4f5;padding:20px 32px;border-radius:0 0 12px 12px;border:1px solid #e5e7eb;border-top:none;">
+              <p style="margin:0;font-size:12px;color:#9ca3af;line-height:1.6;">
+                You're receiving this because you enabled event notifications for
+                <strong style="color:#6b7280;">${projectName}</strong>.
+                You can turn these off in your account settings.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+export async function sendEventNotification(
+  event: EventWithChannelName,
+  projectName: string,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!apiKey || recipientEmails.length === 0) return;
+
+  const resend = new Resend(apiKey);
+
+  await resend.emails.send({
+    from: fromEmail,
+    to: recipientEmails,
+    subject: `${event.icon ? `${event.icon} ` : ""}${event.name} — ${projectName}`,
+    html: buildEmailHtml(event, projectName),
+  });
+}
+
+export function isResendConfigured(): boolean {
+  return !!apiKey;
+}

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -1,4 +1,7 @@
 import { createEvent } from "@/lib/beaver/event";
+import { getProject } from "@/lib/beaver/project";
+import { getNotificationEmails } from "@/lib/beaver/user";
+import { sendEventNotification } from "@/lib/email/resend";
 import type { APIContext, APIRoute } from "astro";
 
 export const POST: APIRoute = async ({ request }: APIContext) => {
@@ -19,7 +22,8 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
     }
 
     // extract body and verify contents
-    const { name, description, icon, channel, tags } = await request.json();
+    const { name, description, icon, channel, tags, notify } =
+      await request.json();
 
     if (!name) {
       return new Response(
@@ -70,6 +74,16 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
       apiKey,
       tags: tagObj,
     });
+
+    if (notify === true) {
+      const emails = await getNotificationEmails(event.projectId);
+      if (emails.length > 0) {
+        const project = await getProject(event.projectId);
+        if (project) {
+          sendEventNotification(event, project.name, emails).catch(() => {});
+        }
+      }
+    }
 
     return new Response(JSON.stringify(event), {
       status: 200,

--- a/src/pages/api/notifications.ts
+++ b/src/pages/api/notifications.ts
@@ -1,0 +1,25 @@
+import { setProjectNotifications } from "@/lib/beaver/user";
+import type { APIContext } from "astro";
+
+export async function POST({ locals, request }: APIContext) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+    });
+  }
+
+  const { projectId, enabled } = await request.json();
+  if (typeof projectId !== "number" || typeof enabled !== "boolean") {
+    return new Response(JSON.stringify({ error: "Invalid request" }), {
+      status: 400,
+    });
+  }
+
+  await setProjectNotifications(user.id, projectId, enabled);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/users/me.ts
+++ b/src/pages/api/users/me.ts
@@ -1,0 +1,20 @@
+import { updateUserEmail } from "@/lib/beaver/user";
+import type { APIContext } from "astro";
+
+export async function PATCH({ locals, request }: APIContext) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+    });
+  }
+
+  const { email } = await request.json();
+
+  await updateUserEmail(user.id, email ?? null);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -4,10 +4,12 @@ import ChannelSettings from "@/components/channel-settings";
 import ProjectDangerZone from "@/components/project-danger-zone";
 import ProjectRename from "@/components/project-rename";
 import ProjectMembers from "@/components/project-members";
+import NotificationSettings from "@/components/notification-settings";
 import Layout from "@/layouts/layout.astro";
 import { getChannels } from "@/lib/beaver/channel";
 import { getProject } from "@/lib/beaver/project";
-import { getUserProjectRole } from "@/lib/beaver/project-member";
+import { getUserProjectRole, getProjectMembership } from "@/lib/beaver/project-member";
+import { getUserByUsername } from "@/lib/beaver/user";
 
 const { projectID } = Astro.params;
 const user = Astro.locals.user!;
@@ -24,6 +26,8 @@ if (userRole === "guest" || userRole === null) {
 }
 
 const channels = await getChannels(parseInt(projectID!));
+const dbUser = await getUserByUsername(user.userName);
+const membership = await getProjectMembership(project.id, user.id);
 
 const isOwner = userRole === "owner";
 
@@ -70,6 +74,15 @@ const metaH3Css = "font-medium shrink-0";
           />
         </div>
       )}
+      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
+        <h2 class="font-mono mb-4">Notifications</h2>
+        <NotificationSettings
+          client:load
+          projectId={project.id}
+          initialEmail={dbUser?.email ?? null}
+          initialEnabled={membership?.notificationsEnabled ?? false}
+        />
+      </div>
       {isOwner && (
         <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
           <h2 class="font-mono">Danger Zone</h2>


### PR DESCRIPTION
## Summary

- Project members can opt into per-project email notifications in **Settings → Notifications**
- When an event is posted with `"notify": true`, opted-in members receive a styled HTML email
- Adds `users.email` and `projectMembers.notificationsEnabled` DB columns (migration included)
- New endpoints: `PATCH /api/users/me` (save email), `POST /api/notifications` (toggle opt-in)
- `notify` field documented in API Docs page with a new Notifications section
- `.env.example` updated with `RESEND_API_KEY` and `RESEND_FROM_EMAIL`
- Fixes Astro dev server middleware crash (`bun:sqlite` loaded in Node.js ESM worker) by switching dev script to `bunx --bun` and adding `bun:sqlite` to Vite `ssr.external`

Closes #24

## Test plan

- [ ] Set `RESEND_API_KEY` in `.env` and restart
- [ ] Go to Settings → Notifications, save an email, enable notifications
- [ ] Post an event with `"notify": true` via the API and verify email is received
- [ ] Post an event without `notify` and verify no email is sent
- [ ] Verify `bun run dev` starts without middleware errors
- [ ] Check API Docs page shows Notifications section and `notify` field in request body table