### PR TITLE
perf: push SSE events via in-process bus instead of DB polling

### DIFF
--- a/src/lib/beaver/event-bus.ts
+++ b/src/lib/beaver/event-bus.ts
@@ -1,0 +1,38 @@
+import type { EventWithChannelName } from "./event";
+
+/**
+ * In-process pub/sub for newly-written events.
+ *
+ * Replaces per-connection DB polling in the SSE handlers: `POST /api/event`
+ * publishes here after a write commits, and event-stream handlers subscribe
+ * and push to clients. Only valid for single-process deployments — we run
+ * `@astrojs/node` in standalone mode with no clustering. A multi-process
+ * deployment would need real pub/sub (Redis/NATS) behind this same interface.
+ */
+
+export type EventBusMessage = {
+  projectId: number;
+  channelId: number;
+  event: EventWithChannelName;
+};
+
+type Subscriber = (msg: EventBusMessage) => void;
+
+const subscribers = new Set<Subscriber>();
+
+export function publishEvent(msg: EventBusMessage): void {
+  for (const subscriber of subscribers) {
+    try {
+      subscriber(msg);
+    } catch (err) {
+      console.error("event-bus subscriber threw:", err);
+    }
+  }
+}
+
+export function subscribeEvents(fn: Subscriber): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}

