### PR TITLE
fix: allow admins to delete projects correctly

### DIFF
--- a/src/pages/api/project.ts
+++ b/src/pages/api/project.ts
@@ -3,6 +3,7 @@ import {
   createProject,
   deleteProject,
   getProject,
+  getProjects,
   renameProject,
   rotateApiKey,
 } from "@/lib/beaver/project";
@@ -167,7 +168,9 @@ export const DELETE: APIRoute = async (context: APIContext) => {
       });
     }
 
-    const userProjects = await getProjectsForUser(context.locals.user.id);
+    const userProjects = context.locals.user.isAdmin
+      ? await getProjects()
+      : await getProjectsForUser(context.locals.user.id);
     if (userProjects.length <= 1) {
       return new Response(
         JSON.stringify({


### PR DESCRIPTION
## Summary

* `getProjectsForUser` only returns projects a user is a member of, so admins who aren't explicit members of all projects would incorrectly hit the "at least one project" guard
* Admins now use `getProjects()` to count all system projects when checking the deletion guard

## Issues

Closes #139