### PR TITLE
feat: metrics schema, DB layer & logging API (#102)

### DIFF
--- a/drizzle/0010_metrics.sql
+++ b/drizzle/0010_metrics.sql
@@ -1,0 +1,24 @@
+CREATE TABLE `metrics` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`unit` text,
+	`type` text NOT NULL,
+	`chart_type` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `metrics_project_id_name_idx` ON `metrics` (`project_id`,`name`);
+--> statement-breakpoint
+CREATE TABLE `metric_values` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`metric_id` integer NOT NULL,
+	`value` real NOT NULL,
+	`timestamp` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`metric_id`) REFERENCES `metrics`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `metric_values_metric_id_timestamp_idx` ON `metric_values` (`metric_id`,`timestamp`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778450824873,
       "tag": "0009_short_nemesis",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1746921600000,
+      "tag": "0010_metrics",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/beaver/metric.ts
+++ b/src/lib/beaver/metric.ts
@@ -155,27 +155,43 @@ export async function deleteMetric(metricId: number): Promise<void> {
 
 export async function setGauge(metricId: number, value: number): Promise<void> {
   const now = new Date();
-  await db.delete(metricValues).where(eq(metricValues.metricId, metricId));
-  await db.insert(metricValues).values({ metricId, value, timestamp: now });
+  await db.transaction(async (tx) => {
+    const updated = await tx
+      .update(metricValues)
+      .set({ value, timestamp: now })
+      .where(eq(metricValues.metricId, metricId))
+      .returning();
+
+    if (updated.length === 0) {
+      await tx.insert(metricValues).values({ metricId, value, timestamp: now });
+    }
+  });
 }
 
 export async function incrementCounter(
   metricId: number,
   amount: number,
 ): Promise<number> {
-  const [existing] = await db
-    .select()
-    .from(metricValues)
-    .where(eq(metricValues.metricId, metricId));
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(metricValues)
+      .where(eq(metricValues.metricId, metricId));
 
-  const current = existing?.value ?? 0;
-  const next = current + amount;
-  const now = new Date();
+    const next = (existing?.value ?? 0) + amount;
+    const now = new Date();
 
-  await db.delete(metricValues).where(eq(metricValues.metricId, metricId));
-  await db.insert(metricValues).values({ metricId, value: next, timestamp: now });
+    if (existing) {
+      await tx
+        .update(metricValues)
+        .set({ value: next, timestamp: now })
+        .where(eq(metricValues.metricId, metricId));
+    } else {
+      await tx.insert(metricValues).values({ metricId, value: next, timestamp: now });
+    }
 
-  return next;
+    return next;
+  });
 }
 
 export async function appendTimeseries(

--- a/src/lib/beaver/metric.ts
+++ b/src/lib/beaver/metric.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/db";
-import { metrics, metricValues, projects } from "../db/schema";
-import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { metrics, metricValues } from "../db/schema";
+import { and, eq, gte, lte, sql } from "drizzle-orm";
 
 export type MetricType = "gauge" | "counter" | "timeseries";
 export type ChartType = "line" | "bar";
@@ -95,25 +95,34 @@ export async function getMetrics(projectId: number): Promise<MetricWithValue[]> 
 }
 
 export async function getMetric(metricId: number): Promise<MetricWithValue | undefined> {
+  const ranked = db
+    .select({
+      metricId: metricValues.metricId,
+      value: metricValues.value,
+      timestamp: metricValues.timestamp,
+      rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${metricValues.metricId} ORDER BY ${metricValues.timestamp} DESC)`.as("rn"),
+    })
+    .from(metricValues)
+    .as("ranked");
+
   const [row] = await db
-    .select()
+    .select({
+      id: metrics.id,
+      projectId: metrics.projectId,
+      name: metrics.name,
+      description: metrics.description,
+      unit: metrics.unit,
+      type: metrics.type,
+      chartType: metrics.chartType,
+      createdAt: metrics.createdAt,
+      currentValue: ranked.value,
+      lastUpdatedAt: ranked.timestamp,
+    })
     .from(metrics)
+    .leftJoin(ranked, and(eq(ranked.metricId, metrics.id), eq(ranked.rn, 1)))
     .where(eq(metrics.id, metricId));
 
-  if (!row) return undefined;
-
-  const [latest] = await db
-    .select()
-    .from(metricValues)
-    .where(eq(metricValues.metricId, metricId))
-    .orderBy(desc(metricValues.timestamp))
-    .limit(1);
-
-  return {
-    ...(row as Metric),
-    currentValue: latest?.value ?? null,
-    lastUpdatedAt: latest?.timestamp ?? null,
-  };
+  return row as MetricWithValue | undefined;
 }
 
 export async function getMetricByName(
@@ -140,6 +149,24 @@ export async function updateMetric(
     unit?: string;
   },
 ): Promise<Metric> {
+  if (name !== undefined) {
+    const [current] = await db
+      .select({ projectId: metrics.projectId })
+      .from(metrics)
+      .where(eq(metrics.id, metricId));
+
+    if (current) {
+      const conflict = await db
+        .select({ id: metrics.id })
+        .from(metrics)
+        .where(and(eq(metrics.projectId, current.projectId), eq(metrics.name, name)));
+
+      if (conflict.length > 0 && conflict[0].id !== metricId) {
+        throw new Error(`A metric named "${name}" already exists in this project.`);
+      }
+    }
+  }
+
   const [updated] = await db
     .update(metrics)
     .set({ name, description, unit })
@@ -234,11 +261,3 @@ export async function getMetricValues(
   return (await query) as MetricValue[];
 }
 
-export async function getProjectByApiKey(apiKey: string) {
-  const [project] = await db
-    .select()
-    .from(projects)
-    .where(eq(projects.apiKey, apiKey));
-
-  return project;
-}

--- a/src/lib/beaver/metric.ts
+++ b/src/lib/beaver/metric.ts
@@ -1,0 +1,223 @@
+import { db } from "../db/db";
+import { metrics, metricValues, projects } from "../db/schema";
+import { and, desc, eq, gte, lte } from "drizzle-orm";
+
+export type MetricType = "gauge" | "counter" | "timeseries";
+export type ChartType = "line" | "bar";
+
+export type Metric = {
+  id: number;
+  projectId: number;
+  name: string;
+  description: string | null;
+  unit: string | null;
+  type: MetricType;
+  chartType: ChartType | null;
+  createdAt: Date;
+};
+
+export type MetricWithValue = Metric & {
+  currentValue: number | null;
+  lastUpdatedAt: Date | null;
+};
+
+export type MetricValue = {
+  id: number;
+  metricId: number;
+  value: number;
+  timestamp: Date;
+  createdAt: Date;
+};
+
+export async function createMetric(
+  projectId: number,
+  {
+    name,
+    description,
+    unit,
+    type,
+    chartType,
+  }: {
+    name: string;
+    description?: string;
+    unit?: string;
+    type: MetricType;
+    chartType?: ChartType;
+  },
+): Promise<Metric> {
+  const existing = await db
+    .select({ id: metrics.id })
+    .from(metrics)
+    .where(and(eq(metrics.projectId, projectId), eq(metrics.name, name)));
+
+  if (existing.length > 0) {
+    throw new Error(`A metric named "${name}" already exists in this project.`);
+  }
+
+  const [metric] = await db
+    .insert(metrics)
+    .values({ projectId, name, description, unit, type, chartType })
+    .returning();
+
+  return metric as Metric;
+}
+
+export async function getMetrics(projectId: number): Promise<MetricWithValue[]> {
+  const rows = await db
+    .select()
+    .from(metrics)
+    .where(eq(metrics.projectId, projectId))
+    .orderBy(metrics.createdAt);
+
+  const result: MetricWithValue[] = [];
+
+  for (const row of rows) {
+    const [latest] = await db
+      .select()
+      .from(metricValues)
+      .where(eq(metricValues.metricId, row.id))
+      .orderBy(desc(metricValues.timestamp))
+      .limit(1);
+
+    result.push({
+      ...(row as Metric),
+      currentValue: latest?.value ?? null,
+      lastUpdatedAt: latest?.timestamp ?? null,
+    });
+  }
+
+  return result;
+}
+
+export async function getMetric(metricId: number): Promise<MetricWithValue | undefined> {
+  const [row] = await db
+    .select()
+    .from(metrics)
+    .where(eq(metrics.id, metricId));
+
+  if (!row) return undefined;
+
+  const [latest] = await db
+    .select()
+    .from(metricValues)
+    .where(eq(metricValues.metricId, metricId))
+    .orderBy(desc(metricValues.timestamp))
+    .limit(1);
+
+  return {
+    ...(row as Metric),
+    currentValue: latest?.value ?? null,
+    lastUpdatedAt: latest?.timestamp ?? null,
+  };
+}
+
+export async function getMetricByName(
+  projectId: number,
+  name: string,
+): Promise<Metric | undefined> {
+  const [row] = await db
+    .select()
+    .from(metrics)
+    .where(and(eq(metrics.projectId, projectId), eq(metrics.name, name)));
+
+  return row as Metric | undefined;
+}
+
+export async function updateMetric(
+  metricId: number,
+  {
+    name,
+    description,
+    unit,
+  }: {
+    name?: string;
+    description?: string;
+    unit?: string;
+  },
+): Promise<Metric> {
+  const [updated] = await db
+    .update(metrics)
+    .set({ name, description, unit })
+    .where(eq(metrics.id, metricId))
+    .returning();
+
+  return updated as Metric;
+}
+
+export async function deleteMetric(metricId: number): Promise<void> {
+  await db.delete(metrics).where(eq(metrics.id, metricId));
+}
+
+export async function setGauge(metricId: number, value: number): Promise<void> {
+  const now = new Date();
+  await db.delete(metricValues).where(eq(metricValues.metricId, metricId));
+  await db.insert(metricValues).values({ metricId, value, timestamp: now });
+}
+
+export async function incrementCounter(
+  metricId: number,
+  amount: number,
+): Promise<number> {
+  const [existing] = await db
+    .select()
+    .from(metricValues)
+    .where(eq(metricValues.metricId, metricId));
+
+  const current = existing?.value ?? 0;
+  const next = current + amount;
+  const now = new Date();
+
+  await db.delete(metricValues).where(eq(metricValues.metricId, metricId));
+  await db.insert(metricValues).values({ metricId, value: next, timestamp: now });
+
+  return next;
+}
+
+export async function appendTimeseries(
+  metricId: number,
+  value: number,
+  timestamp?: Date,
+): Promise<void> {
+  await db.insert(metricValues).values({
+    metricId,
+    value,
+    timestamp: timestamp ?? new Date(),
+  });
+}
+
+export async function getMetricValues(
+  metricId: number,
+  {
+    from,
+    to,
+    limit,
+  }: {
+    from?: Date;
+    to?: Date;
+    limit?: number;
+  } = {},
+): Promise<MetricValue[]> {
+  const conditions = [eq(metricValues.metricId, metricId)];
+  if (from) conditions.push(gte(metricValues.timestamp, from));
+  if (to) conditions.push(lte(metricValues.timestamp, to));
+
+  let query = db
+    .select()
+    .from(metricValues)
+    .where(and(...conditions))
+    .orderBy(metricValues.timestamp)
+    .$dynamic();
+
+  if (limit) query = query.limit(limit);
+
+  return (await query) as MetricValue[];
+}
+
+export async function getProjectByApiKey(apiKey: string) {
+  const [project] = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.apiKey, apiKey));
+
+  return project;
+}

--- a/src/lib/beaver/metric.ts
+++ b/src/lib/beaver/metric.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/db";
 import { metrics, metricValues, projects } from "../db/schema";
-import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 
 export type MetricType = "gauge" | "counter" | "timeseries";
 export type ChartType = "line" | "bar";
@@ -63,30 +63,35 @@ export async function createMetric(
 }
 
 export async function getMetrics(projectId: number): Promise<MetricWithValue[]> {
+  const ranked = db
+    .select({
+      metricId: metricValues.metricId,
+      value: metricValues.value,
+      timestamp: metricValues.timestamp,
+      rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${metricValues.metricId} ORDER BY ${metricValues.timestamp} DESC)`.as("rn"),
+    })
+    .from(metricValues)
+    .as("ranked");
+
   const rows = await db
