### PR TITLE
fix: stable virtualizer keys so trickle animations fire on new events

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -356,6 +356,8 @@ export default function EventFeed({
     getScrollElement: () => scrollContainerRef.current,
     estimateSize: (i) => (rows[i]?.kind === "divider" ? 32 : 112),
     overscan: 5,
+    getItemKey: (i) =>
+      rows[i]?.kind === "divider" ? "divider" : rows[i]?.kind === "event" ? rows[i].event.id : i,
   });
 
   const virtualItems = virtualizer.getVirtualItems();


### PR DESCRIPTION
## Problem

After adding TanStack Virtual, new SSE events trickling in had no entry animation. TanStack Virtual uses index-based keys by default — when a new event is prepended at index 0, React reuses the existing DOM element and just updates its props, so the `animate-in slide-in-from-bottom-10` CSS animation never fires on a real mount.

## Fix

Pass `getItemKey` to the virtualizer returning stable event IDs (and `"divider"` for the unread divider row). New events now get fresh DOM elements and the entry animation fires correctly. Existing cards keep their DOM elements and just reposition.