### PR TITLE
ci: add format check, lint, and type check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format check
+        run: bun format:check
+
+      - name: Lint
+        run: bun lint
+
+      - name: Type check
+        run: bunx tsc --noEmit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
         run: bun lint
 
       - name: Type check
-        run: bunx tsc --noEmit
+        run: bun astro sync && bunx tsc --noEmit

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,21 +1,7 @@
 import { db } from "../db/db";
 import { events, channels, eventTags, channelReads, bookmarks } from "../db/schema";
 import { getEventTags } from "./event-tags";
-import {
-  eq,
-  and,
-  or,
-  asc,
-  desc,
-  like,
-  gt,
-  lt,
-  gte,
-  lte,
-  exists,
-  max,
-  sql,
-} from "drizzle-orm";
+import { eq, and, or, asc, desc, like, gt, lt, gte, lte, exists, max, sql } from "drizzle-orm";
 import { getProject } from "./project";
 
 export async function getMaxEventId(): Promise<number> {


### PR DESCRIPTION
## Summary

- Adds a CI pipeline that runs on PRs and pushes to `main`
- Format check via `bun format:check` (oxfmt)
- Lint via `bun lint` (oxlint)
- Type check via `tsc --noEmit`, preceded by `astro sync` to generate virtual module type declarations

Closes #141