### PR TITLE
fix: sanitize username input

### DIFF
--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -286,7 +286,11 @@ export default function AdminUsersView({
                       <Input
                         id="username"
                         value={newUsername}
-                        onChange={(e) => setNewUsername(e.target.value)}
+                        onChange={(e) =>
+                          setNewUsername(
+                            e.target.value.replace(/[^a-zA-Z0-9-]/g, "-").replace(/-{2,}/g, "-"),
+                          )
+                        }
                         placeholder="e.g. paris"
                         required
                       />

--- a/src/components/onboarding-view.tsx
+++ b/src/components/onboarding-view.tsx
@@ -50,7 +50,7 @@ const CreateAdminAccount = ({
           className="w-full"
           value={username}
           onChange={(e) => {
-            setUsername(e.target.value);
+            setUsername(e.target.value.replace(/[^a-zA-Z0-9-]/g, "-").replace(/-{2,}/g, "-"));
           }}
         />
       </div>

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -68,11 +68,20 @@ export function generateTempPassword(): string {
   return result;
 }
 
+const USERNAME_RE = /^[a-zA-Z0-9-]+$/;
+
+function validateUsername(userName: string) {
+  if (!USERNAME_RE.test(userName)) {
+    throw new Error("Username may only contain letters, numbers, and hyphens.");
+  }
+}
+
 export async function createUser(
   userName: string,
   password: string,
   isAdmin: boolean,
 ): Promise<User> {
+  validateUsername(userName);
   const hashedPassword = await Bun.password.hash(password);
 
   const [user] = await db
@@ -87,6 +96,7 @@ export async function createUserAccount(
   userName: string,
   canCreateProjects = false,
 ): Promise<User & { tempPassword: string }> {
+  validateUsername(userName);
   const tempPassword = generateTempPassword();
   const hashedPassword = await Bun.password.hash(tempPassword);
 


### PR DESCRIPTION
## Summary

* Strip invalid characters from username inputs — only alphanumeric and hyphens are allowed
* Spaces and other characters are replaced with `-`
* Consecutive hyphens are collapsed to a single `-`
* Validation enforced at both the UI layer (onboarding and admin user creation) and the lib layer (`createUser`, `createUserAccount`)

## Issues

Closes #137