### PR TITLE
perf: memoize EventCard to prevent re-renders on feed state updates

### DIFF
--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -1,9 +1,9 @@
 import type { EventWithChannelName } from "@/lib/beaver/event";
 import { Card } from "./ui/card";
 import { getEventTime } from "@/lib/utils";
-import { useRef } from "react";
+import { memo, useRef } from "react";
 
-export default function EventCard({ event }: { event: EventWithChannelName }) {
+const EventCard = memo(function EventCard({ event }: { event: EventWithChannelName }) {
   const eventUrl = `/dashboard/${event.projectId}/events/${event.id}`;
   const prefetched = useRef(false);
 
@@ -35,4 +35,6 @@ export default function EventCard({ event }: { event: EventWithChannelName }) {
       </Card>
     </a>
   );
-}
+});
+
+export default EventCard;


### PR DESCRIPTION
Closes #63

## Summary
Wraps `EventCard` in `React.memo` so visible cards skip re-rendering when the `events` array changes (e.g. a new event trickles in via SSE). With virtual scrolling capping the DOM to ~15 cards the impact per update is small, but memo eliminates unnecessary work on every trickle tick.