### PR TITLE
fix: back to feed fallback when event detail opened in new tab

### DIFF
--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -69,7 +69,7 @@ export default function EventDetail({ event }: { event: EventWithChannelName }) 
   }, [event.id]);
 
   const handleBack = () => {
-    if (window.history.length > 1) {
+    if (sessionStorage.getItem("beaver:hasInAppNav") === "1") {
       window.history.back();
     } else {
       window.location.href = `/dashboard/${event.projectId}/feed`;

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -54,6 +54,9 @@ const userRole = user.isAdmin
       }
       applyStoredTheme();
       document.addEventListener("astro:after-swap", applyStoredTheme);
+      document.addEventListener("astro:before-preparation", () => {
+        sessionStorage.setItem("beaver:hasInAppNav", "1");
+      });
     </script>
     <script is:inline define:vars={{ projectID }}>
       localStorage.setItem("lastProjectId", projectID);


### PR DESCRIPTION
## Summary
- Track in-app navigations via a `sessionStorage` flag set on Astro's `astro:before-preparation` event
- `Back to feed` on the event detail page now uses `history.back()` only when an in-app navigation has occurred in the current tab; otherwise falls back to `/dashboard/{projectId}/feed`
- Previous `window.history.length > 1` heuristic was unreliable because browsers typically include the new-tab/blank entry in history, so the fallback never fired when pasting an event link in a new tab

## Issue
Resolves #176

## Test plan
- [x] Open event link in a new tab → `Back to feed` navigates to the project feed (not the empty tab)
- [x] Click into an event from the feed → `Back to feed` returns to the feed
- [x] Click into an event from bookmarks/channel → `Back to feed` returns to the prior page