### PR TITLE
feat: unread dot indicators and mark channel read on event view (#82)

### DIFF
--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -24,13 +24,16 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
           <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
             <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
           </div>
-          <div>
+          <div className="flex-1 min-w-0">
             <h2 className="text-xl font-medium">{event.name}</h2>
             <div className="flex space-x-2 items-center text-sm text-muted-foreground">
               <p># {event.channelName}</p>
               <p>{getEventTime(new Date(event.createdAt))}</p>
             </div>
           </div>
+          {!event.read && (
+            <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
+          )}
         </div>
       </Card>
     </a>

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "./ui/button";
 import { getEventTime } from "@/lib/utils";
 import { ArrowLeftIcon } from "lucide-react";
+import { useEffect } from "react";
 
 function TagBadge({
   tagKey,
@@ -35,6 +36,20 @@ export default function EventDetail({
   event: EventWithChannelName;
 }) {
   const tags = Object.entries(event.tags);
+
+  useEffect(() => {
+    fetch("/api/unread", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelName: event.channelName, projectId: event.projectId }),
+    }).then((res) => res.json()).then((data) => {
+      window.dispatchEvent(
+        new CustomEvent("channel:read", {
+          detail: { channelId: data.channelId, channelName: event.channelName },
+        }),
+      );
+    }).catch(() => {});
+  }, [event.id]);
 
   const handleBack = () => {
     if (window.history.length > 1) {

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -324,17 +324,32 @@ export default function EventFeed({
     fetch("/api/unread", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ channelId: channel.id }),
+      body: JSON.stringify({ channelName: channel.name, projectId: channel.projectId }),
     })
       .then((res) => res.json())
       .then((data) => {
         if (data.lastReadAt) setLastReadDate(new Date(data.lastReadAt));
         window.dispatchEvent(
-          new CustomEvent("channel:read", { detail: { channelId: channel.id } }),
+          new CustomEvent("channel:read", {
+            detail: { channelId: data.channelId, channelName: channel.name },
+          }),
         );
       })
       .catch(() => {});
   }, [channel?.id]);
