### PR TITLE
feat: tabulate project settings page

### DIFF
--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -1,0 +1,106 @@
+import type { Channel } from "@/lib/beaver/channel";
+import type { MetricWithValue } from "@/lib/beaver/metric";
+import type { Project } from "@/lib/beaver/project";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
+import APIKey from "./api-key";
+import ChangePasswordForm from "./change-password-form";
+import ChannelSettings from "./channel-settings";
+import MetricSettings from "./metric-settings";
+import NotificationSettings from "./notification-settings";
+import ProjectDangerZone from "./project-danger-zone";
+import ProjectMembers from "./project-members";
+import ProjectRename from "./project-rename";
+
+interface Props {
+  project: Project;
+  channels: Channel[];
+  metrics: MetricWithValue[];
+  isOwner: boolean;
+  currentUserId: number;
+  initialEmail: string | null;
+  initialEnabled: boolean;
+}
+
+const row = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
+const label = "font-medium shrink-0";
+
+export default function SettingsTabs({
+  project,
+  channels,
+  metrics,
+  isOwner,
+  currentUserId,
+  initialEmail,
+  initialEnabled,
+}: Props) {
+  const createdAt = project.createdAt ? new Date(project.createdAt).toLocaleDateString() : "—";
+
+  return (
+    <Tabs defaultValue={isOwner ? "general" : "channels"} className="w-full">
+      <TabsList className="mb-6 mt-6 md:mt-0 flex flex-wrap h-auto w-auto gap-1">
+        {isOwner && <TabsTrigger value="general">General</TabsTrigger>}
+        <TabsTrigger value="channels">Channels</TabsTrigger>
+        {isOwner && <TabsTrigger value="members">Members</TabsTrigger>}
+        <TabsTrigger value="metrics">Metrics</TabsTrigger>
+        <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        <TabsTrigger value="account">Account</TabsTrigger>
+        {isOwner && (
+          <TabsTrigger value="danger" className="text-destructive">
+            Danger Zone
+          </TabsTrigger>
+        )}
+      </TabsList>
+
+      {isOwner && (
+        <TabsContent value="general" className="mt-6 md:mt-0">
+          <div className="flex flex-col space-y-4">
+            <div className={row}>
+              <h3 className={label}>Project Name</h3>
+              <ProjectRename project={project} />
+            </div>
+            <div className={row}>
+              <h3 className={label}>Created</h3>
+              <p className="text-muted-foreground">{createdAt}</p>
+            </div>
+            <div className={row}>
+              <h3 className={label}>API Key</h3>
+              <APIKey project={project} />
+            </div>
+          </div>
+        </TabsContent>
+      )}
+
+      <TabsContent value="channels" className="mt-6 md:mt-0">
+        <ChannelSettings channels={channels} project={project} />
+      </TabsContent>
+
+      {isOwner && (
+        <TabsContent value="members" className="mt-6 md:mt-0">
+          <ProjectMembers projectId={project.id} currentUserId={currentUserId} />
+        </TabsContent>
+      )}
+
+      <TabsContent value="metrics" className="mt-6 md:mt-0">
+        <MetricSettings metrics={metrics} projectId={project.id} />
+      </TabsContent>
+
+      <TabsContent value="notifications" className="mt-6 md:mt-0">
+        <NotificationSettings
+          projectId={project.id}
+          initialEmail={initialEmail}
+          initialEnabled={initialEnabled}
+        />
+      </TabsContent>
+
+      <TabsContent value="account" className="mt-6 md:mt-0">
+        <ChangePasswordForm />
+      </TabsContent>
+
+      {isOwner && (
+        <TabsContent value="danger" className="mt-6 md:mt-0">
+          <ProjectDangerZone project={project} />
+        </TabsContent>
+      )}
+    </Tabs>
+  );
+}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Tabs as TabsPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn("group/tabs flex gap-2 data-[orientation=horizontal]:flex-col", className)}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
+        "data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -1,15 +1,8 @@
 ---
