### PR TITLE
feat: channel coalescing (#38)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 // @ts-check
 import { defineConfig } from "astro/config";
+import { createRunnableDevEnvironment } from "vite";
 
 import react from "@astrojs/react";
 import node from "@astrojs/node";
@@ -13,8 +14,13 @@ export default defineConfig({
   adapter: node({ mode: "standalone" }),
   vite: {
     plugins: [tailwindcss()],
-    ssr: {
-      external: ["bun:sqlite", "drizzle-orm/bun-sqlite"],
+    environments: {
+      ssr: {
+        dev: {
+          createEnvironment: (name, config) =>
+            createRunnableDevEnvironment(name, config),
+        },
+      },
     },
   },
   integrations: [

--- a/src/components/channel-settings.tsx
+++ b/src/components/channel-settings.tsx
@@ -1,16 +1,22 @@
 import type { Channel } from "@/lib/beaver/channel";
 import {
   Dialog,
-  DialogTrigger,
   DialogContent,
   DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogClose,
 } from "./ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
-import { Trash2Icon } from "lucide-react";
+import { GitMergeIcon, Trash2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Label } from "./ui/label";
 import type { Project } from "@/lib/beaver/project";
@@ -29,128 +35,320 @@ export default function ChannelSettings({
   project: Project;
 }) {
   const [clientChannels, setChannels] = useState<Channel[]>(channels);
-  const [channelName, setChannelName] = useState("");
-  const [channelDeleteError, setChannelDeleteError] = useState("");
-  const [dialogOpen, setDialogOpen] = useState(false);
 
-  const deleteChannel = async (channel: Channel) => {
-    const res = await fetch("/api/channel", {
-      method: "DELETE",
-      body: JSON.stringify({ channelID: channel.id }),
-    });
+  // Delete state
+  const [deleteTarget, setDeleteTarget] = useState<Channel | null>(null);
+  const [deleteConfirmName, setDeleteConfirmName] = useState("");
+  const [deleteError, setDeleteError] = useState("");
+  const [deleting, setDeleting] = useState(false);
 
-    const data = await res.json();
+  // Merge state
+  const [mergeSource, setMergeSource] = useState<Channel | null>(null);
+  const [mergeTargetId, setMergeTargetId] = useState<string>("");
+  const [nameChoice, setNameChoice] = useState<"source" | "target" | "custom">("target");
+  const [customName, setCustomName] = useState("");
+  const [merging, setMerging] = useState(false);
+  const [mergeError, setMergeError] = useState("");
 
-    if (res.status !== 200) {
-      setChannelDeleteError(data.error);
-      return;
+  const mergeTarget = clientChannels.find((c) => c.id === parseInt(mergeTargetId));
+
+  const survivingName =
+    nameChoice === "source"
+      ? mergeSource?.name ?? ""
+      : nameChoice === "target"
+        ? mergeTarget?.name ?? ""
+        : customName.trim();
+
+  const handleDeleteConfirm = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      const res = await fetch("/api/channel", {
+        method: "DELETE",
+        body: JSON.stringify({ channelID: deleteTarget.id }),
+      });
+      const data = await res.json();
+      if (res.status !== 200) {
+        setDeleteError(data.error);
+        return;
+      }
+      setChannels((prev) => prev.filter((c) => c.id !== deleteTarget.id));
+      window.dispatchEvent(
+        new CustomEvent("channel:deleted", { detail: { id: deleteTarget.id } }),
+      );
+      setDeleteTarget(null);
+      setDeleteConfirmName("");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleMergeConfirm = async () => {
+    if (!mergeSource || !mergeTarget || !survivingName) return;
+    setMerging(true);
+    setMergeError("");
+    try {
+      const res = await fetch("/api/channel/coalesce", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sourceId: mergeSource.id,
+          targetId: mergeTarget.id,
+          survivingName,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMergeError(data.error || "Failed to merge channels.");
+        return;
+      }
+      // Remove source, update target name
+      setChannels((prev) =>
+        prev
+          .filter((c) => c.id !== mergeSource.id)
+          .map((c) => (c.id === mergeTarget.id ? { ...c, name: data.name } : c)),
+      );
+      window.dispatchEvent(
+        new CustomEvent("channel:deleted", { detail: { id: mergeSource.id } }),
+      );
+      setMergeSource(null);
+      setMergeTargetId("");
+      setNameChoice("target");
+      setCustomName("");
+    } finally {
+      setMerging(false);
     }
   };
 
   useEffect(() => {
-    const handleChannelDeleted = (e: CustomEvent<{ id: number }>) => {
-      const { id } = e.detail;
-
-      setChannels((prev) => prev.filter((c) => c.id !== id));
-    };
-
     const handleChannelCreated = (e: CustomEvent<{ channel: Channel }>) => {
-      const { channel } = e.detail;
-
-      setChannels([...clientChannels, channel]);
+      setChannels((prev) => [...prev, e.detail.channel]);
     };
-
-    window.addEventListener(
-      "channel:deleted",
-      handleChannelDeleted as EventListener,
-    );
-
-    window.addEventListener(
-      "channel:created",
-      handleChannelCreated as EventListener,
-    );
-
+    window.addEventListener("channel:created", handleChannelCreated as EventListener);
     return () => {
-      window.removeEventListener(
-        "channel:deleted",
-        handleChannelDeleted as EventListener,
-      );
+      window.removeEventListener("channel:created", handleChannelCreated as EventListener);
     };
   }, []);
+
+  // Reset merge target name choice when target changes
+  useEffect(() => {
+    setNameChoice("target");
+    setCustomName("");
+  }, [mergeTargetId]);
 
   return (
     <TooltipProvider delayDuration={300}>
       {clientChannels.map((channel) => (
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen} key={channel.id}>
-          <div className="rounded border p-3 md:p-4 mt-4 flex justify-between items-center gap-2">
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
-                <a
-                  href={`/dashboard/${project.id}/channels/${channel.id}`}
-                  className="hover:text-black/50 truncate"
-                >
-                  <h3 className="font-medium text-lg"># {channel.name}</h3>
-                </a>
-                <p className="text-xs text-muted-foreground shrink-0">
-                  {channel.createdAt?.toLocaleDateString()}
-                </p>
-              </div>
-              <p className="font-light text-xs truncate">
-                {channel.description}
+        <div
+          key={channel.id}
+          className="rounded border p-3 md:p-4 mt-4 flex justify-between items-center gap-2"
+        >
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
+              <a
+                href={`/dashboard/${project.id}/channels/${channel.id}`}
+                className="hover:text-black/50 truncate"
+              >
+                <h3 className="font-medium text-lg"># {channel.name}</h3>
+              </a>
+              <p className="text-xs text-muted-foreground shrink-0">
+                {channel.createdAt?.toLocaleDateString()}
               </p>
             </div>
-            <div>
+            <p className="font-light text-xs truncate">{channel.description}</p>
+          </div>
+          <div className="flex items-center gap-1">
+            {clientChannels.length > 1 && (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <DialogTrigger asChild>
-                    <button className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors">
-                      <Trash2Icon size={15} />
-                    </button>
-                  </DialogTrigger>
+                  <button
+                    onClick={() => {
+                      setMergeSource(channel);
+                      setMergeTargetId("");
+                      setNameChoice("target");
+                      setCustomName("");
+                      setMergeError("");
+                    }}
+                    className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                  >
+                    <GitMergeIcon size={15} />
+                  </button>
                 </TooltipTrigger>
-                <TooltipContent>Delete channel</TooltipContent>
+                <TooltipContent>Merge channel</TooltipContent>
               </Tooltip>
-            </div>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => {
+                    setDeleteTarget(channel);
+                    setDeleteConfirmName("");
+                    setDeleteError("");
+                  }}
+                  className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
+                >
+                  <Trash2Icon size={15} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Delete channel</TooltipContent>
+            </Tooltip>
           </div>
-          {/* Delete channel dialog */}
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>Delete channel</DialogTitle>
-              <DialogDescription>
-                Are you sure you want to delete{" "}
-                <span className="font-bold"># {channel.name}</span> ?
-              </DialogDescription>
-            </DialogHeader>
-            <p className="font-medium text-sm text-rose-500">
-              {channelDeleteError}
-            </p>
-            <Label>Confirm channel name</Label>
-            <Input
-              id="channel-name"
-              placeholder="Channel name"
-              onChange={(e) => setChannelName(e.target.value)}
-            />
-            <div className="flex space-x-8 w-full justify-end mt-4">
-              <DialogClose asChild>
-                <Button variant="secondary">Cancel</Button>
-              </DialogClose>
+        </div>
+      ))}
+
+      {/* Delete dialog */}
+      <Dialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeleteTarget(null);
+            setDeleteConfirmName("");
+            setDeleteError("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete channel</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete{" "}
+              <span className="font-bold"># {deleteTarget?.name}</span>? This
+              cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteError && (
+            <p className="text-sm text-destructive">{deleteError}</p>
+          )}
+          <Label>Confirm channel name</Label>
+          <Input
+            placeholder="Channel name"
+            value={deleteConfirmName}
+            onChange={(e) => setDeleteConfirmName(e.target.value)}
+          />
+          <div className="flex gap-2 justify-end mt-2">
+            <DialogClose asChild>
+              <Button variant="secondary">Cancel</Button>
+            </DialogClose>
+            <Button
+              variant="destructive"
+              disabled={deleteConfirmName !== deleteTarget?.name || deleting}
+              onClick={handleDeleteConfirm}
+            >
+              {deleting ? "Deleting…" : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Merge dialog */}
+      <Dialog
+        open={!!mergeSource}
+        onOpenChange={(open) => {
+          if (!open) {
+            setMergeSource(null);
+            setMergeTargetId("");
+            setNameChoice("target");
+            setCustomName("");
+            setMergeError("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Merge channel</DialogTitle>
+            <DialogDescription>
+              Merge{" "}
+              <span className="font-bold"># {mergeSource?.name}</span> into
+              another channel. All events will move to the surviving channel and{" "}
+              <span className="font-bold"># {mergeSource?.name}</span> will be
+              deleted.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 mt-1">
+            <div className="flex flex-col gap-1.5">
+              <Label>Merge into</Label>
+              <Select value={mergeTargetId} onValueChange={setMergeTargetId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select a channel…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {clientChannels
+                    .filter((c) => c.id !== mergeSource?.id)
+                    .map((c) => (
+                      <SelectItem key={c.id} value={String(c.id)}>
+                        # {c.name}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {mergeTarget && (
+              <div className="flex flex-col gap-2">
+                <Label>Surviving name</Label>
+                <div className="flex flex-col gap-2">
+                  {(
+                    [
+                      { value: "target", label: `# ${mergeTarget.name}` },
+                      { value: "source", label: `# ${mergeSource?.name}` },
+                      { value: "custom", label: "Custom…" },
+                    ] as const
+                  ).map(({ value, label }) => (
+                    <label
+                      key={value}
+                      className="flex items-center gap-2 cursor-pointer text-sm"
+                    >
+                      <input
+                        type="radio"
+                        name="nameChoice"
+                        value={value}
+                        checked={nameChoice === value}
+                        onChange={() => setNameChoice(value)}
+                        className="h-4 w-4"
+                      />
+                      {label}
+                    </label>
+                  ))}
+                </div>
+                {nameChoice === "custom" && (
+                  <Input
+                    placeholder="Channel name"
+                    value={customName}
+                    onChange={(e) => setCustomName(e.target.value)}
+                    className="mt-1"
+                    autoFocus
+                  />
+                )}
+              </div>
+            )}
+
+            {mergeError && (
+              <p className="text-sm text-destructive">{mergeError}</p>
+            )}
+
+            <div className="flex gap-2 justify-end">
               <Button
-                disabled={channelName !== channel.name}
-                onClick={async () => {
-                  deleteChannel(channel);
-                  const id = channel.id;
-                  window.dispatchEvent(
-                    new CustomEvent("channel:deleted", { detail: { id } }),
-                  );
-                  setDialogOpen(false);
-                }}
+                variant="secondary"
+                onClick={() => setMergeSource(null)}
               >
-                Delete
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !mergeTarget ||
+                  !survivingName ||
+                  (nameChoice === "custom" && !customName.trim()) ||
+                  merging
+                }
+                onClick={handleMergeConfirm}
+              >
+                {merging ? "Merging…" : "Merge"}
               </Button>
             </div>
-          </DialogContent>
-        </Dialog>
-      ))}
+          </div>
+        </DialogContent>
+      </Dialog>
     </TooltipProvider>
   );
 }

--- a/src/lib/beaver/channel.ts
+++ b/src/lib/beaver/channel.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { channels, events, eventTags } from "../db/schema";
+import { channels, events, eventTags, channelReads } from "../db/schema";
 import { eq, and, asc, max, inArray } from "drizzle-orm";
 
 export type Channel = {
@@ -80,6 +80,43 @@ export async function reorderChannels(
         .where(eq(channels.id, id)),
     ),
   );
+}
+
+export async function coalesceChannels(
+  sourceId: number,
+  targetId: number,
+  survivingName: string,
+) {
+  const [source, target] = await Promise.all([
+    db.select().from(channels).where(eq(channels.id, sourceId)).limit(1),
+    db.select().from(channels).where(eq(channels.id, targetId)).limit(1),
+  ]);
+
+  if (!source[0] || !target[0]) throw new Error("Channel not found.");
+  if (source[0].projectId !== target[0].projectId)
+    throw new Error("Channels must belong to the same project.");
+
+  // Move all events from source to target
+  await db
+    .update(events)
+    .set({ channelId: targetId })
+    .where(eq(events.channelId, sourceId));
+
+  // Drop source channel reads — avoid unique constraint conflicts on (userId, channelId)
+  await db.delete(channelReads).where(eq(channelReads.channelId, sourceId));
+
+  // Rename target if the surviving name differs
+  if (survivingName !== target[0].name) {
+    await db
+      .update(channels)
+      .set({ name: survivingName })
+      .where(eq(channels.id, targetId));
+  }
+
+  // Delete source (events already moved, no cascade needed)
+  await db.delete(channels).where(eq(channels.id, sourceId));
+
+  return { ...target[0], name: survivingName };
 }
 
 export async function deleteChannel(channelID: number) {

--- a/src/pages/api/channel/coalesce.ts
+++ b/src/pages/api/channel/coalesce.ts
@@ -1,0 +1,49 @@
+import { coalesceChannels } from "@/lib/beaver/channel";
+import type { APIContext, APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    const { sourceId, targetId, survivingName } = await request.json();
+
+    if (!sourceId || !targetId || !survivingName) {
+      return new Response(
+        JSON.stringify({ error: "sourceId, targetId, and survivingName are required." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    if (sourceId === targetId) {
+      return new Response(
+        JSON.stringify({ error: "Cannot merge a channel into itself." }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const channel = await coalesceChannels(sourceId, targetId, survivingName.trim());
+
+    return new Response(JSON.stringify(channel), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    if (err instanceof Error) {
+      return new Response(JSON.stringify({ error: err.message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    return new Response(JSON.stringify({ error: "An unknown error occurred." }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};
+
+export const prerender = false;


### PR DESCRIPTION
## Summary

- Adds a merge (git merge icon) button to each channel row in **Settings → Channels**
- Select the channel to merge into, choose the surviving name (either channel's name or a custom one), confirm
- All events from the source channel move to the surviving channel; the source is deleted
- Channel reads for the source are dropped to avoid unique constraint conflicts on `(userId, channelId)`
- Merge button only shown when there are 2+ channels

Also fixes the recurring `bun:sqlite` middleware crash. Root cause: Vite 6's Environment API (triggered by the PWA plugin) runs SSR code in a Node.js worker thread that can't load `bun:` protocol imports. The previous `ssr.external` workaround only affected bundling, not the runtime module runner. Fix: configure `environments.ssr.dev.createEnvironment` to use `createRunnableDevEnvironment`, which runs SSR in-process (Bun) instead of a Node.js worker.

Closes #38

## Test plan

- [ ] Go to Settings → Channels with 2+ channels — confirm merge icon appears
- [ ] Merge channel A into channel B, keeping B's name — verify A disappears and B's events include A's
- [ ] Merge keeping A's name — verify B is renamed
- [ ] Merge with a custom name — verify channel is renamed correctly
- [ ] Confirm `bun run dev` starts without any middleware errors across page navigations