### PR TITLE
fix: skip token refresh when access token is still valid

### DIFF
--- a/src/context/user-context.tsx
+++ b/src/context/user-context.tsx
@@ -61,6 +61,17 @@ function clearStoredTokens(): void {
   localStorage.removeItem(TOKEN_STORAGE_KEY);
 }
 
+// Decode a JWT payload without verifying the signature (client-side only)
+function isTokenExpired(token: string): boolean {
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    // 30-second buffer so we refresh slightly before actual expiry
+    return Date.now() >= payload.exp * 1000 - 30_000;
+  } catch {
+    return true;
+  }
+}
+
 export function UserProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({
     user: null,
@@ -161,8 +172,20 @@ export function UserProvider({ children }: { children: ReactNode }) {
   // Validate session on mount
   useEffect(() => {
     const validateSession = async () => {
-      // Always attempt to refresh — even without localStorage tokens,
-      // the httpOnly refresh_token cookie may still be valid
+      const stored = getStoredTokens();
+
+      // If we have a non-expired access token, restore state from localStorage
+      // without hitting the refresh endpoint. Calling refresh on every mount
+      // rotates the session token, and if the user navigates before the response
+      // returns the middleware sees the now-deleted old session and redirects to
+      // /login.
+      if (stored?.accessToken && !isTokenExpired(stored.accessToken)) {
+        setAuth(stored.user, stored.accessToken, stored.refreshToken);
+        return;
+      }
+
+      // Token is expired or missing — refresh using the httpOnly cookie as
+      // fallback so even a cleared localStorage still recovers the session.
       const success = await refreshAccessToken();
 
       if (!success) {
@@ -177,7 +200,7 @@ export function UserProvider({ children }: { children: ReactNode }) {
     };
 
     validateSession();
-  }, [refreshAccessToken]);
+  }, [refreshAccessToken, setAuth]);
 
   return (
     <UserContext.Provider


### PR DESCRIPTION
## Summary

Fixes #71.

`UserProvider` was calling `/api/auth/refresh` on every mount. The refresh endpoint rotates the session — it deletes the old session and inserts a new one. This created a race condition:

1. User navigates to a page → middleware validates the cookie (token A) → page served
2. React hydrates → `UserProvider` mounts → immediately fires `POST /api/auth/refresh` with token A
3. Server deletes session A, creates session B, sets `Set-Cookie: refresh_token=B`
4. User clicks a link before the refresh response returns
5. The navigation request still carries the old cookie (token A), because the browser hasn't yet processed the `Set-Cookie` header
6. Middleware looks up session A → **not found** → redirects to `/login`

## Fix

Before calling the refresh endpoint, `validateSession` now decodes the stored access token client-side and checks its expiry. If the token is still valid (with a 30-second buffer), state is restored from `localStorage` directly — no network call, no rotation. The refresh endpoint is only invoked when the token is actually expired or missing (falling back to the `httpOnly` cookie for recovery when `localStorage` is empty).

## Test plan

- [ ] Log in and navigate between pages quickly — should not be redirected to `/login`
- [ ] Leave the tab idle for >15 minutes (access token TTL), then navigate — should transparently refresh and continue working
- [ ] Clear `localStorage` with a valid session cookie still set, then reload — should recover via cookie fallback
- [ ] Log out and verify the session is properly invalidated