### PR TITLE
fix: persist last active project for users page back navigation

### DIFF
--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { User } from "@/lib/beaver/user";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -142,6 +142,12 @@ export default function AdminUsersView({
   backUrl: string;
 }) {
   const [users, setUsers] = useState<User[]>(initialUsers);
+  const [resolvedBackUrl, setResolvedBackUrl] = useState(backUrl);
+
+  useEffect(() => {
+    const lastId = localStorage.getItem("lastProjectId");
+    if (lastId) setResolvedBackUrl(`/dashboard/${lastId}/feed`);
+  }, []);
 
   // Create
   const [createOpen, setCreateOpen] = useState(false);
@@ -255,7 +261,7 @@ export default function AdminUsersView({
           {/* Header */}
           <div className="mb-8">
             <a
-              href={backUrl}
+              href={resolvedBackUrl}
               data-astro-reload
               className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
             >

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -55,6 +55,9 @@ const userRole = user.isAdmin
       applyStoredTheme();
       document.addEventListener("astro:after-swap", applyStoredTheme);
     </script>
+    <script is:inline define:vars={{ projectID }}>
+      localStorage.setItem("lastProjectId", projectID);
+    </script>
   </head>
   <body>
     <div class="flex flex-col md:flex-row">


### PR DESCRIPTION
## Summary

* Layout writes the current project ID to `localStorage` on every dashboard visit
* Users page back button reads from `localStorage` in a `useEffect` after hydration, returning to the last active project instead of always defaulting to the first project

## Issues

Closes #138