-import APIKey from "@/components/api-key";
-import ChangePasswordForm from "@/components/change-password-form";
-import ChannelSettings from "@/components/channel-settings";
-import MetricSettings from "@/components/metric-settings";
-import ProjectDangerZone from "@/components/project-danger-zone";
-import ProjectRename from "@/components/project-rename";
-import ProjectMembers from "@/components/project-members";
-import NotificationSettings from "@/components/notification-settings";
+import SettingsTabs from "@/components/settings-tabs";
 import Layout from "@/layouts/layout.astro";
-import { getChannels } from "@/lib/beaver/channel";
 import { getMetrics } from "@/lib/beaver/metric";
+import { getChannels } from "@/lib/beaver/channel";
 import { getProject } from "@/lib/beaver/project";
 import { getUserProjectRole, getProjectMembership } from "@/lib/beaver/project-member";
 import { getUserByUsername } from "@/lib/beaver/user";
@@ -23,7 +16,6 @@ const userRole = user.isAdmin
   ? "owner"
   : await getUserProjectRole(project.id, user.id);
 
-// Guests cannot access settings
 if (userRole === "guest" || userRole === null) {
   return Astro.redirect(`/dashboard/${projectID}/feed`);
 }
@@ -34,9 +26,6 @@ const dbUser = await getUserByUsername(user.userName);
 const membership = await getProjectMembership(project.id, user.id);
 
 const isOwner = userRole === "owner";
-
-const metaCss = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
-const metaH3Css = "font-medium shrink-0";
 ---
 
 <Layout projectID={projectID!}>
@@ -44,63 +33,19 @@ const metaH3Css = "font-medium shrink-0";
     <div class="p-4 md:p-8 border-b text-2xl font-semibold">
       <h1>Project Settings</h1>
     </div>
-    <div class="w-full flex flex-col items-center mt-8">
-      {isOwner && (
-        <div class="w-full px-4 md:w-3/4 md:px-0 flex flex-col space-y-4">
-          <h2 class="font-mono mb-2">Meta</h2>
-          <div class={metaCss}>
-            <h3 class={metaH3Css}>Project Name</h3>
-            <ProjectRename client:load project={project} />
-          </div>
-          <div class={metaCss}>
-            <h3 class={metaH3Css}>Created</h3>
-            <p>{project.createdAt?.toLocaleDateString()}</p>
-          </div>
-          <div class={metaCss}>
-            <h3 class={metaH3Css}>API Key</h3>
-            <APIKey client:load project={project} />
-          </div>
-        </div>
-      )}
-      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-        <h2 class="font-mono">Channels</h2>
-        <div class="flex flex-col">
-          <ChannelSettings client:load channels={channels} project={project} />
-        </div>
-      </div>
-      {isOwner && (
-        <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-          <h2 class="font-mono mb-4">Members</h2>
-          <ProjectMembers
-            client:load
-            projectId={project.id}
-            currentUserId={user.id}
-          />
-        </div>
-      )}
-      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-        <MetricSettings client:load metrics={metrics} projectId={project.id} />
-      </div>
-      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-        <h2 class="font-mono mb-4">Account</h2>
-        <h3 class="font-medium mb-3">Change Password</h3>
-        <ChangePasswordForm client:load />
-      </div>
-      <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-        <h2 class="font-mono mb-4">Notifications</h2>
-        <NotificationSettings
+    <div class="w-full flex flex-col items-center mt-8 pb-16">
+      <div class="w-full px-4 md:w-3/4 md:px-0">
+        <SettingsTabs
           client:load
-          projectId={project.id}
+          project={project}
+          channels={channels}
+          metrics={metrics}
+          isOwner={isOwner}
+          currentUserId={user.id}
           initialEmail={dbUser?.email ?? null}
           initialEnabled={membership?.notificationsEnabled ?? false}
         />
       </div>
-      {isOwner && (
-        <div class="w-full px-4 md:w-3/4 md:px-0 mt-8">
-          <h2 class="font-mono">Danger Zone</h2>
-          <ProjectDangerZone client:load project={project} />
-        </div>
-      )}
     </div>
   </div>
 </Layout>


### PR DESCRIPTION
Closes #128

Converts the flat settings page into a tabbed layout using shadcn Tabs. Tabs: General, Channels, Members, Metrics, Notifications, Account, and Danger Zone (owner-only tabs are hidden for maintainers). All existing functionality is preserved — the sections are just organized into a single `SettingsTabs` component instead of stacked on one long page.