### PR TITLE
feat: channel name/description editing with integration warning (#76)

### DIFF
--- a/src/components/channel-settings.tsx
+++ b/src/components/channel-settings.tsx
@@ -16,7 +16,7 @@ import {
 } from "./ui/select";
 import { Input } from "./ui/input";
 import { Button } from "./ui/button";
-import { GitMergeIcon, Trash2Icon } from "lucide-react";
+import { GitMergeIcon, PencilIcon, Trash2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Label } from "./ui/label";
 import type { Project } from "@/lib/beaver/project";
@@ -41,6 +41,53 @@ export default function ChannelSettings({
   const [deleteConfirmName, setDeleteConfirmName] = useState("");
   const [deleteError, setDeleteError] = useState("");
   const [deleting, setDeleting] = useState(false);
+
+  // Edit state
+  const [editTarget, setEditTarget] = useState<Channel | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editing, setEditing] = useState(false);
+  const [editError, setEditError] = useState("");
+
+  const [editNameWarningAcked, setEditNameWarningAcked] = useState(false);
+
+  const nameChanged = editTarget !== null && editName.trim() !== editTarget.name;
+  const nameTaken =
+    nameChanged &&
+    clientChannels.some(
+      (c) => c.id !== editTarget?.id && c.name === editName.trim(),
+    );
+
+  const handleEditConfirm = async () => {
+    if (!editTarget) return;
+    setEditing(true);
+    setEditError("");
+    try {
+      const res = await fetch("/api/channel", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          channelId: editTarget.id,
+          name: editName.trim() || undefined,
+          description: editDescription.trim() || null,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setEditError(data.error || "Failed to update channel.");
+        return;
+      }
+      setChannels((prev) =>
+        prev.map((c) => (c.id === editTarget.id ? { ...c, name: data.name, description: data.description } : c)),
+      );
+      window.dispatchEvent(
+        new CustomEvent("channel:updated", { detail: { id: data.id, name: data.name, description: data.description } }),
+      );
+      setEditTarget(null);
+    } finally {
+      setEditing(false);
+    }
+  };
 
   // Merge state
   const [mergeSource, setMergeSource] = useState<Channel | null>(null);
@@ -158,6 +205,23 @@ export default function ChannelSettings({
             <p className="font-light text-xs truncate">{channel.description}</p>
           </div>
           <div className="flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={() => {
+                    setEditTarget(channel);
+                    setEditName(channel.name);
+                    setEditDescription(channel.description ?? "");
+                    setEditError("");
+                    setEditNameWarningAcked(false);
+                  }}
+                  className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <PencilIcon size={15} />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Edit channel</TooltipContent>
+            </Tooltip>
             {clientChannels.length > 1 && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -195,6 +259,85 @@ export default function ChannelSettings({
           </div>
         </div>
       ))}
+
+      {/* Edit dialog */}
+      <Dialog
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditTarget(null);
+            setEditError("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit channel</DialogTitle>
+            <DialogDescription>
+              Update the name or description for{" "}
+              <span className="font-bold"># {editTarget?.name}</span>.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 mt-1">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-name">Name</Label>
+              <Input
+                id="edit-name"
+                value={editName}
+                maxLength={16}
+                onChange={(e) => {
+                setEditName(e.target.value.replace(" ", "-"));
+                setEditNameWarningAcked(false);
+              }}
+              />
+              {nameTaken && (
+                <p className="text-xs text-destructive">
+                  A channel with this name already exists.
+                </p>
+              )}
+              {nameChanged && !nameTaken && (
+                <label className="flex items-start gap-2 cursor-pointer mt-1">
+                  <input
+                    type="checkbox"
+                    checked={editNameWarningAcked}
+                    onChange={(e) => setEditNameWarningAcked(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 shrink-0"
+                  />
+                  <span className="text-xs text-amber-600">
+                    I understand that changing the channel name may break existing integrations that use this channel name to send events.
+                  </span>
+                </label>
+              )}
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="edit-description">Description</Label>
+              <Input
+                id="edit-description"
+                value={editDescription}
+                placeholder="Optional description"
+                onChange={(e) => setEditDescription(e.target.value)}
+              />
+            </div>
+
+            {editError && (
+              <p className="text-sm text-destructive">{editError}</p>
+            )}
+
+            <div className="flex gap-2 justify-end">
+              <Button variant="secondary" onClick={() => setEditTarget(null)}>
+                Cancel
+              </Button>
+              <Button
+                disabled={!editName.trim() || nameTaken || (nameChanged && !editNameWarningAcked) || editing}
+                onClick={handleEditConfirm}
+              >
+                {editing ? "Saving…" : "Save"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Delete dialog */}
       <Dialog

--- a/src/lib/beaver/channel.ts
+++ b/src/lib/beaver/channel.ts
@@ -119,6 +119,44 @@ export async function coalesceChannels(
   return { ...target[0], name: survivingName };
 }
 
+export async function updateChannel(
+  channelId: number,
+  updates: { name?: string; description?: string | null },
+) {
+  const channel = await db.select().from(channels).where(eq(channels.id, channelId)).limit(1);
+  if (!channel[0]) throw new Error("Channel not found.");
+
+  if (updates.name !== undefined) {
+    if (updates.name.length > 16) {
+      throw new Error("Channel name cannot be longer than 16 characters.");
+    }
+    const existing = await db
+      .select({ id: channels.id })
+      .from(channels)
+      .where(
+        and(
+          eq(channels.projectId, channel[0].projectId),
+          eq(channels.name, updates.name),
+        ),
+      )
+      .limit(1);
+    if (existing.length > 0 && existing[0].id !== channelId) {
+      throw new Error("Channel with name already exists for this project.");
+    }
+  }
+
+  const [updated] = await db
+    .update(channels)
+    .set({
+      ...(updates.name !== undefined ? { name: updates.name } : {}),
+      ...(updates.description !== undefined ? { description: updates.description } : {}),
+    })
+    .where(eq(channels.id, channelId))
+    .returning();
+
+  return updated;
+}
+
 export async function deleteChannel(channelID: number) {
   // Delete event tags for all events in this channel
   const channelEvents = await db

--- a/src/pages/api/channel.ts
+++ b/src/pages/api/channel.ts
@@ -3,6 +3,7 @@ import {
   deleteChannel,
   getChannels,
   reorderChannels,
+  updateChannel,
 } from "@/lib/beaver/channel";
 import type { APIContext, APIRoute } from "astro";
 
@@ -117,6 +118,38 @@ export const PATCH: APIRoute = async ({ request }) => {
         status: 500,
         headers: { "Content-Type": "application/json" },
       },
+    );
+  }
+};
+
+export const PUT: APIRoute = async ({ request }) => {
+  try {
+    const { channelId, name, description } = await request.json();
+
+    if (!channelId) {
+      return new Response(JSON.stringify({ error: "channelId is required." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const channel = await updateChannel(parseInt(channelId), { name, description });
+
+    return new Response(JSON.stringify(channel), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    if (err instanceof Error) {
+      return new Response(JSON.stringify({ error: err.message }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    console.error(err);
+    return new Response(
+      JSON.stringify({ error: "An unkown error has occurred." }),
+      { status: 500, headers: { "Content-Type": "application/json" } },
     );
   }
 };


### PR DESCRIPTION
## Summary
- Adds `updateChannel(channelId, { name, description })` to the channel lib with uniqueness and length validation
- Adds `PUT /api/channel` endpoint for updates
- Adds an edit (pencil) button per channel in settings with a dialog to update name and description
- Client-side duplicate name check with inline error before submitting
- Required acknowledgement checkbox appears when the name changes, warning that integrations may break — Save is disabled until checked

## Test plan
- [ ] Edit a channel name and description, verify changes persist
- [ ] Try renaming to an existing channel name — error should appear inline, Save disabled
- [ ] Rename a channel — confirm the integration warning checkbox appears and Save is blocked until checked
- [ ] Revert name back to original — checkbox disappears, Save re-enables
- [ ] Edit description only — no warning shown, Save enabled immediately