### PR TITLE
fix: change time presets to calendar boundaries (#88)

### DIFF
--- a/src/components/event-filter-dialog.tsx
+++ b/src/components/event-filter-dialog.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState } from "react";
-import { subHours, subDays, subWeeks, subMonths, subYears } from "date-fns";
+import {
+  subHours,
+  startOfDay,
+  endOfDay,
+  startOfWeek,
+  endOfWeek,
+  startOfMonth,
+  endOfMonth,
+  startOfYear,
+  endOfYear,
+} from "date-fns";
 import { FilterIcon, PlusIcon, XIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import {
@@ -44,24 +54,24 @@ const timePresets = [
     getDates: () => ({ start: subHours(new Date(), 1), end: new Date() }),
   },
   {
-    label: "Last day",
+    label: "Today",
     value: "day" as const,
-    getDates: () => ({ start: subDays(new Date(), 1), end: new Date() }),
+    getDates: () => ({ start: startOfDay(new Date()), end: endOfDay(new Date()) }),
   },
   {
-    label: "Last week",
+    label: "This week",
     value: "week" as const,
-    getDates: () => ({ start: subWeeks(new Date(), 1), end: new Date() }),
+    getDates: () => ({ start: startOfWeek(new Date()), end: endOfWeek(new Date()) }),
   },
   {
-    label: "Last month",
+    label: "This month",
     value: "month" as const,
-    getDates: () => ({ start: subMonths(new Date(), 1), end: new Date() }),
+    getDates: () => ({ start: startOfMonth(new Date()), end: endOfMonth(new Date()) }),
   },
   {
-    label: "Last year",
+    label: "This year",
     value: "year" as const,
-    getDates: () => ({ start: subYears(new Date(), 1), end: new Date() }),
+    getDates: () => ({ start: startOfYear(new Date()), end: endOfYear(new Date()) }),
   },
 ];
 
@@ -239,13 +249,15 @@ export default function EventFilterDialog({
 
   const getActivePreset = () => {
     if (!startDate || !endDate) return null;
-    const now = new Date();
-    const diffHours = (now.getTime() - startDate.getTime()) / (1000 * 60 * 60);
-    if (diffHours <= 1.1) return "1h";
-    if (diffHours <= 25) return "day";
-    if (diffHours <= 169) return "week";
-    if (diffHours <= 745) return "month";
-    if (diffHours <= 8785) return "year";
+    for (const preset of timePresets) {
+      const { start, end } = preset.getDates();
+      if (
+        Math.abs(startDate.getTime() - start.getTime()) < 60_000 &&
+        Math.abs(endDate.getTime() - end.getTime()) < 60_000
+      ) {
+        return preset.value;
+      }
+    }
     return null;
   };
 

--- a/src/components/event-filter-dialog.tsx
+++ b/src/components/event-filter-dialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import {
   subHours,
+  subDays,
   startOfDay,
   endOfDay,
   startOfWeek,
@@ -55,8 +56,13 @@ const timePresets = [
   },
   {
     label: "Today",
-    value: "day" as const,
+    value: "today" as const,
     getDates: () => ({ start: startOfDay(new Date()), end: endOfDay(new Date()) }),
+  },
+  {
+    label: "Yesterday",
+    value: "day" as const,
+    getDates: () => ({ start: startOfDay(subDays(new Date(), 1)), end: endOfDay(subDays(new Date(), 1)) }),
   },
   {
     label: "This week",


### PR DESCRIPTION
## Summary
- Replaces all rolling-window presets with calendar-aligned ones: Today, Yesterday, This week, This month, This year
- Last hour remains a rolling 60-minute window
- Updates active preset detection to compare exact boundaries instead of approximate hour diffs

## Test plan
- [ ] "Today" shows events created today (midnight to 11:59pm)
- [ ] "Yesterday" shows events created yesterday only
- [ ] "This week" / "This month" / "This year" cover the full current calendar period
- [ ] Active preset button highlights correctly when filter is applied