### PR TITLE
fix: expand mobile menu drawer to full screen width

### DIFF
--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -1015,7 +1015,7 @@ function SidePanelContent({
       )}
 
       <div
-        className={`md:hidden fixed top-0 left-0 z-50 h-screen w-[300px] bg-background border-r overflow-y-auto p-6 transition-transform duration-200 ${
+        className={`md:hidden fixed top-0 left-0 z-50 h-screen w-full bg-background overflow-y-auto p-6 transition-transform duration-200 ${
           drawerOpen ? "translate-x-0" : "-translate-x-full"
         }`}
       >


### PR DESCRIPTION
## Summary

Fixes #72.

The mobile navigation drawer was set to a fixed `w-[300px]`, leaving the right portion of the screen uncovered when opened. Changed to `w-full` so the drawer covers the entire screen on mobile. Also removed `border-r` since a full-screen overlay doesn't need a right border.

## Test plan

- [ ] Open the app on a mobile viewport (or browser devtools mobile emulation)
- [ ] Tap the menu icon — drawer should cover the full screen width
- [ ] Tap the backdrop or close button — drawer should dismiss correctly
- [ ] Verify desktop layout is unaffected (`md:` breakpoint and above)