+
+  // Clear unread dots when a channel is marked as read
+  useEffect(() => {
+    const handler = (e: CustomEvent<{ channelName: string }>) => {
+      setEvents((prev) =>
+        prev.map((ev) =>
+          ev.channelName === e.detail.channelName ? { ...ev, read: true } : ev,
+        ),
+      );
+    };
+    window.addEventListener("channel:read", handler as EventListener);
+    return () => window.removeEventListener("channel:read", handler as EventListener);
+  }, []);
 
   const hasActiveFilters = startDate || endDate || parsedTags.length > 0;
   const hasNewEvents =

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { events, channels, eventTags } from "../db/schema";
+import { events, channels, eventTags, channelReads } from "../db/schema";
 import {
   eq,
   and,
@@ -208,12 +208,15 @@ export async function getChannelEvents(
     options.sortBy === "name" ? events.name : events.createdAt;
 
   const readExpr = userId !== undefined
-    ? sql<boolean>`EXISTS (
-        SELECT 1 FROM channel_reads
-        WHERE channel_reads.channel_id = ${events.channelId}
-          AND channel_reads.user_id = ${userId}
-          AND channel_reads.last_read_at >= ${events.createdAt}
-      )`
+    ? exists(
+        db.select({ _: sql`1` }).from(channelReads).where(
+          and(
+            eq(channelReads.channelId, events.channelId),
+            eq(channelReads.userId, userId),
+            gte(channelReads.lastReadAt, events.createdAt),
+          ),
+        ),
+      )
     : sql<boolean>`0`;
 
   const eventData = await db
@@ -308,12 +311,15 @@ export async function getProjectEvents(
     options.sortBy === "name" ? events.name : events.createdAt;
 
   const readExpr = userId !== undefined
-    ? sql<boolean>`EXISTS (
-        SELECT 1 FROM channel_reads
-        WHERE channel_reads.channel_id = ${events.channelId}
-          AND channel_reads.user_id = ${userId}
-          AND channel_reads.last_read_at >= ${events.createdAt}
-      )`
+    ? exists(
+        db.select({ _: sql`1` }).from(channelReads).where(
+          and(
+            eq(channelReads.channelId, events.channelId),
+            eq(channelReads.userId, userId),
+            gte(channelReads.lastReadAt, events.createdAt),
+          ),
+        ),
+      )
     : sql<boolean>`0`;
 
   const eventData = await db
@@ -354,12 +360,15 @@ export async function getEvent(
   userId?: number,
 ): Promise<EventWithChannelName | null> {
   const readExpr = userId !== undefined
-    ? sql<boolean>`EXISTS (
-        SELECT 1 FROM channel_reads
-        WHERE channel_reads.channel_id = ${events.channelId}
-          AND channel_reads.user_id = ${userId}
-          AND channel_reads.last_read_at >= ${events.createdAt}
-      )`
+    ? exists(
+        db.select({ _: sql`1` }).from(channelReads).where(
+          and(
+            eq(channelReads.channelId, events.channelId),
+            eq(channelReads.userId, userId),
+            gte(channelReads.lastReadAt, events.createdAt),
+          ),
+        ),
+      )
     : sql<boolean>`0`;
 
   const eventData = await db

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { events, channels, eventTags, channelReads } from "../db/schema";
+import { events, channels, eventTags } from "../db/schema";
 import {
   eq,
   and,
@@ -207,9 +207,14 @@ export async function getChannelEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
-  const readJoin = userId !== undefined
-    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
-    : sql`false`;
+  const readExpr = userId !== undefined
+    ? sql<boolean>`EXISTS (
+        SELECT 1 FROM channel_reads
+        WHERE channel_reads.channel_id = ${events.channelId}
+          AND channel_reads.user_id = ${userId}
+          AND channel_reads.last_read_at >= ${events.createdAt}
+      )`
+    : sql<boolean>`0`;
 
   const eventData = await db
     .select({
@@ -220,11 +225,10 @@ export async function getChannelEvents(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
-      lastReadAt: channelReads.lastReadAt,
+      read: readExpr,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
-    .leftJoin(channelReads, readJoin)
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
@@ -232,10 +236,10 @@ export async function getChannelEvents(
   const eventIds = eventData.map((event) => event.id);
   const fetchedTags = await getEventTags(eventIds);
 
-  return eventData.map(({ lastReadAt, ...event }) => ({
+  return eventData.map((event) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
-    read: lastReadAt !== null && event.createdAt <= lastReadAt,
+    read: Boolean(event.read),
   }));
 }
 
@@ -303,9 +307,14 @@ export async function getProjectEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
-  const readJoin = userId !== undefined
-    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
-    : sql`false`;
+  const readExpr = userId !== undefined
+    ? sql<boolean>`EXISTS (
+        SELECT 1 FROM channel_reads
+        WHERE channel_reads.channel_id = ${events.channelId}
+          AND channel_reads.user_id = ${userId}
+          AND channel_reads.last_read_at >= ${events.createdAt}
+      )`
+    : sql<boolean>`0`;
 
   const eventData = await db
     .select({
@@ -316,7 +325,7 @@ export async function getProjectEvents(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
-      lastReadAt: channelReads.lastReadAt,
+      read: readExpr,
     })
     .from(events)
     .innerJoin(
@@ -326,7 +335,6 @@ export async function getProjectEvents(
         eq(events.projectId, channels.projectId),
       ),
     )
-    .leftJoin(channelReads, readJoin)
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
@@ -334,10 +342,10 @@ export async function getProjectEvents(
   const eventIds = eventData.map((event) => event.id);
   const fetchedTags = await getEventTags(eventIds);
 
-  return eventData.map(({ lastReadAt, ...event }) => ({
+  return eventData.map((event) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
-    read: lastReadAt !== null && event.createdAt <= lastReadAt,
+    read: Boolean(event.read),
   })) as EventWithChannelName[];
 }
 
@@ -345,9 +353,14 @@ export async function getEvent(
   eventId: number,
   userId?: number,
 ): Promise<EventWithChannelName | null> {
-  const readJoin = userId !== undefined
-    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
-    : sql`false`;
+  const readExpr = userId !== undefined
+    ? sql<boolean>`EXISTS (
+        SELECT 1 FROM channel_reads
+        WHERE channel_reads.channel_id = ${events.channelId}
+          AND channel_reads.user_id = ${userId}
+          AND channel_reads.last_read_at >= ${events.createdAt}
+      )`
+    : sql<boolean>`0`;
 
   const eventData = await db
     .select({
@@ -358,11 +371,10 @@ export async function getEvent(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
-      lastReadAt: channelReads.lastReadAt,
+      read: readExpr,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
-    .leftJoin(channelReads, readJoin)
     .where(eq(events.id, eventId))
     .limit(1);
 
@@ -370,13 +382,13 @@ export async function getEvent(
     return null;
   }
 
-  const { lastReadAt, ...event } = eventData[0];
+  const event = eventData[0];
   const tags = await getEventTags([event.id]);
 
   return {
     ...event,
     tags: tags[event.id] || {},
-    read: lastReadAt !== null && event.createdAt <= lastReadAt,
+    read: Boolean(event.read),
   };
 }
 

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,5 +1,5 @@
 import { db } from "../db/db";
-import { events, channels, eventTags } from "../db/schema";
+import { events, channels, eventTags, channelReads } from "../db/schema";
 import {
   eq,
   and,
@@ -54,6 +54,7 @@ export type EventWithChannelName = {
   channelName: string;
   createdAt: Date;
   tags: TagPrimitive;
+  read: boolean;
 };
 
 export type TagFilter = {
@@ -145,6 +146,7 @@ const getEventTags = async (
 export async function getChannelEvents(
   channelId: number,
   options: QueryOptions,
+  userId?: number,
 ): Promise<EventWithChannelName[]> {
   // initial where clause
   const conditions: any[] = [eq(events.channelId, channelId)];
@@ -205,6 +207,10 @@ export async function getChannelEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
+  const readJoin = userId !== undefined
+    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
+    : sql`false`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -214,27 +220,29 @@ export async function getChannelEvents(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
+      lastReadAt: channelReads.lastReadAt,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
+    .leftJoin(channelReads, readJoin)
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
-  const eventIds = eventData.map((event) => event.id);
 
+  const eventIds = eventData.map((event) => event.id);
   const fetchedTags = await getEventTags(eventIds);
 
-  const eventsRes = eventData.map((event) => ({
+  return eventData.map(({ lastReadAt, ...event }) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
+    read: lastReadAt !== null && event.createdAt <= lastReadAt,
   }));
-
-  return eventsRes;
 }
 
 export async function getProjectEvents(
   projectId: number,
   options: QueryOptions,
+  userId?: number,
 ): Promise<EventWithChannelName[]> {
   // initial where clause
   const conditions: any[] = [eq(events.projectId, projectId)];
@@ -295,6 +303,10 @@ export async function getProjectEvents(
   const orderColumn =
     options.sortBy === "name" ? events.name : events.createdAt;
 
+  const readJoin = userId !== undefined
+    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
+    : sql`false`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -304,6 +316,7 @@ export async function getProjectEvents(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
+      lastReadAt: channelReads.lastReadAt,
     })
     .from(events)
     .innerJoin(
@@ -313,25 +326,29 @@ export async function getProjectEvents(
         eq(events.projectId, channels.projectId),
       ),
     )
+    .leftJoin(channelReads, readJoin)
     .where(and(...conditions))
     .orderBy(orderFn(orderColumn))
     .limit(options.limit ?? 100);
 
   const eventIds = eventData.map((event) => event.id);
-
   const fetchedTags = await getEventTags(eventIds);
 
-  const eventsRes = eventData.map((event) => ({
+  return eventData.map(({ lastReadAt, ...event }) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
-  }));
-
-  return eventsRes as EventWithChannelName[];
+    read: lastReadAt !== null && event.createdAt <= lastReadAt,
+  })) as EventWithChannelName[];
 }
 
 export async function getEvent(
   eventId: number,
+  userId?: number,
 ): Promise<EventWithChannelName | null> {
+  const readJoin = userId !== undefined
+    ? and(eq(channelReads.channelId, events.channelId), eq(channelReads.userId, userId))
+    : sql`false`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -341,9 +358,11 @@ export async function getEvent(
       projectId: events.projectId,
       createdAt: events.createdAt,
       channelName: channels.name,
+      lastReadAt: channelReads.lastReadAt,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
+    .leftJoin(channelReads, readJoin)
     .where(eq(events.id, eventId))
     .limit(1);
 
@@ -351,12 +370,13 @@ export async function getEvent(
     return null;
   }
 
-  const event = eventData[0];
+  const { lastReadAt, ...event } = eventData[0];
   const tags = await getEventTags([event.id]);
 
   return {
     ...event,
     tags: tags[event.id] || {},
+    read: lastReadAt !== null && event.createdAt <= lastReadAt,
   };
 }
 
@@ -421,6 +441,7 @@ export async function createEvent({
       projectId: project.id,
       channelName: channelsRes[0].name,
       createdAt: event.createdAt,
+      read: false,
     };
   }
 
@@ -433,5 +454,6 @@ export async function createEvent({
     projectId: project.id,
     channelName: channelsRes[0].name,
     createdAt: event.createdAt,
+    read: false,
   };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -67,8 +67,10 @@ async function getAuthedRedirect(
 
 export const onRequest = defineMiddleware(async (context, next) => {
   const { pathname } = context.url;
+  const isApi = pathname.startsWith("/api/");
 
-  if (pathname.startsWith("/api/") || pathname === "/api/event") {
+  // Wraps next() with request logging for API routes
+  const nextWithLogging = async () => {
     const start = Date.now();
     try {
       const response = await next();
@@ -78,7 +80,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
       logError(context.request.method, pathname, Date.now() - start, err);
       throw err;
     }
-  }
+  };
 
   // For login/onboarding, redirect authed users to dashboard
   if (AUTH_REDIRECT_ROUTES.includes(pathname)) {
@@ -91,7 +93,7 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   // Allow other public routes (API routes)
   if (isPublicRoute(pathname)) {
-    return next();
+    return isApi ? nextWithLogging() : next();
   }
 
   // Check if admin user exists
@@ -148,11 +150,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
     return context.redirect(CHANGE_PASSWORD_ROUTE);
   }
 
-  const response = await next();
+  if (isApi) {
+    return nextWithLogging();
+  }
 
+  const response = await next();
   // Prevent caching of protected pages to ensure auth is checked on every request
   // This is important when using View Transitions/prefetching
   response.headers.set("Cache-Control", "no-store, must-revalidate");
-
   return response;
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,10 +6,10 @@ import { getProjectsForUser } from "./lib/beaver/project-member";
 import { logRequest, logError } from "./lib/logger";
 
 // Routes that don't require authentication
-const PUBLIC_ROUTES = ["/login", "/onboarding"];
+const PUBLIC_ROUTES = ["/login", "/onboarding", "/api/event"];
 
-// API routes that don't require authentication
-const PUBLIC_API_ROUTES = ["/api/auth/", "/api/event", "/api/admin"];
+// API routes that don't require authentication (prefix-matched)
+const PUBLIC_API_ROUTES = ["/api/auth/", "/api/admin"];
 
 // Routes that authed users should be redirected away from
 const AUTH_REDIRECT_ROUTES = ["/login", "/onboarding"];

--- a/src/pages/api/events/channel/[channelID]/index.ts
+++ b/src/pages/api/events/channel/[channelID]/index.ts
@@ -9,9 +9,11 @@ import {
 export async function GET({
   params,
   url,
+  locals,
 }: {
   params: { channelID: string };
   url: URL;
+  locals: App.Locals;
 }) {
   try {
     const { channelID } = params;
@@ -72,7 +74,7 @@ export async function GET({
       tags,
       sortBy: sortBy ?? undefined,
       sortOrder: sortOrder ?? undefined,
-    });
+    }, locals.user?.id);
 
     return new Response(JSON.stringify(events), {
       headers: { "Content-Type": "application/json" },

--- a/src/pages/api/events/project/[projectID]/index.ts
+++ b/src/pages/api/events/project/[projectID]/index.ts
@@ -9,9 +9,11 @@ import {
 export async function GET({
   params,
   url,
+  locals,
 }: {
   params: { projectID: string };
   url: URL;
+  locals: App.Locals;
 }) {
   try {
     const { projectID } = params;
@@ -72,7 +74,7 @@ export async function GET({
       tags,
       sortBy: sortBy ?? undefined,
       sortOrder: sortOrder ?? undefined,
-    });
+    }, locals.user?.id);
 
     return new Response(JSON.stringify(events), {
       headers: { "Content-Type": "application/json" },

--- a/src/pages/api/unread.ts
+++ b/src/pages/api/unread.ts
@@ -1,4 +1,7 @@
 import { markChannelRead, getUnreadCounts } from "@/lib/beaver/channel-read";
+import { db } from "@/lib/db/db";
+import { channels } from "@/lib/db/schema";
+import { and, eq } from "drizzle-orm";
 import type { APIContext } from "astro";
 
 export async function GET({ locals, url }: APIContext) {
@@ -30,16 +33,30 @@ export async function POST({ locals, request }: APIContext) {
     });
   }
 
-  const { channelId } = await request.json();
-  if (!channelId) {
-    return new Response(JSON.stringify({ error: "channelId is required" }), {
-      status: 400,
+  const { channelName, projectId } = await request.json();
+  if (!channelName || !projectId) {
+    return new Response(
+      JSON.stringify({ error: "channelName and projectId are required" }),
+      { status: 400 },
+    );
+  }
+
+  const channelRow = await db
+    .select({ id: channels.id })
+    .from(channels)
+    .where(and(eq(channels.name, channelName), eq(channels.projectId, projectId)))
+    .limit(1);
+
+  if (channelRow.length === 0) {
+    return new Response(JSON.stringify({ error: "Channel not found" }), {
+      status: 404,
     });
   }
 
+  const channelId = channelRow[0].id;
   const lastReadAt = await markChannelRead(user.id, channelId);
   return new Response(
-    JSON.stringify({ lastReadAt: lastReadAt?.toISOString() ?? null }),
+    JSON.stringify({ channelId, lastReadAt: lastReadAt?.toISOString() ?? null }),
     { headers: { "Content-Type": "application/json" } },
   );
 }

--- a/src/pages/dashboard/[projectID]/events/[eventID].astro
+++ b/src/pages/dashboard/[projectID]/events/[eventID].astro
@@ -5,7 +5,7 @@ import { getEvent } from "@/lib/beaver/event";
 
 const { projectID, eventID } = Astro.params;
 
-const event = await getEvent(parseInt(eventID!));
+const event = await getEvent(parseInt(eventID!), Astro.locals.user?.id);
 
 if (!event) {
   return Astro.redirect(`/dashboard/${projectID}/feed`);


### PR DESCRIPTION
## Summary

- Adds `read: boolean` to `EventWithChannelName`, computed via a correlated `EXISTS` subquery on `channel_reads` in all event queries — no extra round-trips
- Events in the feed show a blue dot when unread; dots clear immediately via a `channel:read` browser event when the channel is marked as read
- Viewing an event detail page marks the entire channel as read and updates the sidebar badge
- `/api/unread` POST now accepts `channelName + projectId` instead of the internal `channelId`
- **Bug fix:** `/api/events/*` routes were accidentally matched by the `/api/event` prefix in `PUBLIC_API_ROUTES`, causing the middleware to return before setting `locals.user` — `userId` was always `undefined` in event queries so all events appeared unread. Moved `/api/event` (the ingest endpoint, exact path) to the exact-match list; `/api/events/*` now correctly goes through session auth
- **Bug fix:** The logging block added in #93 returned early for all `/api/` routes before auth ran, so `locals.user` was never set for any authenticated API endpoint. Logging now wraps `next()` at each exit point rather than bypassing auth

## Read tracking behavior

Uses channel-level read tracking (one `lastReadAt` timestamp per user/channel). Viewing any event in a channel marks the whole channel as read and clears all dots for that channel — intentional for now, consistent with how the sidebar unread counts already work.

## Test plan

- [ ] Load the feed with unread events — blue dots appear on unread events
- [ ] Click an event — all dots in that channel clear, sidebar badge updates
- [ ] Open a channel you've fully read — no dots shown
- [ ] SSE-delivered new events appear with a dot
- [ ] Project-wide feed shows dots per-channel correctly
- [ ] `/api/events/*` returns 401/redirect when unauthenticated (no longer public)

Closes #82