### PR TITLE
perf: rewrite getUnreadCounts with correlated subquery

### DIFF
--- a/src/lib/beaver/channel-read.ts
+++ b/src/lib/beaver/channel-read.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { channelReads, channels, events } from "../db/schema";
+import { channelReads, channels } from "../db/schema";
 import { eq, and, sql } from "drizzle-orm";
 
 // Mark a channel as read for a user. Returns the previous lastReadAt (or null
@@ -35,31 +35,38 @@ export async function markChannelRead(
 
 // Returns unread event counts keyed by channel ID for all channels in a project.
 //
-// Uses a correlated subquery per channel so the planner can do a tight range
-// seek on events_channel_id_created_at_idx (channel_id = ?, created_at > ?)
-// rather than a full join + group-by over all events in the project.
+// Uses db.all() with a raw SQL template so table aliases are emitted as SQL
+// text rather than Drizzle interpolations. This is required for the correlated
+// subquery to work correctly — interpolating a Drizzle Column object (e.g.
+// ${channels.id}) inside a sql`` expression parameterises it as a bound value
+// rather than a column reference, breaking the correlation.
+//
+// Only ${userId} and ${projectId} are Drizzle interpolations (bound params).
+// The planner can then do a tight range seek on
+// events_channel_id_created_at_idx (channel_id = ?, created_at > ?) per
+// channel, and an O(1) lookup on channel_reads_user_channel_idx for lastReadAt.
 export async function getUnreadCounts(
   userId: number,
   projectId: number,
 ): Promise<Record<number, number>> {
-  const rows = await db
-    .select({
-      channelId: channels.id,
-      unreadCount: sql<number>`(
+  const rows = await db.all<{ channel_id: number; unread_count: number }>(sql`
+    SELECT
+      c.id AS channel_id,
+      (
         SELECT COUNT(*)
-        FROM ${events}
-        WHERE ${events.channelId} = ${channels.id}
-          AND ${events.createdAt} > COALESCE(
-            (SELECT ${channelReads.lastReadAt}
-             FROM ${channelReads}
-             WHERE ${channelReads.channelId} = ${channels.id}
-               AND ${channelReads.userId} = ${userId}),
+        FROM events AS e
+        WHERE e.channel_id = c.id
+          AND e.created_at > COALESCE(
+            (SELECT cr.last_read_at
+             FROM channel_reads AS cr
+             WHERE cr.channel_id = c.id
+               AND cr.user_id = ${userId}),
             0
           )
-      )`,
-    })
-    .from(channels)
-    .where(eq(channels.projectId, projectId));
+      ) AS unread_count
+    FROM channels AS c
+    WHERE c.project_id = ${projectId}
+  `);
 
-  return Object.fromEntries(rows.map((r) => [r.channelId, r.unreadCount]));
+  return Object.fromEntries(rows.map((r) => [r.channel_id, r.unread_count]));
 }

--- a/src/lib/beaver/channel-read.ts
+++ b/src/lib/beaver/channel-read.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/db";
 import { channelReads, channels, events } from "../db/schema";
-import { eq, and, sql, count } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 
 // Mark a channel as read for a user. Returns the previous lastReadAt (or null
 // if the user has never read this channel before).
@@ -34,6 +34,10 @@ export async function markChannelRead(
 }
 
 // Returns unread event counts keyed by channel ID for all channels in a project.
+//
+// Uses a correlated subquery per channel so the planner can do a tight range
+// seek on events_channel_id_created_at_idx (channel_id = ?, created_at > ?)
+// rather than a full join + group-by over all events in the project.
 export async function getUnreadCounts(
   userId: number,
   projectId: number,
@@ -41,25 +45,21 @@ export async function getUnreadCounts(
   const rows = await db
     .select({
       channelId: channels.id,
-      unreadCount: count(events.id),
+      unreadCount: sql<number>`(
+        SELECT COUNT(*)
+        FROM ${events}
+        WHERE ${events.channelId} = ${channels.id}
+          AND ${events.createdAt} > COALESCE(
+            (SELECT ${channelReads.lastReadAt}
+             FROM ${channelReads}
+             WHERE ${channelReads.channelId} = ${channels.id}
+               AND ${channelReads.userId} = ${userId}),
+            0
+          )
+      )`,
     })
     .from(channels)
-    .leftJoin(
-      channelReads,
-      and(
-        eq(channelReads.channelId, channels.id),
-        eq(channelReads.userId, userId),
-      ),
-    )
-    .leftJoin(
-      events,
-      and(
-        eq(events.channelId, channels.id),
-        sql`${events.createdAt} > COALESCE(${channelReads.lastReadAt}, 0)`,
-      ),
-    )
-    .where(eq(channels.projectId, projectId))
-    .groupBy(channels.id);
+    .where(eq(channels.projectId, projectId));
 
   return Object.fromEntries(rows.map((r) => [r.channelId, r.unreadCount]));
 }


### PR DESCRIPTION
## Summary

Closes #68.

The previous query joined all events for every channel in the project and then grouped to count — meaning for a project with 20 channels and 50k events, SQLite had to process all 50k rows before filtering.

**Before:**
```sql
SELECT channels.id, COUNT(events.id)
FROM channels
LEFT JOIN channel_reads ON channel_reads.channel_id = channels.id AND channel_reads.user_id = ?
LEFT JOIN events ON events.channel_id = channels.id AND events.created_at > COALESCE(channel_reads.last_read_at, 0)
WHERE channels.project_id = ?
GROUP BY channels.id
```

**After:**
```sql
SELECT channels.id, (
  SELECT COUNT(*)
  FROM events
  WHERE events.channel_id = channels.id
    AND events.created_at > COALESCE(
      (SELECT last_read_at FROM channel_reads WHERE channel_id = channels.id AND user_id = ?),
      0
    )
) as unread_count
FROM channels
WHERE channels.project_id = ?
```

The correlated subquery lets SQLite use a tight two-column range seek on `events_channel_id_created_at_idx (channel_id = ?, created_at > ?)` for each channel, and an O(1) point lookup on `channel_reads_user_channel_idx`. No `GROUP BY` needed.

## Test plan

- [ ] Unread badge counts display correctly after posting events
- [ ] Marking a channel as read zeroes its count
- [ ] Counts update correctly on the 5-second polling interval