### PR TITLE
feat: restore feed scroll position when navigating back from event detail

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -300,6 +300,33 @@ export default function EventFeed({
     };
   }, [projectID, channel, title, object, action, startDate, endDate, tags, sortBy, sortOrder]);
 
+  const scrollKey = `feed:scroll:${typeof window !== "undefined" ? window.location.pathname + window.location.search : ""}`;
+
+  useEffect(() => {
+    const saveScroll = (e: Event) => {
+      const dest = (e as CustomEvent & { to: URL }).to;
+      if (dest?.pathname.match(/\/events\/\d+$/)) {
+        const top = scrollContainerRef.current?.scrollTop ?? 0;
+        if (top > 0) sessionStorage.setItem(scrollKey, String(top));
+      }
+    };
+    document.addEventListener("astro:before-preparation", saveScroll);
+    return () => document.removeEventListener("astro:before-preparation", saveScroll);
+  }, [scrollKey]);
+
+  useEffect(() => {
+    if (loading) return;
+    const saved = sessionStorage.getItem(scrollKey);
+    if (!saved) return;
+    sessionStorage.removeItem(scrollKey);
+    const top = parseInt(saved);
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        scrollContainerRef.current?.scrollTo({ top, behavior: "instant" });
+      });
+    });
+  }, [loading, scrollKey]);
+
   useEffect(() => {
     const params = new URLSearchParams();
     if (title) params.set("title", title);


### PR DESCRIPTION
Closes #181

Saves the feed's scroll position to `sessionStorage` via `astro:before-preparation` (only when navigating to an event detail URL). On mount, after events finish loading, the saved position is restored and the key is cleared so it only applies once per back-navigation.