--- a/src/lib/beaver/event-stream.ts
+++ b/src/lib/beaver/event-stream.ts
@@ -1,0 +1,141 @@
+import { subscribeEvents, type EventBusMessage } from "./event-bus";
+import {
+  eventMatchesFilters,
+  type EventWithChannelName,
+  type StreamFilter,
+  type TagFilter,
+} from "./event";
+
+const KEEPALIVE_MS = 15000;
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+  "Access-Control-Allow-Origin": "*",
+};
+
+/** Build a StreamFilter from an event-stream request's query params. */
+export function parseStreamFilter(url: URL): StreamFilter {
+  const filter: StreamFilter = {
+    title: url.searchParams.get("title"),
+    object: url.searchParams.get("object"),
+    action: url.searchParams.get("action"),
+  };
+
+  if (url.searchParams.get("startDate")) {
+    filter.startDate = new Date(url.searchParams.get("startDate")!);
+  }
+  if (url.searchParams.get("endDate")) {
+    filter.endDate = new Date(url.searchParams.get("endDate")!);
+  }
+  if (url.searchParams.get("tags")) {
+    try {
+      filter.tags = JSON.parse(url.searchParams.get("tags")!) as TagFilter[];
+    } catch {
+      // Invalid JSON, ignore
+    }
+  }
+
+  return filter;
+}
+
+/**
+ * Push-based SSE stream. Does one catch-up DB read on connect, then subscribes
+ * to the event bus and pushes matching events as they're written — no polling.
+ *
+ * `matchScope` narrows bus messages to this stream (project or channel), and
+ * `fetchInitial` performs the one-time catch-up read for events after `afterId`.
+ */
+export function streamEvents(opts: {
+  afterId?: number;
+  filter: StreamFilter;
+  matchScope: (msg: EventBusMessage) => boolean;
+  fetchInitial: (afterId?: number) => Promise<EventWithChannelName[]>;
+}): Response {
+  const { afterId, filter, matchScope, fetchInitial } = opts;
+  const encoder = new TextEncoder();
+
+  let unsubscribe: (() => void) | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+  let lastSentId = afterId ?? 0;
+
+  function cleanup() {
+    closed = true;
+    if (unsubscribe) {
+      unsubscribe();
+      unsubscribe = null;
+    }
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+  }
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (batch: EventWithChannelName[]) => {
+        if (closed || batch.length === 0) return;
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(batch)}\n\n`));
+        } catch {
+          cleanup();
+        }
+      };
+
+      controller.enqueue(encoder.encode(": ok\n\n"));
+
+      // Subscribe before the catch-up read so events written during it aren't
+      // lost; buffer them until catch-up completes, then flush in one tick.
+      let caughtUp = false;
+      const buffer: EventWithChannelName[] = [];
+
+      unsubscribe = subscribeEvents((msg) => {
+        if (!matchScope(msg)) return;
+        if (msg.event.id <= lastSentId) return;
+        if (!eventMatchesFilters(msg.event, filter)) return;
+        if (!caughtUp) {
+          buffer.push(msg.event);
+          return;
+        }
+        lastSentId = msg.event.id;
+        send([msg.event]);
+      });
+
+      try {
+        const initial = await fetchInitial(afterId);
+        if (initial.length > 0) {
+          lastSentId = Math.max(lastSentId, ...initial.map((e) => e.id));
+          send(initial);
+        }
+      } catch (err) {
+        console.error("Error fetching initial events for stream:", err);
+      }
+
+      // Flush events that arrived during the catch-up read. Synchronous with
+      // the caughtUp flip, so a concurrent publish can't slip past unbuffered.
+      const pending = buffer.filter((e) => e.id > lastSentId).sort((a, b) => b.id - a.id);
+      caughtUp = true;
+      if (pending.length > 0) {
+        lastSentId = Math.max(lastSentId, ...pending.map((e) => e.id));
+        send(pending);
+      }
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(": keepalive\n\n"));
+        } catch {
+          cleanup();
+        }
+      }, KEEPALIVE_MS);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+}

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -123,6 +123,57 @@ function applyFilterConditions(conditions: any[], options: QueryOptions) {
   }
 }
 
+export type StreamFilter = {
+  title?: string | null;
+  object?: string | null;
+  action?: string | null;
+  startDate?: Date;
+  endDate?: Date;
+  tags?: TagFilter[];
+};
+
+function tagMatches(tags: TagPrimitive, filter: TagFilter): boolean {
+  if (!(filter.key in tags)) return false;
+  const raw = tags[filter.key];
+
+  if (filter.type === "number") {
+    const n = typeof raw === "number" ? raw : parseFloat(String(raw));
+    if (Number.isNaN(n)) return false;
+    const v = parseFloat(filter.value);
+    const op = filter.operator ?? "eq";
+    if (op === "gt") return n > v;
+    if (op === "lt") return n < v;
+    if (op === "between") return n >= v && n <= parseFloat(filter.value2 ?? filter.value);
+    return n === v;
+  }
+
+  return String(raw) === filter.value;
+}
+
+/**
+ * In-process mirror of `applyFilterConditions`, for matching a single event
+ * pushed via the event bus against an SSE stream's filters. Must stay in sync
+ * with the SQL semantics there (substring title, exact object/action,
+ * inclusive date bounds, and tag eq/gt/lt/between).
+ */
+export function eventMatchesFilters(event: EventWithChannelName, filter: StreamFilter): boolean {
+  if (filter.title && !event.title.toLowerCase().includes(filter.title.toLowerCase())) return false;
+  if (filter.object && event.eventObject !== filter.object) return false;
+  if (filter.action && event.eventAction !== filter.action) return false;
+
+  const createdAt = new Date(event.createdAt).getTime();
+  if (filter.startDate && createdAt < filter.startDate.getTime()) return false;
+  if (filter.endDate && createdAt > filter.endDate.getTime()) return false;
+
+  if (filter.tags?.length) {
+    for (const tag of filter.tags) {
+      if (!tagMatches(event.tags, tag)) return false;
+    }
+  }
+
+  return true;
+}
+
 function applyCursorAndPagination(conditions: any[], options: QueryOptions) {
   if (options.afterId) conditions.push(gt(events.id, options.afterId));
   if (options.beforeId) conditions.push(lt(events.id, options.beforeId));

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -4,6 +4,7 @@ import { EVENT_NAME_REGEX, RESERVED_OBJECT } from "@/lib/beaver/event";
 import { getProject } from "@/lib/beaver/project";
 import { getNotificationEmails } from "@/lib/beaver/user";
 import { sendEventNotification } from "@/lib/email/resend";
+import { publishEvent } from "@/lib/beaver/event-bus";
 import { eq } from "drizzle-orm";
 import type { APIContext, APIRoute } from "astro";
 
@@ -124,6 +125,13 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
           };
         }),
       );
+    });
+
+    // Push to live SSE feeds — one publish per committed event. This is the
+    // single write chokepoint for ingested events; keep it in sync with any
+    // other event-insert path.
+    created.forEach((event, i) => {
+      publishEvent({ projectId: event.projectId, channelId: resolved[i].channel.id, event });
     });
 
     // Fire notifications outside the transaction

--- a/src/pages/api/events/channel/[channelID]/event-stream.ts
+++ b/src/pages/api/events/channel/[channelID]/event-stream.ts
@@ -1,79 +1,19 @@
-import { getChannelEvents, type TagFilter } from "@/lib/beaver/event";
+import { getChannelEvents } from "@/lib/beaver/event";
+import { streamEvents, parseStreamFilter } from "@/lib/beaver/event-stream";
 
 export async function GET({ params, url }: { params: { channelID: string }; url: URL }) {
-  const { channelID } = params;
-  const title = url.searchParams.get("title");
-  const object = url.searchParams.get("object");
-  const action = url.searchParams.get("action");
+  const channelId = parseInt(params.channelID);
+  const filter = parseStreamFilter(url);
 
-  let startDate: Date | undefined;
-  let endDate: Date | undefined;
-  if (url.searchParams.get("startDate")) {
-    startDate = new Date(url.searchParams.get("startDate")!);
-  }
-  if (url.searchParams.get("endDate")) {
-    endDate = new Date(url.searchParams.get("endDate")!);
+  let afterId: number | undefined;
+  if (url.searchParams.get("afterId")) {
+    afterId = parseInt(url.searchParams.get("afterId")!);
   }
 
-  let tags: TagFilter[] = [];
-  if (url.searchParams.get("tags")) {
-    try {
-      tags = JSON.parse(url.searchParams.get("tags")!);
-    } catch {
-      // Invalid JSON, ignore
-    }
-  }
-
-  const headers = {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-    "X-Accel-Buffering": "no",
-    "Access-Control-Allow-Origin": "*",
-  };
-
-  const encoder = new TextEncoder();
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode(": ok\n\n"));
-
-      async function sendEvents() {
-        try {
-          var afterId;
-          if (url.searchParams.get("afterId")) {
-            afterId = parseInt(url.searchParams.get("afterId")!);
-          }
-
-          while (true) {
-            const events = await getChannelEvents(parseInt(channelID), {
-              title,
-              object,
-              action,
-              afterId,
-              startDate,
-              endDate,
-              tags,
-            });
-
-            if (events.length > 0) {
-              afterId = events.at(0)!.id;
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(events)}\n\n`));
-            } else {
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify([])}\n\n`));
-            }
-
-            await new Promise((resolve) => setTimeout(resolve, 2000));
-          }
-        } catch (err) {
-          console.error("Error in SSE stream:", err);
-          controller.close();
-        }
-      }
-
-      sendEvents();
-    },
+  return streamEvents({
+    afterId,
+    filter,
+    matchScope: (msg) => msg.channelId === channelId,
+    fetchInitial: (id) => getChannelEvents(channelId, { ...filter, afterId: id }),
   });
-
-  return new Response(stream, { headers });
 }

--- a/src/pages/api/events/project/[projectID]/event-stream.ts
+++ b/src/pages/api/events/project/[projectID]/event-stream.ts
@@ -1,79 +1,19 @@
-import { getProjectEvents, type TagFilter } from "@/lib/beaver/event";
+import { getProjectEvents } from "@/lib/beaver/event";
+import { streamEvents, parseStreamFilter } from "@/lib/beaver/event-stream";
 
 export async function GET({ params, url }: { params: { projectID: string }; url: URL }) {
-  const { projectID } = params;
-  const title = url.searchParams.get("title");
-  const object = url.searchParams.get("object");
-  const action = url.searchParams.get("action");
+  const projectId = parseInt(params.projectID);
+  const filter = parseStreamFilter(url);
 
-  let startDate: Date | undefined;
-  let endDate: Date | undefined;
-  if (url.searchParams.get("startDate")) {
-    startDate = new Date(url.searchParams.get("startDate")!);
-  }
-  if (url.searchParams.get("endDate")) {
-    endDate = new Date(url.searchParams.get("endDate")!);
+  let afterId: number | undefined;
+  if (url.searchParams.get("afterId")) {
+    afterId = parseInt(url.searchParams.get("afterId")!);
   }
 
-  let tags: TagFilter[] = [];
-  if (url.searchParams.get("tags")) {
-    try {
-      tags = JSON.parse(url.searchParams.get("tags")!);
-    } catch {
-      // Invalid JSON, ignore
-    }
-  }
-
-  const headers = {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-    "X-Accel-Buffering": "no",
-    "Access-Control-Allow-Origin": "*",
-  };
-
-  const encoder = new TextEncoder();
-
-  const stream = new ReadableStream({
-    start(controller) {
-      controller.enqueue(encoder.encode(": ok\n\n"));
-
-      async function sendEvents() {
-        try {
-          var afterId;
-          if (url.searchParams.get("afterId")) {
-            afterId = parseInt(url.searchParams.get("afterId")!);
-          }
-
-          while (true) {
-            const events = await getProjectEvents(parseInt(projectID), {
-              title,
-              object,
-              action,
-              afterId,
-              startDate,
-              endDate,
-              tags,
-            });
-
-            if (events.length > 0) {
-              afterId = events.at(0)!.id;
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify(events)}\n\n`));
-            } else {
-              controller.enqueue(encoder.encode(`data: ${JSON.stringify([])}\n\n`));
-            }
-
-            await new Promise((resolve) => setTimeout(resolve, 2000));
-          }
-        } catch (err) {
-          console.error("Error in SSE stream:", err);
-          controller.close();
-        }
-      }
-
-      sendEvents();
-    },
+  return streamEvents({
+    afterId,
+    filter,
+    matchScope: (msg) => msg.projectId === projectId,
+    fetchInitial: (id) => getProjectEvents(projectId, { ...filter, afterId: id }),
   });
