### PR TITLE
perf: replace offset pagination with cursor-based for all sort orders

### DIFF
--- a/drizzle/0008_amusing_blazing_skull.sql
+++ b/drizzle/0008_amusing_blazing_skull.sql
@@ -1,0 +1,2 @@
+CREATE INDEX `events_channel_id_name_id_idx` ON `events` (`channel_id`,`name`,`id`);--> statement-breakpoint
+CREATE INDEX `events_project_id_name_id_idx` ON `events` (`project_id`,`name`,`id`);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,780 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "31b68335-6536-44e6-b837-f9da578daea1",
+  "prevId": "8a8784ee-21d0-40fd-83c2-eaddcd8be4ce",
+  "tables": {
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": [
+            "user_id",
+            "channel_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": [
+            "event_id",
+            "key",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": [
+            "channel_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_channel_id_name_id_idx": {
+          "name": "events_channel_id_name_id_idx",
+          "columns": [
+            "channel_id",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "events_project_id_name_id_idx": {
+          "name": "events_project_id_name_id_idx",
+          "columns": [
+            "project_id",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": [
+            "project_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777838882202,
       "tag": "0007_small_colonel_america",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1778435340995,
+      "tag": "0008_amusing_blazing_skull",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -85,6 +85,7 @@ export default function EventFeed({
   const newEventIdsRef = useRef<Set<number>>(new Set());
   const eventsRef = useRef<EventWithChannelName[]>([]);
   const loadingMoreRef = useRef(false);
+  const hasMoreRef = useRef(true);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const didScrollToDivider = useRef(false);
   const trickleQueueRef = useRef<EventWithChannelName[]>([]);
@@ -244,6 +245,7 @@ export default function EventFeed({
     setLoading(true);
     eventIdsRef.current.clear();
     newEventIdsRef.current.clear();
+    hasMoreRef.current = true;
     trickleQueueRef.current = [];
     if (trickleTimerRef.current) {
       clearTimeout(trickleTimerRef.current);
@@ -385,6 +387,7 @@ export default function EventFeed({
     if (
       lastItem.index >= rows.length - 5 &&
       !loadingMoreRef.current &&
+      hasMoreRef.current &&
       eventsRef.current.length > 0
     ) {
       setLoadingMore(true);
@@ -392,6 +395,8 @@ export default function EventFeed({
         if (res.length > 0) {
           res.forEach((e) => eventIdsRef.current.add(e.id));
           setEvents((prev) => [...prev, ...res]);
+        } else {
+          hasMoreRef.current = false;
         }
         setLoadingMore(false);
       });

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -184,8 +184,17 @@ export default function EventFeed({
       endpoint += `/project/${projectID}?limit=20`;
     }
 
-    if (eventsRef.current.length > 0) {
-      endpoint += `&offset=${eventsRef.current.length}`;
+    const lastEvent = eventsRef.current[eventsRef.current.length - 1];
+    if (lastEvent) {
+      const field = sortBy ?? "date";
+      const order = sortOrder ?? "desc";
+      if (field === "name") {
+        endpoint += `&cursorName=${encodeURIComponent(lastEvent.name)}&cursorId=${lastEvent.id}`;
+      } else if (order === "asc") {
+        endpoint += `&afterId=${lastEvent.id}`;
+      } else {
+        endpoint += `&beforeId=${lastEvent.id}`;
+      }
     }
 
     if (search) {

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -71,7 +71,8 @@ type QueryOptions = {
   search: string | null;
   afterId?: number;
   beforeId?: number;
-  offset?: number;
+  cursorName?: string;
+  cursorId?: number;
   limit?: number;
   startDate?: Date;
   endDate?: Date;
@@ -162,9 +163,26 @@ export async function getChannelEvents(
     conditions.push(gt(events.id, options.afterId));
   }
 
-  // Only use cursor pagination for default sort (date desc)
-  if (options.beforeId && !options.offset) {
+  if (options.beforeId) {
     conditions.push(lt(events.id, options.beforeId));
+  }
+
+  if (options.cursorName !== undefined && options.cursorId !== undefined) {
+    if (options.sortOrder === "asc") {
+      conditions.push(
+        or(
+          gt(events.name, options.cursorName),
+          and(eq(events.name, options.cursorName), gt(events.id, options.cursorId)),
+        ),
+      );
+    } else {
+      conditions.push(
+        or(
+          lt(events.name, options.cursorName),
+          and(eq(events.name, options.cursorName), lt(events.id, options.cursorId)),
+        ),
+      );
+    }
   }
 
   // Date range filtering
@@ -187,7 +205,7 @@ export async function getChannelEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
-  let query = db
+  const eventData = await db
     .select({
       id: events.id,
       name: events.name,
@@ -202,12 +220,6 @@ export async function getChannelEvents(
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
-
-  if (options.offset) {
-    query = query.offset(options.offset) as typeof query;
-  }
-
-  const eventData = await query;
   const eventIds = eventData.map((event) => event.id);
 
   const fetchedTags = await getEventTags(eventIds);
@@ -241,9 +253,26 @@ export async function getProjectEvents(
     conditions.push(gt(events.id, options.afterId));
   }
 
-  // Only use cursor pagination for default sort (date desc)
-  if (options.beforeId && !options.offset) {
+  if (options.beforeId) {
     conditions.push(lt(events.id, options.beforeId));
+  }
+
+  if (options.cursorName !== undefined && options.cursorId !== undefined) {
+    if (options.sortOrder === "asc") {
+      conditions.push(
+        or(
+          gt(events.name, options.cursorName),
+          and(eq(events.name, options.cursorName), gt(events.id, options.cursorId)),
+        ),
+      );
+    } else {
+      conditions.push(
+        or(
+          lt(events.name, options.cursorName),
+          and(eq(events.name, options.cursorName), lt(events.id, options.cursorId)),
+        ),
+      );
+    }
   }
 
   // Date range filtering
@@ -266,7 +295,7 @@ export async function getProjectEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
-  let query = db
+  const eventData = await db
     .select({
       id: events.id,
       name: events.name,
@@ -287,12 +316,6 @@ export async function getProjectEvents(
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
-
-  if (options.offset) {
-    query = query.offset(options.offset) as typeof query;
-  }
-
-  const eventData = await query;
 
   const eventIds = eventData.map((event) => event.id);
 

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -89,6 +89,16 @@ export const events = sqliteTable(
       table.projectId,
       table.createdAt,
     ),
+    channelNameIdIdx: index("events_channel_id_name_id_idx").on(
+      table.channelId,
+      table.name,
+      table.id,
+    ),
+    projectNameIdIdx: index("events_project_id_name_id_idx").on(
+      table.projectId,
+      table.name,
+      table.id,
+    ),
   }),
 );
 

--- a/src/pages/api/events/channel/[channelID]/index.ts
+++ b/src/pages/api/events/channel/[channelID]/index.ts
@@ -19,12 +19,22 @@ export async function GET({
 
     let limit;
     let beforeId;
+    let afterId;
+    let cursorName: string | undefined;
+    let cursorId: number | undefined;
 
     if (url.searchParams.get("limit")) {
       limit = parseInt(url.searchParams.get("limit")!);
     }
     if (url.searchParams.get("beforeId")) {
       beforeId = parseInt(url.searchParams.get("beforeId")!);
+    }
+    if (url.searchParams.get("afterId")) {
+      afterId = parseInt(url.searchParams.get("afterId")!);
+    }
+    if (url.searchParams.get("cursorName") && url.searchParams.get("cursorId")) {
+      cursorName = url.searchParams.get("cursorName")!;
+      cursorId = parseInt(url.searchParams.get("cursorId")!);
     }
 
     // Date range params
@@ -47,11 +57,6 @@ export async function GET({
       }
     }
 
-    let offset;
-    if (url.searchParams.get("offset")) {
-      offset = parseInt(url.searchParams.get("offset")!);
-    }
-
     const sortBy = url.searchParams.get("sortBy") as SortField | null;
     const sortOrder = url.searchParams.get("sortOrder") as SortOrder | null;
 
@@ -59,7 +64,9 @@ export async function GET({
       search,
       limit,
       beforeId,
-      offset,
+      afterId,
+      cursorName,
+      cursorId,
       startDate,
       endDate,
       tags,

--- a/src/pages/api/events/project/[projectID]/index.ts
+++ b/src/pages/api/events/project/[projectID]/index.ts
@@ -19,12 +19,22 @@ export async function GET({
 
     let limit;
     let beforeId;
+    let afterId;
+    let cursorName: string | undefined;
+    let cursorId: number | undefined;
 
     if (url.searchParams.get("limit")) {
       limit = parseInt(url.searchParams.get("limit")!);
     }
     if (url.searchParams.get("beforeId")) {
       beforeId = parseInt(url.searchParams.get("beforeId")!);
+    }
+    if (url.searchParams.get("afterId")) {
+      afterId = parseInt(url.searchParams.get("afterId")!);
+    }
+    if (url.searchParams.get("cursorName") && url.searchParams.get("cursorId")) {
+      cursorName = url.searchParams.get("cursorName")!;
+      cursorId = parseInt(url.searchParams.get("cursorId")!);
     }
 
     // Date range params
@@ -47,11 +57,6 @@ export async function GET({
       }
     }
 
-    let offset;
-    if (url.searchParams.get("offset")) {
-      offset = parseInt(url.searchParams.get("offset")!);
-    }
-
     const sortBy = url.searchParams.get("sortBy") as SortField | null;
     const sortOrder = url.searchParams.get("sortOrder") as SortOrder | null;
 
@@ -59,7 +64,9 @@ export async function GET({
       search,
       limit,
       beforeId,
-      offset,
+      afterId,
+      cursorName,
+      cursorId,
       startDate,
       endDate,
       tags,


### PR DESCRIPTION
Closes #66

## Summary
- **date desc** (default): cursor on `id < lastId` — was already partially implemented, now consistently applied
- **date asc**: cursor on `id > lastId` — reuses `afterId` param
- **name asc/desc**: composite cursor `(name, id)` using keyset pagination — `WHERE (name > ?) OR (name = ? AND id > ?)`
- Adds `(channel_id, name, id)` and `(project_id, name, id)` indexes to support O(log n) name-sort page fetches
- Fixes infinite scroll spam loop when no more events match a filter by tracking `hasMoreRef` — resets on channel/filter change, set to `false` when a page returns empty

## Why this is faster

Offset pagination (`OFFSET 500`) makes SQLite scan and discard all preceding rows before returning the next page. The deeper the page, the more rows get thrown away — `OFFSET 10000` scans 10,000 rows. Cost grows linearly with scroll depth: O(n).

Cursor pagination (`WHERE id < 500`) lets SQLite seek directly to the right position via the B-tree index, regardless of how deep the page is. Page 2 and page 200 are the same cost. That's what makes the new indexes load-bearing — without them the `WHERE (name > ?) OR (name = ? AND id > ?)` clause would still full-scan. With them it's O(log n) per page fetch.

For most users with a few hundred events the difference is imperceptible. It matters at scale — thousands of events with deep scroll sessions.

## Migration
Includes a Drizzle migration (`0008`) for the two new indexes. Run `bun src/lib/db/migrate.ts` on deploy.