-    .select()
+    .select({
+      id: metrics.id,
+      projectId: metrics.projectId,
+      name: metrics.name,
+      description: metrics.description,
+      unit: metrics.unit,
+      type: metrics.type,
+      chartType: metrics.chartType,
+      createdAt: metrics.createdAt,
+      currentValue: ranked.value,
+      lastUpdatedAt: ranked.timestamp,
+    })
     .from(metrics)
+    .leftJoin(ranked, and(eq(ranked.metricId, metrics.id), eq(ranked.rn, 1)))
     .where(eq(metrics.projectId, projectId))
     .orderBy(metrics.createdAt);
 
-  const result: MetricWithValue[] = [];
-
-  for (const row of rows) {
-    const [latest] = await db
-      .select()
-      .from(metricValues)
-      .where(eq(metricValues.metricId, row.id))
-      .orderBy(desc(metricValues.timestamp))
-      .limit(1);
-
-    result.push({
-      ...(row as Metric),
-      currentValue: latest?.value ?? null,
-      lastUpdatedAt: latest?.timestamp ?? null,
-    });
-  }
-
-  return result;
+  return rows as MetricWithValue[];
 }
 
 export async function getMetric(metricId: number): Promise<MetricWithValue | undefined> {

--- a/src/lib/beaver/project.ts
+++ b/src/lib/beaver/project.ts
@@ -81,3 +81,12 @@ export async function rotateApiKey(projectId: number): Promise<string> {
     .where(eq(projects.id, projectId));
   return newKey;
 }
+
+export async function getProjectByApiKey(apiKey: string) {
+  const [project] = await db
+    .select()
+    .from(projects)
+    .where(eq(projects.apiKey, apiKey));
+
+  return project;
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -3,6 +3,7 @@ import {
   sqliteTable,
   text,
   integer,
+  real,
   index,
   uniqueIndex,
 } from "drizzle-orm/sqlite-core";
@@ -223,6 +224,55 @@ export const bookmarks = sqliteTable(
   }),
 );
 
