### PR TITLE
perf: enable SQLite WAL mode

### DIFF
--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -10,4 +10,6 @@ import { mkdirSync } from "fs";
 const dbPath = resolve(process.cwd(), "data", "beaver.sqlite");
 mkdirSync(dirname(dbPath), { recursive: true });
 const sqlite = new Database(dbPath);
+sqlite.exec("PRAGMA journal_mode=WAL;");
+sqlite.exec("PRAGMA synchronous=NORMAL;");
 export const db = drizzle(sqlite, { schema });


### PR DESCRIPTION
## Summary

Closes #65.

Enables WAL (Write-Ahead Logging) journal mode and sets `synchronous=NORMAL` at database startup.

WAL mode allows concurrent readers and writers without blocking each other — reads never block writes and writes never block reads. This is a significant improvement for event ingestion, which competes with read queries from the feed and unread count polling.

`synchronous=NORMAL` is safe with WAL (no data loss on application crash, only on OS crash) and reduces unnecessary fsync overhead.

## Test plan

- [ ] App starts and operates normally
- [ ] Verify WAL is active: `sqlite3 data/beaver.sqlite "PRAGMA journal_mode;"` should return `wal`
- [ ] Concurrent event ingestion and feed reads work without errors