### PR TITLE
fix: remove dead access token, use cookie-only session auth

### DIFF
--- a/src/components/login-view.tsx
+++ b/src/components/login-view.tsx
@@ -14,19 +14,10 @@ interface AuthResponse {
     userName: string;
     isAdmin: boolean;
   };
-  accessToken: string;
-  refreshToken: string;
 }
 
 function storeTokens(data: AuthResponse): void {
-  localStorage.setItem(
-    TOKEN_STORAGE_KEY,
-    JSON.stringify({
-      user: data.user,
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-    }),
-  );
+  localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({ user: data.user }));
 }
 
 function LoginView() {

--- a/src/components/onboarding-view.tsx
+++ b/src/components/onboarding-view.tsx
@@ -11,19 +11,10 @@ const TOKEN_STORAGE_KEY = "beaver_tokens";
 
 interface AuthResponse {
   user: User;
-  accessToken: string;
-  refreshToken: string;
 }
 
 function storeTokens(data: AuthResponse): void {
-  localStorage.setItem(
-    TOKEN_STORAGE_KEY,
-    JSON.stringify({
-      user: data.user,
-      accessToken: data.accessToken,
-      refreshToken: data.refreshToken,
-    }),
-  );
+  localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({ user: data.user }));
 }
 
 interface AdminAccountProps {

--- a/src/context/user-context.tsx
+++ b/src/context/user-context.tsx
@@ -18,8 +18,6 @@ export interface User {
 
 interface AuthState {
   user: User | null;
-  accessToken: string | null;
-  refreshToken: string | null;
   isLoading: boolean;
   isAuthenticated: boolean;
 }
@@ -27,73 +25,45 @@ interface AuthState {
 interface UserContextType extends AuthState {
   signIn: (username: string, password: string) => Promise<boolean>;
   signOut: () => Promise<void>;
-  setAuth: (user: User, accessToken: string, refreshToken: string) => void;
+  setAuth: (user: User) => void;
 }
 
 const UserContext = createContext<UserContextType | null>(null);
 
 const TOKEN_STORAGE_KEY = "beaver_tokens";
 
-interface StoredTokens {
-  accessToken: string;
-  refreshToken: string;
-  user: User;
-}
-
-function getStoredTokens(): StoredTokens | null {
+function getStoredUser(): User | null {
   if (typeof window === "undefined") return null;
   const stored = localStorage.getItem(TOKEN_STORAGE_KEY);
   if (!stored) return null;
   try {
-    return JSON.parse(stored);
+    return JSON.parse(stored).user ?? null;
   } catch {
     return null;
   }
 }
 
-function storeTokens(tokens: StoredTokens): void {
+function storeUser(user: User): void {
   if (typeof window === "undefined") return;
-  localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+  localStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify({ user }));
 }
 
-function clearStoredTokens(): void {
+function clearStoredUser(): void {
   if (typeof window === "undefined") return;
   localStorage.removeItem(TOKEN_STORAGE_KEY);
-}
-
-// Decode a JWT payload without verifying the signature (client-side only)
-function isTokenExpired(token: string): boolean {
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1]));
-    // 30-second buffer so we refresh slightly before actual expiry
-    return Date.now() >= payload.exp * 1000 - 30_000;
-  } catch {
-    return true;
-  }
 }
 
 export function UserProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<AuthState>({
     user: null,
-    accessToken: null,
-    refreshToken: null,
     isLoading: true,
     isAuthenticated: false,
   });
 
-  const setAuth = useCallback(
-    (user: User, accessToken: string, refreshToken: string) => {
-      storeTokens({ user, accessToken, refreshToken });
-      setState({
-        user,
-        accessToken,
-        refreshToken,
-        isLoading: false,
-        isAuthenticated: true,
-      });
-    },
-    [],
-  );
+  const setAuth = useCallback((user: User) => {
+    storeUser(user);
+    setState({ user, isLoading: false, isAuthenticated: true });
+  }, []);
 
   const signIn = useCallback(
     async (username: string, password: string): Promise<boolean> => {
@@ -103,13 +73,9 @@ export function UserProvider({ children }: { children: ReactNode }) {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ username, password }),
         });
-
-        if (!res.ok) {
-          return false;
-        }
-
+        if (!res.ok) return false;
         const data = await res.json();
-        setAuth(data.user, data.accessToken, data.refreshToken);
+        setAuth(data.user);
         return true;
       } catch {
         return false;
@@ -120,97 +86,45 @@ export function UserProvider({ children }: { children: ReactNode }) {
 
   const signOut = useCallback(async () => {
     try {
-      if (state.refreshToken) {
-        await fetch("/api/auth/signout", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ refreshToken: state.refreshToken }),
-        });
-      }
+      await fetch("/api/auth/signout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      });
     } catch {
       // Ignore errors during sign out
     } finally {
-      clearStoredTokens();
-      setState({
-        user: null,
-        accessToken: null,
-        refreshToken: null,
-        isLoading: false,
-        isAuthenticated: false,
-      });
+      clearStoredUser();
+      setState({ user: null, isLoading: false, isAuthenticated: false });
     }
-  }, [state.refreshToken]);
+  }, []);
 