+// --- METRICS ---
+export const metrics = sqliteTable(
+  "metrics",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    projectId: integer("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    description: text("description"),
+    unit: text("unit"),
+    type: text("type", {
+      enum: ["gauge", "counter", "timeseries"],
+    }).notNull(),
+    chartType: text("chart_type", { enum: ["line", "bar"] }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    projectNameIdx: uniqueIndex("metrics_project_id_name_idx").on(
+      table.projectId,
+      table.name,
+    ),
+  }),
+);
+
+// --- METRIC VALUES ---
+export const metricValues = sqliteTable(
+  "metric_values",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    metricId: integer("metric_id")
+      .notNull()
+      .references(() => metrics.id, { onDelete: "cascade" }),
+    value: real("value").notNull(),
+    timestamp: integer("timestamp", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    metricTimestampIdx: index("metric_values_metric_id_timestamp_idx").on(
+      table.metricId,
+      table.timestamp,
+    ),
+  }),
+);
+
 // --- SESSIONS ----
 export const sessions = sqliteTable("sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -313,5 +363,20 @@ export const channelReadRelations = relations(channelReads, ({ one }) => ({
   channel: one(channels, {
     fields: [channelReads.channelId],
     references: [channels.id],
+  }),
+}));
+
+export const metricRelations = relations(metrics, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [metrics.projectId],
+    references: [projects.id],
+  }),
+  values: many(metricValues),
+}));
+
+export const metricValueRelations = relations(metricValues, ({ one }) => ({
+  metric: one(metrics, {
+    fields: [metricValues.metricId],
+    references: [metrics.id],
   }),
 }));