-
-  return new Response(stream, { headers });
 }


### PR DESCRIPTION
## Summary

Replaces the per-connection `while(true)` 2s DB poll in the project and channel SSE handlers with **push-on-write**. The ingestion handler (`POST /api/event`) publishes each committed event to an in-process bus; SSE handlers do one catch-up read on connect, then subscribe and push matching events as they arrive.

- Idle DB load for the feed drops to **zero** (was O(connections × time))
- Push latency goes from up-to-2s to **immediate**
- Filters re-applied in-process via `eventMatchesFilters`, mirroring the SQL `WHERE` semantics
- Targets the **v2.1.0** release branch; publishes from the batched ingestion path (#195), including multi-event array payloads

## Why not `update_hook` (the original issue approach)

`bun:sqlite` exposes no update hook, and neither does better-sqlite3 natively. It would also be strictly worse here — a hook only yields `(op, table, rowid)`, forcing a follow-up `SELECT`, whereas the write path already holds the enriched event object. Details in #192.

## Changes

- **`event-bus.ts`** (new) — in-process `publishEvent` / `subscribeEvents` registry.
- **`event-stream.ts`** (new) — shared `streamEvents()` + `parseStreamFilter()`; race-safe catch-up→subscribe→push, `cancel()` cleanup, 15s keepalive.
- **`event.ts`** — `StreamFilter` + `eventMatchesFilters`.
- **`POST /api/event`** — publishes each committed event after the transaction (single chokepoint for ingestion).
- **Project/channel `event-stream.ts`** — collapsed from ~84 lines each to thin wrappers.
- Client `event-feed.tsx` unchanged (wire format preserved).

## Verification

- E2E push confirmed against the dev server: single POST and batched array (across multiple channels) both pushed
- Filter parity: object mismatch excluded, numeric tag `gt` matched/excluded, project-scope routing
- Module-singleton holds under Vite SSR
- `tsc`, `oxfmt`, `oxlint`, production build all clean

Closes #192