### PR TITLE
feat: add event count to feed header

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -25,6 +25,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import { Badge } from "./ui/badge";
 
 type SortOption = `${SortField}_${SortOrder}`;
 
@@ -72,6 +73,7 @@ export default function EventFeed({
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
   const [searchInput, setSearchInput] = useState(search ?? "");
+  const [eventCount, setEventCount] = useState<number | null>(null);
   const [lastReadDate, setLastReadDate] = useState<Date | null>(null);
 
   const eventIdsRef = useRef<Set<number>>(new Set());
@@ -301,6 +303,24 @@ export default function EventFeed({
     };
   }, [projectID, channel, search, startDate, endDate, tags, sortBy, sortOrder]);
 
+  // Fetch total event count scoped to current filters
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (search) params.set("search", search);
+    if (startDate) params.set("startDate", startDate);
+    if (endDate) params.set("endDate", endDate);
+    if (tags) params.set("tags", tags);
+
+    const endpoint = channel
+      ? `/api/events/channel/${channel.id}/count?${params}`
+      : `/api/events/project/${projectID}/count?${params}`;
+
+    fetch(endpoint)
+      .then((r) => r.json())
+      .then((d) => setEventCount(d.count))
+      .catch(() => {});
+  }, [projectID, channel, search, startDate, endDate, tags]);
+
   // Mark channel as read, capture lastReadAt for divider
   useEffect(() => {
     if (type !== "channel" || !channel) return;
@@ -447,9 +467,16 @@ export default function EventFeed({
       {/* Header */}
       <div className="w-full flex flex-col md:flex-row md:items-center justify-between p-4 md:p-8 border-b gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">
-            {type === "project" ? "Feed" : `# ${channel?.name}`}
-          </h1>
+          <div className="flex items-center gap-3">
+            <h1 className="text-2xl font-semibold">
+              {type === "project" ? "Feed" : `# ${channel?.name}`}
+            </h1>
+            {eventCount !== null && (
+              <Badge variant="secondary" className="tabular-nums">
+                {eventCount.toLocaleString()} {eventCount === 1 ? "event" : "events"}
+              </Badge>
+            )}
+          </div>
           {type === "channel" && channel?.description && (
             <p className="text-sm text-muted-foreground mt-1">{channel.description}</p>
           )}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Slot } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a&]:hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90",
+        destructive:
+          "bg-destructive text-white focus-visible:ring-destructive/20 dark:bg-destructive/60 dark:focus-visible:ring-destructive/40 [a&]:hover:bg-destructive/90",
+        outline:
+          "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 [a&]:hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> & VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -332,6 +332,55 @@ export async function getProjectEvents(
   })) as EventWithChannelName[];
 }
 
+type CountOptions = Pick<QueryOptions, "search" | "startDate" | "endDate" | "tags">;
+
+export async function countChannelEvents(
+  channelId: number,
+  options: CountOptions,
+): Promise<number> {
+  const conditions: any[] = [eq(events.channelId, channelId)];
+  if (options.search) {
+    const terms = options.search.split(" ").map((w) => `%${w}%`);
+    conditions.push(...terms.map((t) => or(like(events.name, t), like(events.description, t))));
+  }
+  if (options.startDate) conditions.push(gte(events.createdAt, options.startDate));
+  if (options.endDate) conditions.push(lte(events.createdAt, options.endDate));
+  if (options.tags?.length) {
+    for (const tag of options.tags) conditions.push(buildTagCondition(tag));
+  }
+  const [{ count }] = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(events)
+    .innerJoin(channels, eq(events.channelId, channels.id))
+    .where(and(...conditions));
+  return count;
+}
+
+export async function countProjectEvents(
+  projectId: number,
+  options: CountOptions,
+): Promise<number> {
+  const conditions: any[] = [eq(events.projectId, projectId)];
+  if (options.search) {
+    const terms = options.search.split(" ").map((w) => `%${w}%`);
+    conditions.push(...terms.map((t) => or(like(events.name, t), like(events.description, t))));
+  }
+  if (options.startDate) conditions.push(gte(events.createdAt, options.startDate));
+  if (options.endDate) conditions.push(lte(events.createdAt, options.endDate));
+  if (options.tags?.length) {
+    for (const tag of options.tags) conditions.push(buildTagCondition(tag));
+  }
+  const [{ count }] = await db
+    .select({ count: sql<number>`COUNT(*)` })
+    .from(events)
+    .innerJoin(
+      channels,
+      and(eq(events.channelId, channels.id), eq(events.projectId, channels.projectId)),
+    )
+    .where(and(...conditions));
+  return count;
+}
+
 export async function getEvent(
   eventId: number,
   userId?: number,

--- a/src/pages/api/events/channel/[channelID]/count.ts
+++ b/src/pages/api/events/channel/[channelID]/count.ts
@@ -1,0 +1,25 @@
+import { countChannelEvents, type TagFilter } from "@/lib/beaver/event";
+
+export async function GET({ params, url }: { params: { channelID: string }; url: URL }) {
+  const channelId = parseInt(params.channelID);
+  const search = url.searchParams.get("search");
+  const startDate = url.searchParams.get("startDate")
+    ? new Date(url.searchParams.get("startDate")!)
+    : undefined;
+  const endDate = url.searchParams.get("endDate")
+    ? new Date(url.searchParams.get("endDate")!)
+    : undefined;
+  let tags: TagFilter[] = [];
+  if (url.searchParams.get("tags")) {
+    try {
+      tags = JSON.parse(url.searchParams.get("tags")!);
+    } catch {}
+  }
+
+  const count = await countChannelEvents(channelId, { search, startDate, endDate, tags });
+  return new Response(JSON.stringify({ count }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/events/project/[projectID]/count.ts
+++ b/src/pages/api/events/project/[projectID]/count.ts
@@ -1,0 +1,25 @@
+import { countProjectEvents, type TagFilter } from "@/lib/beaver/event";
+
+export async function GET({ params, url }: { params: { projectID: string }; url: URL }) {
+  const projectId = parseInt(params.projectID);
+  const search = url.searchParams.get("search");
+  const startDate = url.searchParams.get("startDate")
+    ? new Date(url.searchParams.get("startDate")!)
+    : undefined;
+  const endDate = url.searchParams.get("endDate")
+    ? new Date(url.searchParams.get("endDate")!)
+    : undefined;
+  let tags: TagFilter[] = [];
+  if (url.searchParams.get("tags")) {
+    try {
+      tags = JSON.parse(url.searchParams.get("tags")!);
+    } catch {}
+  }
+
+  const count = await countProjectEvents(projectId, { search, startDate, endDate, tags });
+  return new Response(JSON.stringify({ count }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;


### PR DESCRIPTION
## Summary

* Adds `countChannelEvents` and `countProjectEvents` to the event lib using the same filter conditions as the existing queries
* New API endpoints: `GET /api/events/channel/[channelID]/count` and `GET /api/events/project/[projectID]/count`
* Event feed header shows a badge with the total event count, scoped to any active filters (search, date range, tags)
* Count refreshes whenever filters change

## Issues

Closes #101