### PR TITLE
feat: bookmark events with per-user bookmarks page (#83)

### DIFF
--- a/drizzle/0009_short_nemesis.sql
+++ b/drizzle/0009_short_nemesis.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `bookmarks` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`event_id` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `bookmarks_user_event_idx` ON `bookmarks` (`user_id`,`event_id`);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,855 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "633b7647-065d-47a3-baf0-84c6710f0cb4",
+  "prevId": "31b68335-6536-44e6-b837-f9da578daea1",
+  "tables": {
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": [
+            "user_id",
+            "event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": [
+            "user_id",
+            "channel_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": [
+            "event_id",
+            "key",
+            "value"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": [
+            "channel_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": [
+            "project_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "events_channel_id_name_id_idx": {
+          "name": "events_channel_id_name_id_idx",
+          "columns": [
+            "channel_id",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "events_project_id_name_id_idx": {
+          "name": "events_project_id_name_id_idx",
+          "columns": [
+            "project_id",
+            "name",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "notifications_enabled": {
+          "name": "notifications_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": [
+            "project_id",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": [
+            "api_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778435340995,
       "tag": "0008_amusing_blazing_skull",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778450824873,
+      "tag": "0009_short_nemesis",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/bookmarks-feed.tsx
+++ b/src/components/bookmarks-feed.tsx
@@ -1,0 +1,149 @@
+import type { EventWithChannelName } from "@/lib/beaver/event";
+import type { Channel } from "@/lib/beaver/channel";
+import { useEffect, useState } from "react";
+import EventCard from "./event-card";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { SearchIcon, BookmarkIcon } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+import EventFilterDialog from "./event-filter-dialog";
+
+export default function BookmarksFeed({
+  projectID,
+  channels,
+  search,
+  startDate,
+  endDate,
+  tags,
+  channelId,
+}: {
+  projectID: number;
+  channels: Channel[];
+  search?: string | null;
+  startDate?: string | null;
+  endDate?: string | null;
+  tags?: string | null;
+  channelId?: string | null;
+}) {
+  const [events, setEvents] = useState<EventWithChannelName[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchInput, setSearchInput] = useState(search ?? "");
+
+  const parsedTags = (() => {
+    try { return tags ? JSON.parse(tags) : []; } catch { return []; }
+  })();
+
+  const navigate = (params: Record<string, string | null>) => {
+    const url = new URL(window.location.href);
+    for (const [k, v] of Object.entries(params)) {
+      if (v === null) url.searchParams.delete(k);
+      else url.searchParams.set(k, v);
+    }
+    window.location.href = url.toString();
+  };
+
+  const handleSearch = () => navigate({ search: searchInput || null });
+
+  const handleApplyFilters = (
+    start: string | null,
+    end: string | null,
+    newTags: any[],
+  ) => {
+    navigate({
+      startDate: start,
+      endDate: end,
+      tags: newTags.length ? JSON.stringify(newTags) : null,
+    });
+  };
+
+  const handleChannelFilter = (value: string) => {
+    navigate({ channelId: value === "all" ? null : value });
+  };
+
+  useEffect(() => {
+    const params = new URLSearchParams({ projectId: String(projectID) });
+    if (search) params.set("search", search);
+    if (startDate) params.set("startDate", startDate);
+    if (endDate) params.set("endDate", endDate);
+    if (tags) params.set("tags", tags);
+    if (channelId) params.set("channelId", channelId);
+
+    fetch(`/api/events/bookmarks?${params}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (Array.isArray(data)) setEvents(data);
+      })
+      .finally(() => setLoading(false));
+  }, [projectID, search, startDate, endDate, tags, channelId]);
+
+  return (
+    <div className="w-full flex flex-col">
+      {/* Header */}
+      <div className="w-full flex flex-col md:flex-row md:items-center justify-between p-4 md:p-8 border-b gap-4">
+        <h1 className="text-2xl font-semibold">Bookmarks</h1>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap gap-2 items-center justify-end">
+            <Select value={channelId ?? "all"} onValueChange={handleChannelFilter}>
+              <SelectTrigger className="w-[160px]">
+                <SelectValue placeholder="All channels" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All channels</SelectItem>
+                {channels.map((c) => (
+                  <SelectItem key={c.id} value={String(c.id)}>
+                    # {c.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <EventFilterDialog
+              type="project"
+              projectID={projectID}
+              currentStartDate={startDate ?? null}
+              currentEndDate={endDate ?? null}
+              currentTags={parsedTags}
+              onApplyFilters={handleApplyFilters}
+            />
+          </div>
+          <div className="flex gap-2 items-center">
+            <Input
+              placeholder="Search..."
+              type="text"
+              className="flex-1"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+            />
+            <Button variant="secondary" onClick={handleSearch}>
+              <SearchIcon />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Events */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex justify-center items-center p-8">
+            <p>Loading...</p>
+          </div>
+        ) : events.length === 0 ? (
+          <div className="flex flex-col items-center justify-center p-16 gap-3 text-muted-foreground">
+            <BookmarkIcon size={32} strokeWidth={1.5} />
+            <p>No bookmarks yet.</p>
+          </div>
+        ) : (
+          <div className="px-4 md:px-8 py-4 md:py-8 w-full lg:w-1/2 mx-auto flex flex-col gap-4">
+            {events.map((event) => <EventCard key={event.id} event={event} />)}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -1,6 +1,7 @@
 import type { EventWithChannelName } from "@/lib/beaver/event";
 import { Card } from "./ui/card";
 import { getEventTime } from "@/lib/utils";
+import { BookmarkIcon } from "lucide-react";
 import { memo, useRef } from "react";
 
 const EventCard = memo(function EventCard({ event }: { event: EventWithChannelName }) {
@@ -31,9 +32,14 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
               <p>{getEventTime(new Date(event.createdAt))}</p>
             </div>
           </div>
-          {!event.read && (
-            <div className="w-2 h-2 rounded-full bg-blue-500 flex-shrink-0" />
-          )}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {event.bookmarked && (
+              <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
+            )}
+            {!event.read && (
+              <div className="w-2 h-2 rounded-full bg-blue-500" />
+            )}
+          </div>
         </div>
       </Card>
     </a>

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -8,8 +8,8 @@ import {
 } from "./ui/card";
 import { Button } from "./ui/button";
 import { getEventTime } from "@/lib/utils";
-import { ArrowLeftIcon } from "lucide-react";
-import { useEffect } from "react";
+import { ArrowLeftIcon, BookmarkIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 
 function TagBadge({
   tagKey,
@@ -36,6 +36,23 @@ export default function EventDetail({
   event: EventWithChannelName;
 }) {
   const tags = Object.entries(event.tags);
+  const [bookmarked, setBookmarked] = useState(event.bookmarked);
+  const [bookmarking, setBookmarking] = useState(false);
+
+  const handleBookmark = async () => {
+    setBookmarking(true);
+    try {
+      const res = await fetch("/api/bookmarks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ eventId: event.id }),
+      });
+      const data = await res.json();
+      if (res.ok) setBookmarked(data.bookmarked);
+    } finally {
+      setBookmarking(false);
+    }
+  };
 
   useEffect(() => {
     fetch("/api/unread", {
@@ -68,18 +85,32 @@ export default function EventDetail({
         </Button>
         <Card>
           <CardHeader>
-            <div className="flex items-center space-x-4">
-              <div className="bg-gray-100 dark:bg-white/10 p-3 rounded-md">
-                <p className="text-2xl">{event.icon ? event.icon : "🪵"}</p>
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex items-center space-x-4">
+                <div className="bg-gray-100 dark:bg-white/10 p-3 rounded-md">
+                  <p className="text-2xl">{event.icon ? event.icon : "🪵"}</p>
+                </div>
+                <div>
+                  <CardTitle className="text-2xl">{event.name}</CardTitle>
+                  <CardDescription className="flex items-center gap-2 mt-1">
+                    <span># {event.channelName}</span>
+                    <span className="text-muted-foreground">·</span>
+                    <span>{getEventTime(new Date(event.createdAt))}</span>
+                  </CardDescription>
+                </div>
               </div>
-              <div>
-                <CardTitle className="text-2xl">{event.name}</CardTitle>
-                <CardDescription className="flex items-center gap-2 mt-1">
-                  <span># {event.channelName}</span>
-                  <span className="text-muted-foreground">·</span>
-                  <span>{getEventTime(new Date(event.createdAt))}</span>
-                </CardDescription>
-              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={handleBookmark}
+                disabled={bookmarking}
+                className="shrink-0"
+              >
+                <BookmarkIcon
+                  className={bookmarked ? "fill-current" : ""}
+                  size={18}
+                />
+              </Button>
             </div>
           </CardHeader>
 

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -31,6 +31,7 @@ import {
   SelectValue,
 } from "./ui/select";
 import {
+  BookmarkIcon,
   BookOpenIcon,
   ChevronDownIcon,
   ChevronRightIcon,
@@ -785,6 +786,7 @@ function PanelContent({
 
   const project = currentProject;
   const isFeedActive = () => pathname === `/dashboard/${project.id}/feed`;
+  const isBookmarksActive = () => pathname === `/dashboard/${project.id}/bookmarks`;
   const isSettingsActive = () =>
     pathname === `/dashboard/${project.id}/settings`;
   const isApiDocsActive = () =>
@@ -863,6 +865,14 @@ function PanelContent({
         >
           <InboxIcon size={20} />
           <p>Feed</p>
+        </a>
+        <a
+          className={isBookmarksActive() ? activeNavCss : navCss}
+          href={`/dashboard/${project.id}/bookmarks`}
+          onClick={() => onNavigate?.()}
+        >
+          <BookmarkIcon size={20} />
+          <p>Bookmarks</p>
         </a>
         {canEdit && (
           <a

--- a/src/lib/beaver/bookmark.ts
+++ b/src/lib/beaver/bookmark.ts
@@ -1,0 +1,76 @@
+import { db } from "../db/db";
+import { bookmarks, events, channels, eventTags } from "../db/schema";
+import { eq, and, desc, asc, or, like, gte, lte, inArray } from "drizzle-orm";
+import type { EventWithChannelName, TagFilter, SortField, SortOrder } from "./event";
+import { getEventTags } from "./event-tags";
+
+export async function toggleBookmark(userId: number, eventId: number): Promise<boolean> {
+  const existing = await db
+    .select({ id: bookmarks.id })
+    .from(bookmarks)
+    .where(and(eq(bookmarks.userId, userId), eq(bookmarks.eventId, eventId)))
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db.delete(bookmarks).where(eq(bookmarks.id, existing[0].id));
+    return false;
+  }
+
+  await db.insert(bookmarks).values({ userId, eventId });
+  return true;
+}
+
+export async function getBookmarkedEvents(
+  userId: number,
+  projectId: number,
+  options: {
+    search?: string | null;
+    channelId?: number;
+    startDate?: Date;
+    endDate?: Date;
+    tags?: TagFilter[];
+    sortBy?: SortField;
+    sortOrder?: SortOrder;
+  } = {},
+): Promise<EventWithChannelName[]> {
+  const conditions: any[] = [
+    eq(bookmarks.userId, userId),
+    eq(events.projectId, projectId),
+  ];
+
+  if (options.channelId) conditions.push(eq(events.channelId, options.channelId));
+  if (options.startDate) conditions.push(gte(events.createdAt, options.startDate));
+  if (options.endDate) conditions.push(lte(events.createdAt, options.endDate));
+
+  if (options.search) {
+    const terms = options.search.split(" ").map((w) => `%${w}%`);
+    conditions.push(...terms.map((t) => or(like(events.name, t), like(events.description, t))));
+  }
+
+  const orderFn = options.sortOrder === "asc" ? asc : desc;
+  const orderColumn = options.sortBy === "name" ? events.name : events.createdAt;
+
+  const eventData = await db
+    .select({
+      id: events.id,
+      name: events.name,
+      description: events.description,
+      icon: events.icon,
+      projectId: events.projectId,
+      createdAt: events.createdAt,
+      channelName: channels.name,
+    })
+    .from(bookmarks)
+    .innerJoin(events, eq(bookmarks.eventId, events.id))
+    .innerJoin(channels, eq(events.channelId, channels.id))
+    .where(and(...conditions))
+    .orderBy(orderFn(orderColumn));
+
+  const fetchedTags = await getEventTags(eventData.map((e) => e.id));
+  return eventData.map((e) => ({
+    ...e,
+    tags: fetchedTags[e.id] || {},
+    read: true,
+    bookmarked: true,
+  }));
+}

--- a/src/lib/beaver/event-tags.ts
+++ b/src/lib/beaver/event-tags.ts
@@ -1,0 +1,26 @@
+import { db } from "../db/db";
+import { eventTags } from "../db/schema";
+import { inArray } from "drizzle-orm";
+import type { TagPrimitive } from "./event";
+
+export async function getEventTags(ids: number[]): Promise<Record<number, TagPrimitive>> {
+  if (ids.length === 0) return {};
+
+  const allTags = await db
+    .select()
+    .from(eventTags)
+    .where(inArray(eventTags.eventId, ids));
+
+  const tagsByEventId: Record<number, TagPrimitive> = {};
+  for (const tag of allTags) {
+    if (!tagsByEventId[tag.eventId]) tagsByEventId[tag.eventId] = {};
+    if (tag.type === "number") {
+      tagsByEventId[tag.eventId][tag.key] = Number(tag.value);
+    } else if (tag.type === "boolean") {
+      tagsByEventId[tag.eventId][tag.key] = tag.value === "true";
+    } else {
+      tagsByEventId[tag.eventId][tag.key] = tag.value;
+    }
+  }
+  return tagsByEventId;
+}

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,5 +1,6 @@
 import { db } from "../db/db";
-import { events, channels, eventTags, channelReads } from "../db/schema";
+import { events, channels, eventTags, channelReads, bookmarks } from "../db/schema";
+import { getEventTags } from "./event-tags";
 import {
   eq,
   and,
@@ -55,6 +56,7 @@ export type EventWithChannelName = {
   createdAt: Date;
   tags: TagPrimitive;
   read: boolean;
+  bookmarked: boolean;
 };
 
 export type TagFilter = {
@@ -115,33 +117,6 @@ const buildTagCondition = (tagFilter: TagFilter) => {
   );
 };
 
-// helper function to get tag primitive object from event tags
-const getEventTags = async (
-  ids: number[],
-): Promise<Record<number, TagPrimitive>> => {
-  // batch fetch all tags for these events
-  const allTags = await db
-    .select()
-    .from(eventTags)
-    .where(inArray(eventTags.eventId, ids));
-
-  // group tags by eventId and convert to TagPrimitive
-  const tagsByEventId: Record<number, TagPrimitive> = {};
-
-  for (const tag of allTags) {
-    if (!tagsByEventId[tag.eventId]) tagsByEventId[tag.eventId] = {};
-
-    if (tag.type === "number") {
-      tagsByEventId[tag.eventId][tag.key] = Number(tag.value);
-    } else if (tag.type === "boolean") {
-      tagsByEventId[tag.eventId][tag.key] = tag.value === "true";
-    } else {
-      tagsByEventId[tag.eventId][tag.key] = tag.value;
-    }
-  }
-
-  return tagsByEventId;
-};
 
 export async function getChannelEvents(
   channelId: number,
@@ -219,6 +194,14 @@ export async function getChannelEvents(
       )
     : sql<boolean>`0`;
 
+  const bookmarkedExpr = userId !== undefined
+    ? exists(
+        db.select({ _: sql`1` }).from(bookmarks).where(
+          and(eq(bookmarks.eventId, events.id), eq(bookmarks.userId, userId)),
+        ),
+      )
+    : sql<boolean>`0`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -229,6 +212,7 @@ export async function getChannelEvents(
       createdAt: events.createdAt,
       channelName: channels.name,
       read: readExpr,
+      bookmarked: bookmarkedExpr,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
@@ -243,6 +227,7 @@ export async function getChannelEvents(
     ...event,
     tags: fetchedTags[event.id] || {},
     read: Boolean(event.read),
+    bookmarked: Boolean(event.bookmarked),
   }));
 }
 
@@ -322,6 +307,14 @@ export async function getProjectEvents(
       )
     : sql<boolean>`0`;
 
+  const bookmarkedExpr = userId !== undefined
+    ? exists(
+        db.select({ _: sql`1` }).from(bookmarks).where(
+          and(eq(bookmarks.eventId, events.id), eq(bookmarks.userId, userId)),
+        ),
+      )
+    : sql<boolean>`0`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -332,6 +325,7 @@ export async function getProjectEvents(
       createdAt: events.createdAt,
       channelName: channels.name,
       read: readExpr,
+      bookmarked: bookmarkedExpr,
     })
     .from(events)
     .innerJoin(
@@ -352,6 +346,7 @@ export async function getProjectEvents(
     ...event,
     tags: fetchedTags[event.id] || {},
     read: Boolean(event.read),
+    bookmarked: Boolean(event.bookmarked),
   })) as EventWithChannelName[];
 }
 
@@ -371,6 +366,14 @@ export async function getEvent(
       )
     : sql<boolean>`0`;
 
+  const bookmarkedExpr = userId !== undefined
+    ? exists(
+        db.select({ _: sql`1` }).from(bookmarks).where(
+          and(eq(bookmarks.eventId, events.id), eq(bookmarks.userId, userId)),
+        ),
+      )
+    : sql<boolean>`0`;
+
   const eventData = await db
     .select({
       id: events.id,
@@ -381,6 +384,7 @@ export async function getEvent(
       createdAt: events.createdAt,
       channelName: channels.name,
       read: readExpr,
+      bookmarked: bookmarkedExpr,
     })
     .from(events)
     .innerJoin(channels, eq(events.channelId, channels.id))
@@ -398,6 +402,7 @@ export async function getEvent(
     ...event,
     tags: tags[event.id] || {},
     read: Boolean(event.read),
+    bookmarked: Boolean(event.bookmarked),
   };
 }
 
@@ -447,7 +452,7 @@ export async function exportChannelEvents(
     .orderBy(orderFn(orderColumn));
 
   const fetchedTags = await getEventTags(eventData.map((e) => e.id));
-  return eventData.map((e) => ({ ...e, tags: fetchedTags[e.id] || {}, read: false }));
+  return eventData.map((e) => ({ ...e, tags: fetchedTags[e.id] || {}, read: false, bookmarked: false }));
 }
 
 export async function exportProjectEvents(
@@ -474,7 +479,7 @@ export async function exportProjectEvents(
     .orderBy(orderFn(orderColumn));
 
   const fetchedTags = await getEventTags(eventData.map((e) => e.id));
-  return eventData.map((e) => ({ ...e, tags: fetchedTags[e.id] || {}, read: false }));
+  return eventData.map((e) => ({ ...e, tags: fetchedTags[e.id] || {}, read: false, bookmarked: false }));
 }
 
 export async function createEvent({
@@ -539,6 +544,7 @@ export async function createEvent({
       channelName: channelsRes[0].name,
       createdAt: event.createdAt,
       read: false,
+      bookmarked: false,
     };
   }
 
@@ -552,5 +558,6 @@ export async function createEvent({
     channelName: channelsRes[0].name,
     createdAt: event.createdAt,
     read: false,
+    bookmarked: false,
   };
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -200,6 +200,29 @@ export const channelReads = sqliteTable(
   }),
 );
 
+// --- BOOKMARKS ---
+export const bookmarks = sqliteTable(
+  "bookmarks",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    eventId: integer("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    userEventIdx: uniqueIndex("bookmarks_user_event_idx").on(
+      table.userId,
+      table.eventId,
+    ),
+  }),
+);
+
 // --- SESSIONS ----
 export const sessions = sqliteTable("sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),

--- a/src/pages/api/bookmarks.ts
+++ b/src/pages/api/bookmarks.ts
@@ -1,0 +1,21 @@
+import { toggleBookmark } from "@/lib/beaver/bookmark";
+import type { APIContext, APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ locals, request }: APIContext) => {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const { eventId } = await request.json();
+  if (!eventId) {
+    return new Response(JSON.stringify({ error: "eventId is required" }), { status: 400 });
+  }
+
+  const bookmarked = await toggleBookmark(user.id, parseInt(eventId));
+  return new Response(JSON.stringify({ bookmarked }), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const prerender = false;

--- a/src/pages/api/events/bookmarks/index.ts
+++ b/src/pages/api/events/bookmarks/index.ts
@@ -1,0 +1,47 @@
+import { getBookmarkedEvents } from "@/lib/beaver/bookmark";
+import type { TagFilter, SortField, SortOrder } from "@/lib/beaver/event";
+
+export async function GET({
+  url,
+  locals,
+}: {
+  url: URL;
+  locals: App.Locals;
+}) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const projectId = url.searchParams.get("projectId");
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+
+  const channelId = url.searchParams.get("channelId");
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  let tags: TagFilter[] = [];
+
+  if (url.searchParams.get("startDate")) startDate = new Date(url.searchParams.get("startDate")!);
+  if (url.searchParams.get("endDate")) endDate = new Date(url.searchParams.get("endDate")!);
+  if (url.searchParams.get("tags")) {
+    try { tags = JSON.parse(url.searchParams.get("tags")!); } catch {}
+  }
+
+  const events = await getBookmarkedEvents(user.id, parseInt(projectId), {
+    search: url.searchParams.get("search"),
+    channelId: channelId ? parseInt(channelId) : undefined,
+    startDate,
+    endDate,
+    tags,
+    sortBy: (url.searchParams.get("sortBy") ?? undefined) as SortField | undefined,
+    sortOrder: (url.searchParams.get("sortOrder") ?? undefined) as SortOrder | undefined,
+  });
+
+  return new Response(JSON.stringify(events), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/bookmarks.astro
+++ b/src/pages/dashboard/[projectID]/bookmarks.astro
@@ -1,0 +1,27 @@
+---
+import Layout from "@/layouts/layout.astro";
+import BookmarksFeed from "@/components/bookmarks-feed";
+import { getChannels } from "@/lib/beaver/channel";
+
+const { projectID } = Astro.params;
+const channels = await getChannels(parseInt(projectID!));
+
+const search = Astro.url.searchParams.get("search");
+const startDate = Astro.url.searchParams.get("startDate");
+const endDate = Astro.url.searchParams.get("endDate");
+const tags = Astro.url.searchParams.get("tags");
+const channelId = Astro.url.searchParams.get("channelId");
+---
+
+<Layout projectID={projectID!}>
+  <BookmarksFeed
+    client:load
+    projectID={parseInt(projectID!)}
+    channels={channels}
+    search={search}
+    startDate={startDate}
+    endDate={endDate}
+    tags={tags}
+    channelId={channelId}
+  />
+</Layout>


### PR DESCRIPTION
## Summary
- Adds `bookmarks` table (userId + eventId, unique per user)
- `bookmarked: boolean` on `EventWithChannelName` via EXISTS subquery (same pattern as `read`)
- `POST /api/bookmarks` toggles bookmark state, returns `{ bookmarked: boolean }`
- `GET /api/events/bookmarks` returns bookmarked events for the current user with full filter support
- Bookmark toggle button on event detail page (filled when bookmarked)
- Small bookmark icon on event cards in the feed
- Bookmarks page at `/dashboard/[projectID]/bookmarks` with channel, date, tag, and search filters
- Sidebar link under Feed
- Extracted shared `getEventTags` helper to `src/lib/beaver/event-tags.ts`

## Test plan
- [ ] Click bookmark button on event detail — icon fills, revisit page and it stays filled
- [ ] Click again — unbookmarks
- [ ] Bookmarked events show icon in feed cards
- [ ] Bookmarks page shows only bookmarked events for the current user
- [ ] Channel, date, tag, and search filters work on bookmarks page
- [ ] Bookmarking is per-user — other users don't see each other's bookmarks