### PR TITLE
fix: clamp date picker selections to local day boundaries (#89)

### DIFF
--- a/src/components/event-filter-dialog.tsx
+++ b/src/components/event-filter-dialog.tsx
@@ -323,7 +323,7 @@ export default function EventFilterDialog({
                 <label className="text-sm text-muted-foreground">From</label>
                 <DatePicker
                   date={startDate}
-                  onSelect={setStartDate}
+                  onSelect={(d) => setStartDate(d ? startOfDay(d) : undefined)}
                   placeholder="Start date"
                 />
               </div>
@@ -331,7 +331,7 @@ export default function EventFilterDialog({
                 <label className="text-sm text-muted-foreground">To</label>
                 <DatePicker
                   date={endDate}
-                  onSelect={setEndDate}
+                  onSelect={(d) => setEndDate(d ? endOfDay(d) : undefined)}
                   placeholder="End date"
                 />
               </div>


### PR DESCRIPTION
## Summary
- Start date from the custom DatePicker is clamped to `startOfDay` in local time
- End date is clamped to `endOfDay` in local time
- Ensures `.toISOString()` produces correct UTC bounds for any timezone offset
- Presets were already correct (they call `startOfDay`/`endOfDay` explicitly)

## Test plan
- [ ] Pick a custom start and end date — events on those days should appear regardless of timezone offset
- [ ] Preset buttons still work correctly