--- a/src/pages/api/metric.ts
+++ b/src/pages/api/metric.ts
@@ -1,10 +1,10 @@
 import {
   appendTimeseries,
   getMetricByName,
-  getProjectByApiKey,
   incrementCounter,
   setGauge,
 } from "@/lib/beaver/metric";
+import { getProjectByApiKey } from "@/lib/beaver/project";
 import type { APIContext, APIRoute } from "astro";
 
 export const POST: APIRoute = async ({ request }: APIContext) => {
@@ -35,7 +35,13 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
       );
     }
 
-    const ts = timestamp ? new Date(timestamp) : undefined;
+    let ts: Date | undefined;
+    if (timestamp !== undefined) {
+      ts = new Date(timestamp);
+      if (isNaN(ts.getTime())) {
+        return json({ error: "timestamp is not a valid ISO 8601 date." }, 400);
+      }
+    }
 
     if (metric.type === "gauge") {
       if (value === undefined || value === null) {

--- a/src/pages/api/metric.ts
+++ b/src/pages/api/metric.ts
@@ -1,0 +1,89 @@
+import {
+  appendTimeseries,
+  getMetricByName,
+  getProjectByApiKey,
+  incrementCounter,
+  setGauge,
+} from "@/lib/beaver/metric";
+import type { APIContext, APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ request }: APIContext) => {
+  const apiKey = request.headers.get("X-API-Key");
+
+  if (!apiKey) {
+    return json({ error: "X-API-Key header is required." }, 401);
+  }
+
+  try {
+    const body = await request.json();
+    const { metric: metricName, value, increment, timestamp } = body;
+
+    if (!metricName) {
+      return json({ error: "metric is a required field." }, 400);
+    }
+
+    const project = await getProjectByApiKey(apiKey);
+    if (!project) {
+      return json({ error: "Invalid API key." }, 401);
+    }
+
+    const metric = await getMetricByName(project.id, metricName);
+    if (!metric) {
+      return json(
+        { error: `Metric "${metricName}" does not exist. Create it in the dashboard first.` },
+        404,
+      );
+    }
+
+    const ts = timestamp ? new Date(timestamp) : undefined;
+
+    if (metric.type === "gauge") {
+      if (value === undefined || value === null) {
+        return json({ error: "value is required for gauge metrics." }, 400);
+      }
+      if (typeof value !== "number") {
+        return json({ error: "value must be a number." }, 400);
+      }
+      await setGauge(metric.id, value);
+      return json({ ok: true, metric: metricName, value });
+    }
+
+    if (metric.type === "counter") {
+      if (increment === undefined || increment === null) {
+        return json({ error: "increment is required for counter metrics." }, 400);
+      }
+      if (typeof increment !== "number") {
+        return json({ error: "increment must be a number." }, 400);
+      }
+      const total = await incrementCounter(metric.id, increment);
+      return json({ ok: true, metric: metricName, total });
+    }
+
+    if (metric.type === "timeseries") {
+      if (value === undefined || value === null) {
+        return json({ error: "value is required for timeseries metrics." }, 400);
+      }
+      if (typeof value !== "number") {
+        return json({ error: "value must be a number." }, 400);
+      }
+      await appendTimeseries(metric.id, value, ts);
+      return json({ ok: true, metric: metricName, value, timestamp: (ts ?? new Date()).toISOString() });
+    }
+
+    return json({ error: "Unknown metric type." }, 500);
+  } catch (err) {
+    if (err instanceof Error) {
+      return json({ error: err.message }, 500);
+    }
+    return json({ error: "An unknown error has occurred." }, 500);
+  }
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;


### PR DESCRIPTION
## Summary

- Adds `metrics` and `metric_values` tables to the schema with a migration
- Three metric types: **gauge** (upsert, latest only), **counter** (upsert, running total with increment/decrement), **timeseries** (append-only)
- `src/lib/beaver/metric.ts` — full DB layer: create, get, update, delete, setGauge, incrementCounter, appendTimeseries, getMetricValues
- `POST /api/metric` — external logging API authenticated via `X-API-Key`; returns 404 for unknown metric names (metrics are UI-first)

## Test plan

- [ ] Run migration: `bun src/lib/db/migrate.ts`
- [ ] POST gauge value, verify upsert (only one row in metric_values)
- [ ] POST counter increment and decrement, verify running total
- [ ] POST timeseries values, verify multiple rows appended
- [ ] POST to unknown metric name, verify 404
- [ ] POST with wrong API key, verify 401
- [ ] POST timeseries without timestamp, verify it defaults to now