### PR TITLE
feat: batch event ingestion on POST /api/event

### DIFF
--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -572,10 +572,9 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
               Batch Events
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
-              Pass an array of up to{" "}
-              <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">100</code> event objects
-              to ingest them in a single request. The batch is atomic — if any event fails
-              validation or insertion, the entire batch is rejected and nothing is written.
+              Pass an array of event objects to ingest them in a single request. The batch is atomic
+              — if any event fails validation or insertion, the entire batch is rejected and nothing
+              is written.
             </p>
             <div className="mb-8">
               <CodeBlock
@@ -652,13 +651,6 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 language="json"
                 code={`{
   "error": "X-API-Key header is required."
-}`}
-              />
-              <CodeBlock
-                title="400 Bad Request - Batch too large"
-                language="json"
-                code={`{
-  "error": "Batch size cannot exceed 100 events."
 }`}
               />
             </div>

--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -139,8 +139,9 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
       children: [
         { id: "request-headers", title: "Request Headers" },
         { id: "request-body", title: "Request Body" },
-        { id: "example-request", title: "Example Request" },
-        { id: "success-response", title: "Success Response" },
+        { id: "example-request", title: "Single Event" },
+        { id: "batch-request", title: "Batch Events" },
+        { id: "success-response", title: "Response Format" },
         { id: "error-responses", title: "Error Responses" },
       ],
     },
@@ -281,7 +282,9 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
               Create Event
             </h2>
             <p className="text-gray-600 dark:text-gray-400 mb-6 text-lg leading-relaxed">
-              Send events to a specific channel in your project.
+              Send one event or a batch of up to 100 events to channels in your project. The
+              endpoint accepts either a single event object or an array — the response is always an
+              array of per-event results.
             </p>
             <div className="bg-blue-50 dark:bg-blue-500/10 border border-blue-200 dark:border-blue-500/20 rounded-xl p-5 mb-6">
               <p className="text-blue-800 dark:text-blue-300 font-semibold mb-2">
@@ -533,16 +536,16 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
               </table>
             </div>
 
-            {/* Example Request */}
+            {/* Single Event Example */}
             <h3
               id="example-request"
               className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4"
             >
-              Example Request
+              Single Event
             </h3>
             <div className="mb-8">
               <CodeBlock
-                title="cURL"
+                title="cURL — single event"
                 language="bash"
                 code={`curl -X POST ${baseUrl}/api/event \\
   -H "Content-Type: application/json" \\
@@ -561,32 +564,85 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
               />
             </div>
 
-            {/* Success Response */}
+            {/* Batch Example */}
+            <h3
+              id="batch-request"
+              className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4"
+            >
+              Batch Events
+            </h3>
+            <p className="text-gray-600 dark:text-gray-400 mb-4">
+              Pass an array of up to{" "}
+              <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">100</code> event objects
+              to ingest them in a single request. Each item is processed independently — a failure
+              on one does not affect the others.
+            </p>
+            <div className="mb-8">
+              <CodeBlock
+                title="cURL — batch"
+                language="bash"
+                code={`curl -X POST ${baseUrl}/api/event \\
+  -H "Content-Type: application/json" \\
+  -H "X-API-Key: ${displayKey}" \\
+  -d '[
+    {
+      "name": "user.signed_up",
+      "title": "Alice registered",
+      "channel": "signups"
+    },
+    {
+      "name": "payment.completed",
+      "title": "Alice paid $99.99",
+      "channel": "payments",
+      "tags": { "amount": 99.99 }
+    }
+  ]'`}
+              />
+            </div>
+
+            {/* Response Format */}
             <h3
               id="success-response"
               className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4"
             >
-              Success Response
+              Response Format
             </h3>
-            <div className="mb-8">
+            <p className="text-gray-600 dark:text-gray-400 mb-4">
+              The response is always an array — one entry per input event. Each entry has an{" "}
+              <code className="bg-gray-100 dark:bg-white/10 px-1 rounded text-pink-600 dark:text-pink-400">
+                ok
+              </code>{" "}
+              field indicating success or failure.
+            </p>
+            <div className="space-y-4 mb-8">
               <CodeBlock
-                title="200 OK"
+                title="200 OK — all succeeded"
                 language="json"
