### PR TITLE
feat: hide API key by default with reveal toggle

### DIFF
--- a/src/components/api-docs-view.tsx
+++ b/src/components/api-docs-view.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Highlight, themes } from "prism-react-renderer";
-import { CheckIcon, CopyIcon, TerminalIcon } from "lucide-react";
+import { CheckIcon, CopyIcon, EyeIcon, EyeOffIcon, TerminalIcon } from "lucide-react";
 
 interface CodeBlockProps {
   code: string;
@@ -127,8 +127,13 @@ function MethodBadge({ method }: { method: string }) {
 }
 
 export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
-  const displayKey = apiKey;
-  const baseUrl = typeof window !== "undefined" ? window.location.origin : "";
+  const [revealed, setRevealed] = useState(false);
+  const [baseUrl, setBaseUrl] = useState("");
+  const displayKey = revealed ? apiKey : "YOUR_API_KEY";
+
+  useEffect(() => {
+    setBaseUrl(window.location.origin);
+  }, []);
 
   const sections = [
     { id: "overview", title: "Overview" },
@@ -266,9 +271,18 @@ export default function ApiDocsView({ apiKey }: ApiDocsViewProps) {
                 </span>
                 <Badge variant="warning">Keep this secret</Badge>
               </div>
-              <code className="block font-mono text-amber-900 dark:text-amber-300 bg-white/60 dark:bg-white/10 px-4 py-3 rounded-lg text-sm break-all">
-                {displayKey}
-              </code>
+              <div className="flex items-center gap-2 bg-white/60 dark:bg-white/10 px-4 py-3 rounded-lg overflow-hidden">
+                <code className="font-mono text-amber-900 dark:text-amber-300 text-sm truncate flex-1">
+                  {revealed ? apiKey : "•".repeat(apiKey.length)}
+                </code>
+                <button
+                  onClick={() => setRevealed((r) => !r)}
+                  className="shrink-0 p-1 rounded text-amber-700 dark:text-amber-400 hover:text-amber-900 dark:hover:text-amber-200 transition-colors"
+                  aria-label={revealed ? "Hide API key" : "Reveal API key"}
+                >
+                  {revealed ? <EyeOffIcon size={16} /> : <EyeIcon size={16} />}
+                </button>
+              </div>
             </div>
             <div className="bg-gray-900 rounded-xl p-4">
               <code className="text-gray-100 font-mono text-sm">X-API-Key: {displayKey}</code>

--- a/src/components/api-key.tsx
+++ b/src/components/api-key.tsx
@@ -1,5 +1,5 @@
 import type { Project } from "@/lib/beaver/project";
-import { CheckIcon, ClipboardIcon, RefreshCwIcon } from "lucide-react";
+import { CheckIcon, ClipboardIcon, EyeIcon, EyeOffIcon, RefreshCwIcon } from "lucide-react";
 import { useState } from "react";
 import { Button } from "./ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./ui/dialog";
@@ -10,6 +10,7 @@ const CONFIRM_PHRASE = "rotate api key";
 
 export default function APIKey({ project }: { project: Project }) {
   const [apiKey, setApiKey] = useState(project.apiKey);
+  const [revealed, setRevealed] = useState(false);
   const [copied, setCopied] = useState(false);
   const [rotateOpen, setRotateOpen] = useState(false);
   const [confirmText, setConfirmText] = useState("");
@@ -37,6 +38,7 @@ export default function APIKey({ project }: { project: Project }) {
         return;
       }
       setApiKey(data.apiKey);
+      setRevealed(false);
       setRotateOpen(false);
       setConfirmText("");
     } finally {
@@ -48,7 +50,20 @@ export default function APIKey({ project }: { project: Project }) {
     <TooltipProvider delayDuration={300}>
       <div className="flex items-center gap-2 min-w-0 max-w-full">
         <div className="border px-3 py-1.5 rounded flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
-          <p className="font-mono text-sm truncate min-w-0">{apiKey}</p>
+          <p className="font-mono text-sm truncate min-w-0">
+            {revealed ? apiKey : "•".repeat(apiKey.length)}
+          </p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => setRevealed((r) => !r)}
+                className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+              >
+                {revealed ? <EyeOffIcon size={14} /> : <EyeIcon size={14} />}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{revealed ? "Hide" : "Reveal"}</TooltipContent>
+          </Tooltip>
           <Tooltip>
             <TooltipTrigger asChild>
               <button


### PR DESCRIPTION
Closes #135

API keys are now hidden by default behind bullet placeholders. An eye icon toggles visibility in both the settings page and the API docs page. The docs page also fixes a pre-existing hydration mismatch (`baseUrl` was reading `window.location.origin` during SSR render) that was preventing React from attaching event handlers.