-  const refreshAccessToken = useCallback(async (): Promise<boolean> => {
-    const stored = getStoredTokens();
-
-    try {
-      // Send refresh token from localStorage if available,
-      // otherwise the server will fall back to the httpOnly cookie
-      const res = await fetch("/api/auth/refresh", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: stored?.refreshToken
-          ? JSON.stringify({ refreshToken: stored.refreshToken })
-          : "{}",
-      });
-
-      if (!res.ok) {
-        clearStoredTokens();
-        return false;
-      }
-
-      const data = await res.json();
-      setAuth(data.user, data.accessToken, data.refreshToken);
-      return true;
-    } catch {
-      clearStoredTokens();
-      return false;
-    }
-  }, [setAuth]);
-
-  // Validate session on mount
   useEffect(() => {
     const validateSession = async () => {
-      const stored = getStoredTokens();
-
-      // If we have a non-expired access token, restore state from localStorage
-      // without hitting the refresh endpoint. Calling refresh on every mount
-      // rotates the session token, and if the user navigates before the response
-      // returns the middleware sees the now-deleted old session and redirects to
-      // /login.
-      if (stored?.accessToken && !isTokenExpired(stored.accessToken)) {
-        setAuth(stored.user, stored.accessToken, stored.refreshToken);
+      // If the middleware let this page through, the session cookie is valid.
+      // Restore user identity from localStorage to avoid any network call.
+      const stored = getStoredUser();
+      if (stored) {
+        setAuth(stored);
         return;
       }
 
-      // Token is expired or missing — refresh using the httpOnly cookie as
-      // fallback so even a cleared localStorage still recovers the session.
-      const success = await refreshAccessToken();
-
-      if (!success) {
-        setState({
-          user: null,
-          accessToken: null,
-          refreshToken: null,
-          isLoading: false,
-          isAuthenticated: false,
-        });
+      // Fresh tab: localStorage is empty. Ask the server who we are using the
+      // httpOnly cookie — read-only, no session rotation.
+      const res = await fetch("/api/auth/me");
+      if (res.ok) {
+        const data = await res.json();
+        setAuth(data.user);
+      } else {
+        setState({ user: null, isLoading: false, isAuthenticated: false });
       }
     };
 
     validateSession();
-  }, [refreshAccessToken, setAuth]);
+  }, [setAuth]);
 
   return (
-    <UserContext.Provider
-      value={{
-        ...state,
-        signIn,
-        signOut,
-        setAuth,
-      }}
-    >
+    <UserContext.Provider value={{ ...state, signIn, signOut, setAuth }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/lib/auth/jwt.ts
+++ b/src/lib/auth/jwt.ts
@@ -4,7 +4,6 @@ const JWT_SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET || "beaver-default-secret-change-in-production",
 );
 
-const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "7d";
 
 export interface JWTPayload {
@@ -13,14 +12,6 @@ export interface JWTPayload {
   isAdmin: boolean;
   canCreateProjects: boolean;
   mustChangePassword: boolean;
-}
-
-export async function createAccessToken(payload: JWTPayload): Promise<string> {
-  return await new jose.SignJWT({ ...payload })
-    .setProtectedHeader({ alg: "HS256" })
-    .setIssuedAt()
-    .setExpirationTime(ACCESS_TOKEN_EXPIRY)
-    .sign(JWT_SECRET);
 }
 
 export async function createRefreshToken(payload: JWTPayload): Promise<string> {

--- a/src/pages/api/admin.ts
+++ b/src/pages/api/admin.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from "astro";
 import { createUser, getAdminUsers } from "@/lib/beaver/user";
 import {
-  createAccessToken,
   createRefreshToken,
   getRefreshTokenExpiryDate,
 } from "@/lib/auth/jwt";
@@ -35,13 +34,11 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       mustChangePassword: user.mustChangePassword,
     };
 
-    const accessToken = await createAccessToken(payload);
     const refreshToken = await createRefreshToken(payload);
     const expiresAt = getRefreshTokenExpiryDate();
 
     await createSession(user.id, refreshToken, expiresAt);
 
-    // Set refresh token as HTTP-only cookie
     cookies.set("refresh_token", refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
@@ -51,11 +48,7 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     });
 
     return new Response(
-      JSON.stringify({
-        user,
-        accessToken,
-        refreshToken,
-      }),
+      JSON.stringify({ user }),
       {
         status: 200,
         headers: { "Content-Type": "application/json" },

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -1,0 +1,63 @@
+import type { APIRoute } from "astro";
+import { verifyToken } from "../../../lib/auth/jwt";
+import { getSessionByToken } from "../../../lib/auth/session";
+
+export const GET: APIRoute = async ({ cookies }) => {
+  try {
+    const refreshToken = cookies.get("refresh_token")?.value;
+
+    if (!refreshToken) {
+      return new Response(JSON.stringify({ error: "No session" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const payload = await verifyToken(refreshToken);
+    if (!payload) {
+      cookies.delete("refresh_token", { path: "/" });
+      return new Response(JSON.stringify({ error: "Invalid token" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const session = await getSessionByToken(refreshToken);
+    if (!session) {
+      cookies.delete("refresh_token", { path: "/" });
+      return new Response(JSON.stringify({ error: "Session not found" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (new Date(session.expiresAt) < new Date()) {
+      cookies.delete("refresh_token", { path: "/" });
+      return new Response(JSON.stringify({ error: "Session expired" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    return new Response(
+      JSON.stringify({
+        user: {
+          id: payload.userId,
+          userName: payload.userName,
+          isAdmin: payload.isAdmin,
+          canCreateProjects: payload.canCreateProjects,
+        },
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Get current user error:", error);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+};

--- a/src/pages/api/auth/refresh.ts
+++ b/src/pages/api/auth/refresh.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from "astro";
 import {
   verifyToken,
-  createAccessToken,
   createRefreshToken,
   getRefreshTokenExpiryDate,
 } from "../../../lib/auth/jwt";
@@ -64,7 +63,6 @@ export const POST: APIRoute = async ({ request, cookies }) => {
     // Delete old session
     await deleteSession(refreshToken);
 
-    // Create new tokens
     const newPayload = {
       userId: payload.userId,
       userName: payload.userName,
@@ -73,14 +71,11 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       mustChangePassword: payload.mustChangePassword,
     };
 
-    const newAccessToken = await createAccessToken(newPayload);
     const newRefreshToken = await createRefreshToken(newPayload);
     const expiresAt = getRefreshTokenExpiryDate();
 
-    // Create new session
     await createSession(payload.userId, newRefreshToken, expiresAt);
 
-    // Set new refresh token cookie
     cookies.set("refresh_token", newRefreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
@@ -91,7 +86,6 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 
     return new Response(
       JSON.stringify({
-        accessToken: newAccessToken,
         refreshToken: newRefreshToken,
         user: {
           id: payload.userId,

--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -1,7 +1,6 @@
 import type { APIRoute } from "astro";
 import { getUserByUsername, verifyPassword } from "../../../lib/beaver/user";
 import {
-  createAccessToken,
   createRefreshToken,
   getRefreshTokenExpiryDate,
 } from "../../../lib/auth/jwt";
@@ -43,13 +42,11 @@ export const POST: APIRoute = async ({ request, cookies }) => {
       mustChangePassword: user.mustChangePassword,
     };
 
-    const accessToken = await createAccessToken(payload);
     const refreshToken = await createRefreshToken(payload);
     const expiresAt = getRefreshTokenExpiryDate();
 
     await createSession(user.id, refreshToken, expiresAt);
 
-    // Set refresh token as HTTP-only cookie
     cookies.set("refresh_token", refreshToken, {
       httpOnly: true,
       secure: process.env.NODE_ENV === "production",
@@ -60,8 +57,6 @@ export const POST: APIRoute = async ({ request, cookies }) => {
 
     return new Response(
       JSON.stringify({
-        accessToken,
-        refreshToken,
         user: {
           id: user.id,
           userName: user.userName,


### PR DESCRIPTION
## Summary

Fixes #75. Also supersedes the partial fix in #73.

The middleware only ever validated the `refresh_token` httpOnly cookie — the access token issued to the client was never checked by any backend route, making it dead code. Calling `/api/auth/refresh` on every `UserProvider` mount to obtain it was the root cause of the session expiry race condition: the endpoint rotates the session (deletes the old row, inserts a new one), and if the user navigated before the `Set-Cookie` response arrived, the outgoing request carried a now-deleted cookie → middleware redirected to `/login`.

This was especially bad on fresh tabs where `localStorage` is empty, because the previous partial fix still fell through to the rotation path.

## Changes

- **Remove `createAccessToken`** from `jwt.ts` — access tokens are no longer issued anywhere
- **Add `GET /api/auth/me`** — validates the httpOnly cookie and returns user info without touching the session (no rotation, no side effects)
- **Simplify `UserProvider`** — on mount, restores user from `localStorage` (zero network calls for existing tabs) or calls `/api/auth/me` for a fresh tab; no refresh endpoint called on mount
- **Strip `accessToken`/`refreshToken` from API responses** — `signin`, `refresh`, and `admin` endpoints now return only `user`
- **Simplify `login-view` and `onboarding-view`** — local `storeTokens` now stores `{ user }` only

## Test plan

- [ ] Sign in — should land on dashboard with no errors
- [ ] Open a fresh tab to the app — should load correctly without being booted
- [ ] Click through pages quickly — should never redirect to `/login`
- [ ] Sign out — session should be invalidated, cookie cleared
- [ ] Complete onboarding flow — should auto sign-in and land on dashboard