### PR TITLE
fix: stable DndContext id to resolve aria-describedby hydration mismatch (#85)

### DIFF
--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -623,6 +623,7 @@ function ChannelGroups({
 
   return (
     <DndContext
+      id="side-panel-dnd"
       sensors={sensors}
       collisionDetection={closestCenter}
       onDragStart={handleDragStart}


### PR DESCRIPTION
## Summary
- Adds `id="side-panel-dnd"` to the `<DndContext>` in `side-panel.tsx`
- Pins the `aria-describedby` ID so server and client always produce the same value, eliminating the hydration mismatch warning

## Test plan
- [ ] No hydration mismatch warning in the console on page load
- [ ] DnD channel/group reordering still works correctly