### PR TITLE
feat: apply new feed header layout to bookmarks page

### DIFF
--- a/src/components/bookmarks-feed.tsx
+++ b/src/components/bookmarks-feed.tsx
@@ -89,42 +89,38 @@ export default function BookmarksFeed({
   return (
     <div className="w-full flex flex-col">
       {/* Header */}
-      <div className="w-full flex flex-col md:flex-row md:items-center justify-between p-4 md:p-8 border-b gap-4">
+      <div className="w-full flex flex-col p-4 md:p-8 border-b gap-4">
         <h1 className="text-2xl font-semibold">Bookmarks</h1>
-        <div className="flex flex-col gap-2">
-          <div className="flex flex-wrap gap-2 items-center justify-end">
-            <Select value={channelId ?? "all"} onValueChange={handleChannelFilter}>
-              <SelectTrigger className="w-[160px]">
-                <SelectValue placeholder="All channels" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All channels</SelectItem>
-                {channels.map((c) => (
-                  <SelectItem key={c.id} value={String(c.id)}>
-                    # {c.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <EventFilterDialog
-              type="project"
-              projectID={projectID}
-              currentStartDate={startDate ?? null}
-              currentEndDate={endDate ?? null}
-              currentTags={parsedTags}
-              onApplyFilters={handleApplyFilters}
-            />
-          </div>
-          <div className="flex gap-2 items-center">
-            <EventSearchBar
-              type="project"
-              projectID={projectID}
-              title={title ?? null}
-              object={object ?? null}
-              action={action ?? null}
-              onApply={handleSearchApply}
-            />
-          </div>
+        <EventSearchBar
+          type="project"
+          projectID={projectID}
+          title={title ?? null}
+          object={object ?? null}
+          action={action ?? null}
+          onApply={handleSearchApply}
+        />
+        <div className="flex flex-wrap gap-2 items-center">
+          <Select value={channelId ?? "all"} onValueChange={handleChannelFilter}>
+            <SelectTrigger className="flex-1 sm:flex-none sm:w-[160px]">
+              <SelectValue placeholder="All channels" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All channels</SelectItem>
+              {channels.map((c) => (
+                <SelectItem key={c.id} value={String(c.id)}>
+                  # {c.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <EventFilterDialog
+            type="project"
+            projectID={projectID}
+            currentStartDate={startDate ?? null}
+            currentEndDate={endDate ?? null}
+            currentTags={parsedTags}
+            onApplyFilters={handleApplyFilters}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Restructured the bookmarks page header in `bookmarks-feed.tsx` to mirror the feed/channel layout: h1 on top, full-width `EventSearchBar` on its own row, filter row below with the channel select + `EventFilterDialog`
- Channel select gets `flex-1 sm:flex-none sm:w-[160px]` so it shares one row with the filter dialog on mobile, matching feed behavior

## Issue
Resolves #178

## Test plan
- [x] `/dashboard/<projectID>/bookmarks` header matches the feed page visually
- [x] On mobile width, the channel select grows with `flex-1` and the filter dialog sits beside it on one row
- [x] Search, channel filter, and event filters still apply correctly