-                code={`{
-  "id": 123,
-  "eventObject": "user",
-  "eventAction": "signed_up",
-  "title": "New user registered via Google",
-  "description": "New user registration",
-  "icon": "🎉",
-  "tags": {
-    "plan": "premium",
-    "source": "landing-page"
-  },
-  "projectId": 1,
-  "channelName": "signups",
-  "createdAt": "2024-01-15T10:30:00.000Z"
-}`}
+                code={`[
+  {
+    "ok": true,
+    "event": {
+      "id": 123,
+      "eventObject": "user",
+      "eventAction": "signed_up",
+      "title": "Alice registered",
+      "description": null,
+      "icon": null,
+      "tags": {},
+      "projectId": 1,
+      "channelName": "signups",
+      "createdAt": "2024-01-15T10:30:00.000Z"
+    }
+  }
+]`}
+              />
+              <CodeBlock
+                title="200 OK — partial failure (batch)"
+                language="json"
+                code={`[
+  { "ok": true, "event": { "id": 123, ... } },
+  { "ok": false, "error": "Channel with name unknown does not exist." }
+]`}
               />
             </div>
 
@@ -597,6 +653,14 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
             >
               Error Responses
             </h3>
+            <p className="text-gray-600 dark:text-gray-400 mb-4">
+              These top-level errors are returned when the request itself is invalid (missing auth,
+              oversized batch). Per-event errors are returned inline in the results array with{" "}
+              <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">
+                {"{ ok: false, error }"}
+              </code>
+              .
+            </p>
             <div className="space-y-4">
               <CodeBlock
                 title="401 Unauthorized - Missing API key"
