### PR TITLE
feat: password reset guard and self-service change password (#42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "migrate": "bun src/lib/db/migrate.ts",
-    "seed": "bun src/lib/db/seed.ts"
+    "seed": "bun src/lib/db/seed.ts",
+    "reset-admin": "bun src/scripts/reset-admin.ts"
   },
   "dependencies": {
     "@astrojs/node": "^9.5.0",

--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -131,17 +131,19 @@ function UserActions({
           </TooltipContent>
         </Tooltip>
       )}
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            onClick={() => onReset(user)}
-            className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-          >
-            <RefreshCwIcon size={15} />
-          </button>
-        </TooltipTrigger>
-        <TooltipContent>Reset password</TooltipContent>
-      </Tooltip>
+      {!(user.id === currentUserId && user.isAdmin) && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              onClick={() => onReset(user)}
+              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <RefreshCwIcon size={15} />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Reset password</TooltipContent>
+        </Tooltip>
+      )}
       {user.id !== currentUserId && (
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/change-password-form.tsx
+++ b/src/components/change-password-form.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+
+export default function ChangePasswordForm() {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(false);
+
+    if (newPassword !== confirmPassword) {
+      setError("Passwords do not match.");
+      return;
+    }
+
+    if (newPassword.length < 8) {
+      setError("Password must be at least 8 characters.");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/users/update-password", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "Failed to update password.");
+        return;
+      }
+      setSuccess(true);
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      setTimeout(() => setSuccess(false), 3000);
+    } catch {
+      setError("Failed to update password.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-3 max-w-sm">
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="current-password">Current password</Label>
+        <Input
+          id="current-password"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="new-password">New password</Label>
+        <Input
+          id="new-password"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+        />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="confirm-password">Confirm new password</Label>
+        <Input
+          id="confirm-password"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+        />
+      </div>
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <Button type="submit" disabled={saving} className="w-fit">
+        {success ? "Updated!" : saving ? "Updating…" : "Update password"}
+      </Button>
+    </form>
+  );
+}

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -40,6 +40,11 @@ export async function getAllUsers(): Promise<User[]> {
   return await db.select(userSelect).from(users).orderBy(users.createdAt);
 }
 
+export async function getUserById(id: number): Promise<DatabaseUser | null> {
+  const result = await db.select().from(users).where(eq(users.id, id)).limit(1);
+  return result[0] || null;
+}
+
 export async function getAdminUsers(): Promise<User[]> {
   return await db.select(userSelect).from(users).where(eq(users.isAdmin, true));
 }
@@ -160,6 +165,18 @@ export async function changePassword(
 
   // Invalidate all sessions so user must re-login with new password
   await db.delete(sessions).where(eq(sessions.userId, id));
+}
+
+export async function updatePassword(
+  id: number,
+  newPassword: string,
+): Promise<void> {
+  const hashedPassword = await Bun.password.hash(newPassword);
+
+  await db
+    .update(users)
+    .set({ password: hashedPassword, tempPassword: null, mustChangePassword: false })
+    .where(eq(users.id, id));
 }
 
 export async function updateUserEmail(

--- a/src/pages/api/users/reset-password.ts
+++ b/src/pages/api/users/reset-password.ts
@@ -1,5 +1,5 @@
 import type { APIContext, APIRoute } from "astro";
-import { resetUserPassword } from "@/lib/beaver/user";
+import { resetUserPassword, getUserById } from "@/lib/beaver/user";
 
 export const POST: APIRoute = async (context: APIContext) => {
   if (!context.locals.user?.isAdmin) {
@@ -17,6 +17,14 @@ export const POST: APIRoute = async (context: APIContext) => {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    const target = await getUserById(id);
+    if (target?.isAdmin && target.id === context.locals.user?.id) {
+      return new Response(
+        JSON.stringify({ error: "Cannot reset your own password. Use Settings → Change Password instead." }),
+        { status: 403, headers: { "Content-Type": "application/json" } },
+      );
     }
 
     const tempPassword = await resetUserPassword(id);

--- a/src/pages/api/users/update-password.ts
+++ b/src/pages/api/users/update-password.ts
@@ -1,0 +1,59 @@
+import { getUserByUsername, updatePassword, verifyPassword } from "@/lib/beaver/user";
+import type { APIContext, APIRoute } from "astro";
+
+export const POST: APIRoute = async (context: APIContext) => {
+  const user = context.locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { currentPassword, newPassword } = await context.request.json();
+
+    if (!currentPassword || !newPassword) {
+      return new Response(JSON.stringify({ error: "Missing required fields." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (newPassword.length < 8) {
+      return new Response(
+        JSON.stringify({ error: "Password must be at least 8 characters." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const dbUser = await getUserByUsername(user.userName);
+    if (!dbUser) {
+      return new Response(JSON.stringify({ error: "User not found." }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const valid = await verifyPassword(currentPassword, dbUser.password);
+    if (!valid) {
+      return new Response(
+        JSON.stringify({ error: "Current password is incorrect." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    await updatePassword(user.id, newPassword);
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch {
+    return new Response(JSON.stringify({ error: "Failed to update password." }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -1,5 +1,6 @@
 ---
 import APIKey from "@/components/api-key";
+import ChangePasswordForm from "@/components/change-password-form";
 import ChannelSettings from "@/components/channel-settings";
 import ProjectDangerZone from "@/components/project-danger-zone";
 import ProjectRename from "@/components/project-rename";
@@ -74,6 +75,11 @@ const metaH3Css = "font-medium shrink-0";
           />
         </div>
       )}
+      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
+        <h2 class="font-mono mb-4">Account</h2>
+        <h3 class="font-medium mb-3">Change Password</h3>
+        <ChangePasswordForm client:load />
+      </div>
       <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
         <h2 class="font-mono mb-4">Notifications</h2>
         <NotificationSettings

--- a/src/scripts/reset-admin.ts
+++ b/src/scripts/reset-admin.ts
@@ -1,0 +1,70 @@
+import { parseArgs } from "util";
+import { db } from "../lib/db/db";
+import { users, sessions } from "../lib/db/schema";
+import { eq } from "drizzle-orm";
+
+const { values } = parseArgs({
+  args: Bun.argv.slice(2),
+  options: {
+    username: { type: "string" },
+    password: { type: "string" },
+  },
+  strict: true,
+});
+
+if (!values.username) {
+  console.error("Usage: bun run reset-admin --username <username> [--password <password>]");
+  process.exit(1);
+}
+
+const [user] = await db
+  .select()
+  .from(users)
+  .where(eq(users.userName, values.username))
+  .limit(1);
+
+if (!user) {
+  console.error(`Error: user "${values.username}" not found.`);
+  process.exit(1);
+}
+
+if (!user.isAdmin) {
+  console.error(`Error: "${values.username}" is not an admin. Use the admin panel to reset non-admin passwords.`);
+  process.exit(1);
+}
+
+let newPassword = values.password ?? "";
+
+if (!newPassword) {
+  process.stdout.write("New password: ");
+  newPassword = await new Promise<string>((resolve) => {
+    let input = "";
+    process.stdin.resume();
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk: string) => {
+      input += chunk;
+      if (input.includes("\n")) {
+        process.stdin.pause();
+        resolve(input.trim());
+      }
+    });
+  });
+  process.stdout.write("\n");
+}
+
+if (newPassword.length < 8) {
+  console.error("Error: password must be at least 8 characters.");
+  process.exit(1);
+}
+
+const hashedPassword = await Bun.password.hash(newPassword);
+
+await db
+  .update(users)
+  .set({ password: hashedPassword, tempPassword: null, mustChangePassword: false })
+  .where(eq(users.id, user.id));
+
+await db.delete(sessions).where(eq(sessions.userId, user.id));
+
+console.log(`✓ Password reset for @${user.userName}. All sessions have been invalidated.`);
+process.exit(0);


### PR DESCRIPTION
## Summary

- **Admin panel**: Reset password button hidden when viewing your own row as an admin — resetting yourself would kill your session. Other admins can still be reset normally
- **API guard**: `POST /api/users/reset-password` rejects self-reset for admins with a clear error pointing to Settings
- **Settings → Account**: New Change Password form for all logged-in users — verifies current password, updates in place, no session invalidation
- **`bun run reset-admin`**: Emergency CLI recovery script. Accepts `--username` (required) and optional `--password`; prompts interactively if password not provided. Admin-only — rejects non-admin targets. Invalidates all sessions after reset

Closes #42

## Test plan

- [ ] Log in as admin, go to Admin → Users — confirm no reset button on your own row
- [ ] Confirm reset button still appears on other users (including other admins)
- [ ] Go to Settings → Account, change password with correct current password — confirm it works without signing out
- [ ] Try with wrong current password — confirm error message
- [ ] Run `bun run reset-admin --username <admin>` and confirm password is updated and session invalidated
- [ ] Run `bun run reset-admin --username <non-admin>` and confirm it is rejected