### PR TITLE
perf: simplify event feed animations for virtual scrolling

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -86,14 +86,6 @@ export default function EventFeed({
   const trickleQueueRef = useRef<EventWithChannelName[]>([]);
   const trickleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Lazy-load framer-motion after initial paint so it stays out of the main bundle.
-  // AnimatePresence initial={false} prevents already-visible cards from re-animating
-  // when the module first loads.
-  const [fm, setFm] = useState<typeof import("framer-motion") | null>(null);
-  useEffect(() => {
-    import("framer-motion").then(setFm);
-  }, []);
-
   // Parse tags from URL param
   const parsedTags: TagFilter[] = tags ? JSON.parse(tags) : [];
 
@@ -554,19 +546,6 @@ export default function EventFeed({
                 new Date(event.createdAt) <= lastReadDate! &&
                 (i === 0 || new Date(events[i - 1].createdAt) > lastReadDate!);
 
-              const CardWrapper = fm ? fm.motion.div : "div";
-              const wrapperProps = fm
-                ? {
-                    layout: true as const,
-                    initial: { opacity: 0, y: 40 },
-                    animate: { opacity: 1, y: 0 },
-                    transition: { duration: 0.3, ease: "easeOut" as const },
-                  }
-                : {
-                    className:
-                      "animate-in fade-in slide-in-from-bottom-10 duration-300 ease-out",
-                  };
-
               return (
                 <div key={event.id}>
                   {isFirstOld && (
@@ -581,18 +560,14 @@ export default function EventFeed({
                       <div className="flex-1 border-t border-primary/40" />
                     </div>
                   )}
-                  <CardWrapper {...wrapperProps}>
+                  <div className="animate-in fade-in slide-in-from-bottom-10 duration-300 ease-out">
                     <EventCard event={event} />
-                  </CardWrapper>
+                  </div>
                 </div>
               );
             });
 
-            return fm ? (
-              <fm.AnimatePresence initial={false}>{cards}</fm.AnimatePresence>
-            ) : (
-              cards
-            );
+            return cards;
           })()}
           <div ref={bottomRef} style={{ height: "1px" }} />
         </div>


### PR DESCRIPTION
## Summary

Prerequisite for #64 (virtual scrolling).

PR #79 introduced a framer-motion lazy-load + `layout` animation. The `layout` animation conflicts with virtual scrolling — cards constantly mount/unmount as the user scrolls, triggering spurious layout animations. This PR strips it back to just the trickle queue + CSS enter animation, which work fine in a virtual list.

**What changed:**
- Removed framer-motion lazy-load and `motion.div` with `layout`
- Kept the SSE trickle queue (one card per 150ms)
- Kept CSS fade/slide-in enter animation via `tw-animate-css`

## Test plan

- [ ] New events trickle in one at a time with a fade/slide-in
- [ ] No framer-motion in the bundle