@@ -606,45 +670,10 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
 }`}
               />
               <CodeBlock
-                title="400 Bad Request - Missing required field"
+                title="400 Bad Request - Batch too large"
                 language="json"
                 code={`{
-  "error": "name is a required field."
-}`}
-              />
-              <CodeBlock
-                title="400 Bad Request - Missing title"
-                language="json"
-                code={`{
-  "error": "title is a required field."
-}`}
-              />
-              <CodeBlock
-                title="400 Bad Request - Non-conforming name"
-                language="json"
-                code={`{
-  "error": "name must follow the object.action convention (e.g. server.status_changed)."
-}`}
-              />
-              <CodeBlock
-                title="400 Bad Request - Reserved object"
-                language="json"
-                code={`{
-  "error": "'legacy' is a reserved object name."
-}`}
-              />
-              <CodeBlock
-                title="400 Bad Request - Invalid tags format"
-                language="json"
-                code={`{
-  "error": "tags object is not valid JSON."
-}`}
-              />
-              <CodeBlock
-                title="500 Internal Server Error - Invalid API key or channel"
-                language="json"
-                code={`{
-  "error": "Channel not found for the given API key."
+  "error": "Batch size cannot exceed 100 events."
 }`}
               />
             </div>
@@ -1160,41 +1189,42 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                   </span>
                   JavaScript / Node.js
                 </h3>
-                <CodeBlock
-                  title="sendEvent.js"
-                  language="javascript"
-                  code={`const API_KEY = '${displayKey}';
+                <div className="space-y-4">
+                  <CodeBlock
+                    title="sendEvent.js"
+                    language="javascript"
+                    code={`const API_KEY = '${displayKey}';
 
-async function sendEvent(eventData) {
+// Send one event or an array of events — always returns an array of results.
+async function sendEvent(events) {
   const response = await fetch('${baseUrl}/api/event', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       'X-API-Key': API_KEY,
     },
-    body: JSON.stringify({
-      name: eventData.name,
-      title: eventData.title,
-      channel: eventData.channel,
-      description: eventData.description,
-      icon: eventData.icon,
-      tags: eventData.tags,
-    }),
+    body: JSON.stringify(events),
   });
 
   return response.json();
 }
 
-// Usage
+// Single event
 await sendEvent({
   name: 'payment.completed',
   title: 'Customer paid $99.99',
   channel: 'payments',
-  description: 'Customer completed checkout',
   icon: '💰',
-  tags: { amount: '99.99', currency: 'USD' }
-});`}
-                />
+  tags: { amount: 99.99, currency: 'USD' }
+});
+
+// Batch
+await sendEvent([
+  { name: 'user.signed_up',      title: 'Alice registered',    channel: 'signups' },
+  { name: 'payment.completed',   title: 'Alice paid $99.99',   channel: 'payments' },
+]);`}
+                  />
+                </div>
               </div>
 
               <div id="python">

--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -574,8 +574,8 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
             <p className="text-gray-600 dark:text-gray-400 mb-4">
               Pass an array of up to{" "}
               <code className="bg-gray-100 dark:bg-white/10 px-1 rounded">100</code> event objects
-              to ingest them in a single request. Each item is processed independently — a failure
-              on one does not affect the others.
+              to ingest them in a single request. The batch is atomic — if any event fails
+              validation or insertion, the entire batch is rejected and nothing is written.
             </p>
             <div className="mb-8">
               <CodeBlock
@@ -608,11 +608,7 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
               Response Format
             </h3>
             <p className="text-gray-600 dark:text-gray-400 mb-4">
-              The response is always an array — one entry per input event. Each entry has an{" "}
-              <code className="bg-gray-100 dark:bg-white/10 px-1 rounded text-pink-600 dark:text-pink-400">
-                ok
-              </code>{" "}
-              field indicating success or failure.
+              On success the response is always an array — one created event object per input.
             </p>
             <div className="space-y-4 mb-8">
               <CodeBlock
@@ -620,28 +616,17 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 language="json"
                 code={`[
   {
-    "ok": true,
-    "event": {
-      "id": 123,
-      "eventObject": "user",
-      "eventAction": "signed_up",
-      "title": "Alice registered",
-      "description": null,
-      "icon": null,
-      "tags": {},
-      "projectId": 1,
-      "channelName": "signups",
-      "createdAt": "2024-01-15T10:30:00.000Z"
-    }
+    "id": 123,
+    "eventObject": "user",
+    "eventAction": "signed_up",
+    "title": "Alice registered",
+    "description": null,
+    "icon": null,
+    "tags": {},
+    "projectId": 1,
+    "channelName": "signups",
+    "createdAt": "2024-01-15T10:30:00.000Z"
   }
-]`}
-              />
-              <CodeBlock
-                title="200 OK — partial failure (batch)"
-                language="json"
-                code={`[
-  { "ok": true, "event": { "id": 123, ... } },
-  { "ok": false, "error": "Channel with name unknown does not exist." }
 ]`}
               />
             </div>

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -1,72 +1,35 @@
-import { createEvent, EVENT_NAME_REGEX, RESERVED_OBJECT } from "@/lib/beaver/event";
+import { db } from "@/lib/db/db";
+import { events, channels, eventTags } from "@/lib/db/schema";
+import { EVENT_NAME_REGEX, RESERVED_OBJECT } from "@/lib/beaver/event";
 import { getProject } from "@/lib/beaver/project";
 import { getNotificationEmails } from "@/lib/beaver/user";
 import { sendEventNotification } from "@/lib/email/resend";
+import { eq } from "drizzle-orm";
 import type { APIContext, APIRoute } from "astro";
 
 const MAX_BATCH_SIZE = 100;
 
 type EventPayload = Record<string, unknown>;
 
-async function processOne(payload: EventPayload, apiKey: string) {
-  const { name, title, description, icon, channel, tags, notify } = payload;
+function validate(payload: EventPayload): string | null {
+  const { name, title, channel, tags } = payload;
 
-  if (!name) {
-    return { ok: false as const, error: "name is a required field." };
-  }
-  if (typeof name !== "string" || !EVENT_NAME_REGEX.test(name)) {
-    return {
-      ok: false as const,
-      error: "name must follow the object.action convention (e.g. server.status_changed).",
-    };
-  }
-  if (name.split(".")[0] === RESERVED_OBJECT) {
-    return { ok: false as const, error: "'legacy' is a reserved object name." };
-  }
-  if (!title || typeof title !== "string" || title.trim() === "") {
-    return { ok: false as const, error: "title is a required field." };
-  }
-  if (!channel) {
-    return { ok: false as const, error: "channel is a required field." };
-  }
-
-  let tagObj;
-  if (tags) {
+  if (!name) return "name is a required field.";
+  if (typeof name !== "string" || !EVENT_NAME_REGEX.test(name))
+    return "name must follow the object.action convention (e.g. server.status_changed).";
+  if (name.split(".")[0] === RESERVED_OBJECT) return "'legacy' is a reserved object name.";
+  if (!title || typeof title !== "string" || title.trim() === "")
+    return "title is a required field.";
+  if (!channel) return "channel is a required field.";
+  if (tags !== undefined && tags !== null) {
     try {
-      tagObj = typeof tags === "string" ? JSON.parse(tags) : tags;
+      if (typeof tags === "string") JSON.parse(tags);
+      else if (typeof tags !== "object") return "tags must be an object.";
     } catch {
-      return { ok: false as const, error: "tags object is not valid JSON." };
+      return "tags object is not valid JSON.";
     }
   }
-
-  try {
-    const event = await createEvent({
-      name,
-      title,
-      description: typeof description === "string" ? description : undefined,
-      icon: typeof icon === "string" ? icon : undefined,
-      channel: channel as string,
-      apiKey,
-      tags: tagObj,
-    });
-
-    if (notify === true) {
-      const emails = await getNotificationEmails(event.projectId);
-      if (emails.length > 0) {
-        const project = await getProject(event.projectId);
-        if (project) {
-          sendEventNotification(event, project.name, emails).catch(() => {});
-        }
-      }
-    }
-
-    return { ok: true as const, event };
-  } catch (err) {
-    return {
-      ok: false as const,
-      error: err instanceof Error ? err.message : "An unknown error has occurred.",
-    };
-  }
+  return null;
 }
 
 export const POST: APIRoute = async ({ request }: APIContext) => {
@@ -90,9 +53,100 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
       );
     }
 
-    const results = await Promise.all(payloads.map((p) => processOne(p, apiKey)));
+    // Validate all payloads before touching the DB
+    for (let i = 0; i < payloads.length; i++) {
+      const err = validate(payloads[i]);
+      if (err) {
+        const msg = payloads.length > 1 ? `Event at index ${i}: ${err}` : err;
+        return new Response(JSON.stringify({ error: msg }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
 
-    return new Response(JSON.stringify(results), {
+    // Resolve channels and verify API key (reads, before transaction)
+    const resolved = await Promise.all(
+      payloads.map(async (p) => {
+        const channelName = p.channel as string;
+        const channelsRes = await db.select().from(channels).where(eq(channels.name, channelName));
+        if (channelsRes.length === 0) throw new Error(`Channel '${channelName}' does not exist.`);
+        const channel = channelsRes[0];
+        const project = await getProject(channel.projectId);
+        if (project.apiKey !== apiKey) throw new Error("Invalid API key.");
+        return { channel, project, payload: p };
+      }),
+    );
+
+    // Insert all events and their tags atomically
+    const created = await db.transaction(async (tx) => {
+      return Promise.all(
+        resolved.map(async ({ channel, project, payload }) => {
+          const [eventObject, eventAction] = (payload.name as string).split(".");
+          const title = payload.title as string;
+          const description =
+            typeof payload.description === "string" ? payload.description : undefined;
+          const icon = typeof payload.icon === "string" ? payload.icon : undefined;
+
+          const [event] = await tx
+            .insert(events)
+            .values({
+              eventObject,
+              eventAction,
+              title,
+              description,
+              icon,
+              projectId: project.id,
+              channelId: channel.id,
+            })
+            .returning();
+
+          let tags: Record<string, string | number | boolean> = {};
+          const rawTags = payload.tags;
+          if (rawTags) {
+            tags =
+              typeof rawTags === "string"
+                ? JSON.parse(rawTags)
+                : (rawTags as Record<string, string | number | boolean>);
+            const tagEntries = Object.entries(tags).map(([key, value]) => ({
+              eventId: event.id,
+              key,
+              value: String(value),
+              type: typeof value as "string" | "number" | "boolean",
+            }));
+            await tx.insert(eventTags).values(tagEntries);
+          }
+
+          return {
+            id: event.id,
+            eventObject: event.eventObject,
+            eventAction: event.eventAction,
+            title: event.title,
+            icon: event.icon,
+            description: event.description,
+            tags,
+            projectId: project.id,
+            channelName: channel.name,
+            createdAt: event.createdAt,
+            read: false,
+            bookmarked: false,
+          };
+        }),
+      );
+    });
+
+    // Fire notifications outside the transaction
+    created.forEach((event, i) => {
+      if (resolved[i].payload.notify === true) {
+        getNotificationEmails(event.projectId).then((emails) => {
+          if (emails.length > 0) {
+            sendEventNotification(event, resolved[i].project.name, emails).catch(() => {});
+          }
+        });
+      }
+    });
+
+    return new Response(JSON.stringify(created), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -7,8 +7,6 @@ import { sendEventNotification } from "@/lib/email/resend";
 import { eq } from "drizzle-orm";
 import type { APIContext, APIRoute } from "astro";
 
-const MAX_BATCH_SIZE = 100;
-
 type EventPayload = Record<string, unknown>;
 
 function validate(payload: EventPayload): string | null {
@@ -45,13 +43,6 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
 
     const body = await request.json();
     const payloads: EventPayload[] = Array.isArray(body) ? body : [body];
-
-    if (payloads.length > MAX_BATCH_SIZE) {
-      return new Response(
-        JSON.stringify({ error: `Batch size cannot exceed ${MAX_BATCH_SIZE} events.` }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
-    }
 
     // Validate all payloads before touching the DB
     for (let i = 0; i < payloads.length; i++) {

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -4,75 +4,48 @@ import { getNotificationEmails } from "@/lib/beaver/user";
 import { sendEventNotification } from "@/lib/email/resend";
 import type { APIContext, APIRoute } from "astro";
 
-export const POST: APIRoute = async ({ request }: APIContext) => {
+const MAX_BATCH_SIZE = 100;
+
+type EventPayload = Record<string, unknown>;
+
+async function processOne(payload: EventPayload, apiKey: string) {
+  const { name, title, description, icon, channel, tags, notify } = payload;
+
+  if (!name) {
+    return { ok: false as const, error: "name is a required field." };
+  }
+  if (typeof name !== "string" || !EVENT_NAME_REGEX.test(name)) {
+    return {
+      ok: false as const,
+      error: "name must follow the object.action convention (e.g. server.status_changed).",
+    };
+  }
+  if (name.split(".")[0] === RESERVED_OBJECT) {
+    return { ok: false as const, error: "'legacy' is a reserved object name." };
+  }
+  if (!title || typeof title !== "string" || title.trim() === "") {
+    return { ok: false as const, error: "title is a required field." };
+  }
+  if (!channel) {
+    return { ok: false as const, error: "channel is a required field." };
+  }
+
+  let tagObj;
+  if (tags) {
+    try {
+      tagObj = typeof tags === "string" ? JSON.parse(tags) : tags;
+    } catch {
+      return { ok: false as const, error: "tags object is not valid JSON." };
+    }
+  }
+
   try {
-    const apiKey = request.headers.get("X-API-Key");
-
-    if (!apiKey) {
-      return new Response(JSON.stringify({ error: "X-API-Key header is required." }), {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    const { name, title, description, icon, channel, tags, notify } = await request.json();
-
-    if (!name) {
-      return new Response(JSON.stringify({ error: "name is a required field." }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    if (typeof name !== "string" || !EVENT_NAME_REGEX.test(name)) {
-      return new Response(
-        JSON.stringify({
-          error: "name must follow the object.action convention (e.g. server.status_changed).",
-        }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
-    }
-    if (name.split(".")[0] === RESERVED_OBJECT) {
-      return new Response(JSON.stringify({ error: "'legacy' is a reserved object name." }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    if (!title || typeof title !== "string" || title.trim() === "") {
-      return new Response(JSON.stringify({ error: "title is a required field." }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    if (!channel) {
-      return new Response(JSON.stringify({ error: "channel is a required field." }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    let tagObj;
-
-    if (tags) {
-      try {
-        if (typeof tags === "string") {
-          tagObj = JSON.parse(tags);
-        } else {
-          tagObj = tags;
-        }
-      } catch {
-        return new Response(JSON.stringify({ error: "tags object is not valid JSON." }), {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-    }
-
     const event = await createEvent({
       name,
       title,
-      description,
-      icon,
-      channel,
+      description: typeof description === "string" ? description : undefined,
+      icon: typeof icon === "string" ? icon : undefined,
+      channel: channel as string,
       apiKey,
       tags: tagObj,
     });
@@ -87,7 +60,39 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
       }
     }
 
-    return new Response(JSON.stringify(event), {
+    return { ok: true as const, event };
+  } catch (err) {
+    return {
+      ok: false as const,
+      error: err instanceof Error ? err.message : "An unknown error has occurred.",
+    };
+  }
+}
+
+export const POST: APIRoute = async ({ request }: APIContext) => {
+  try {
+    const apiKey = request.headers.get("X-API-Key");
+
+    if (!apiKey) {
+      return new Response(JSON.stringify({ error: "X-API-Key header is required." }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    const body = await request.json();
+    const payloads: EventPayload[] = Array.isArray(body) ? body : [body];
+
+    if (payloads.length > MAX_BATCH_SIZE) {
+      return new Response(
+        JSON.stringify({ error: `Batch size cannot exceed ${MAX_BATCH_SIZE} events.` }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    const results = await Promise.all(payloads.map((p) => processOne(p, apiKey)));
+
+    return new Response(JSON.stringify(results), {
       status: 200,
       headers: { "Content-Type": "application/json" },
     });
@@ -99,7 +104,7 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
       });
     }
     console.error(err);
-    return new Response(JSON.stringify({ error: "An unkown error has occurred." }), {
+    return new Response(JSON.stringify({ error: "An unknown error has occurred." }), {
       status: 500,
       headers: { "Content-Type": "application/json" },
     });


### PR DESCRIPTION
Closes #113

## What changed

`POST /api/event` now accepts either a single event object or an array of events — the response is always an array of the created events.

Batches are **atomic**: all events are validated upfront and inserted in a single SQLite transaction. If anything fails, nothing is written.

## Why

High-throughput use cases (e.g. flushing a buffer of events from a background worker) would otherwise require one HTTP round-trip per event. A batch endpoint cuts that to one request regardless of how many events are in the payload, with no risk of partial writes leaving the DB in an inconsistent state.