### PR TITLE
feat: add server logging with daily rotation

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,46 @@
+import { appendFileSync, mkdirSync } from "fs";
+import { resolve } from "path";
+
+const logsDir = resolve(process.cwd(), "data", "logs");
+mkdirSync(logsDir, { recursive: true });
+
+function currentDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function logPath(): string {
+  return resolve(logsDir, `server-${currentDate()}.log`);
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace("T", " ").replace("Z", "").slice(0, 23);
+}
+
+function write(line: string): void {
+  const out = line + "\n";
+  process.stdout.write(out);
+  appendFileSync(logPath(), out);
+}
+
+export function logRequest(
+  method: string,
+  pathname: string,
+  status: number,
+  durationMs: number,
+): void {
+  write(`[${timestamp()}] ${method} ${pathname} ${status} ${durationMs}ms`);
+}
+
+export function logError(
+  method: string,
+  pathname: string,
+  durationMs: number,
+  error: unknown,
+): void {
+  const message = error instanceof Error ? error.message : String(error);
+  const stack =
+    error instanceof Error && error.stack
+      ? "\n" + error.stack.split("\n").slice(1).map((l) => "  " + l.trim()).join("\n")
+      : "";
+  write(`[${timestamp()}] ERROR ${method} ${pathname} ${durationMs}ms - ${message}${stack}`);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { getAdminUsers } from "./lib/beaver/user";
 import { verifyToken } from "./lib/auth/jwt";
 import { getSessionByToken } from "./lib/auth/session";
 import { getProjectsForUser } from "./lib/beaver/project-member";
+import { logRequest, logError } from "./lib/logger";
 
 // Routes that don't require authentication
 const PUBLIC_ROUTES = ["/login", "/onboarding"];
@@ -66,6 +67,18 @@ async function getAuthedRedirect(
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
+
+  if (pathname.startsWith("/api/") || pathname === "/api/event") {
+    const start = Date.now();
+    try {
+      const response = await next();
+      logRequest(context.request.method, pathname, response.status, Date.now() - start);
+      return response;
+    } catch (err) {
+      logError(context.request.method, pathname, Date.now() - start, err);
+      throw err;
+    }
+  }
 
   // For login/onboarding, redirect authed users to dashboard
   if (AUTH_REDIRECT_ROUTES.includes(pathname)) {


### PR DESCRIPTION
Closes #69

## Summary
- Logs all `/api/*` requests to stdout and `data/logs/server-YYYY-MM-DD.log`
- Format: `[2026-05-10 18:34:48.051] GET /api/events/project/1 200 1ms`
- Errors include message and stack trace
- Daily rotation — each day gets its own file (`server-2026-05-10.log`, `server-2026-05-11.log`, etc.)
- `data/` is already gitignored so log files are never committed
- No automatic cleanup — users can delete old log files manually