### PR TITLE
feat: add role descriptions to project member role assignment

### DIFF
--- a/src/components/project-members.tsx
+++ b/src/components/project-members.tsx
@@ -3,9 +3,47 @@ import { Button } from "./ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
-import { UserMinusIcon, UserPlusIcon } from "lucide-react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon, UserMinusIcon, UserPlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 type Role = "owner" | "maintainer" | "guest";
+
+const ROLE_INFO: Record<Role, { label: string; description: string }> = {
+  owner: {
+    label: "Owner",
+    description: "Full control: manage members, project settings, channels, and events.",
+  },
+  maintainer: {
+    label: "Maintainer",
+    description: "Manage channels and channel groups; view all events.",
+  },
+  guest: {
+    label: "Guest",
+    description: "View-only access to channels and events.",
+  },
+};
+
+function RoleSelectItem({ role }: { role: Role }) {
+  const info = ROLE_INFO[role];
+  return (
+    <SelectPrimitive.Item
+      value={role}
+      textValue={info.label}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default flex-col items-start gap-0.5 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      )}
+    >
+      <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{info.label}</SelectPrimitive.ItemText>
+      <span className="text-xs text-muted-foreground pr-2">{info.description}</span>
+    </SelectPrimitive.Item>
+  );
+}
 
 type Member = {
   id: number;
@@ -124,9 +162,9 @@ export default function ProjectMembers({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="owner">Owner</SelectItem>
-                  <SelectItem value="maintainer">Maintainer</SelectItem>
-                  <SelectItem value="guest">Guest</SelectItem>
+                  <RoleSelectItem role="owner" />
+                  <RoleSelectItem role="maintainer" />
+                  <RoleSelectItem role="guest" />
                 </SelectContent>
               </Select>
               {member.userId !== currentUserId && (
@@ -190,9 +228,9 @@ export default function ProjectMembers({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="owner">Owner</SelectItem>
-                  <SelectItem value="maintainer">Maintainer</SelectItem>
-                  <SelectItem value="guest">Guest</SelectItem>
+                  <RoleSelectItem role="owner" />
+                  <RoleSelectItem role="maintainer" />
+                  <RoleSelectItem role="guest" />
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
## Summary
- Added a `ROLE_INFO` map with a short description of each role's abilities (owner / maintainer / guest), derived from existing role gates in the codebase
- New `RoleSelectItem` component renders each role option as the label plus a small muted description line below — only inside the dropdown, not in the trigger (uses Radix's `textValue` so the trigger still shows just the role label)
- Both `<Select>` instances in `src/components/project-members.tsx` now use `RoleSelectItem` — the inline role-change Select on each member row, and the role Select in the Add Member dialog
- `admin-users-view.tsx` only has the binary `isAdmin` toggle, not the owner/maintainer/guest scale, so it's untouched. Project assignment during user creation lives in #131

## Issue
Resolves #132

## Test plan
- [x] Project settings → Members: opening the role dropdown on a member row shows label + description per option
- [x] Selecting an option updates the trigger to show only the role label
- [x] Add Member dialog: role dropdown shows the same layout
- [ ] Typeahead in the dropdown still matches role label (via `textValue`)