### PR TITLE
perf: drive event-count pill and unread badges off the event bus

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -271,6 +271,9 @@ export default function EventFeed({
         if (unique.length > 0) {
           unique.forEach((e) => eventIdsRef.current.add(e.id));
           trickleQueueRef.current.push(...unique);
+          // The stream is already server-filtered to the current query, so every
+          // event received matches the pill's filter — keep the count live.
+          setEventCount((prev) => (prev === null ? prev : prev + unique.length));
           if (!trickleTimerRef.current) drainQueue();
         }
       });

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -1,6 +1,7 @@
 import type { Channel } from "@/lib/beaver/channel";
 import type { ChannelGroupWithChannels } from "@/lib/beaver/channel-group";
 import type { Project } from "@/lib/beaver/project";
+import type { EventWithChannelName } from "@/lib/beaver/event";
 import { useEffect, useRef, useState } from "react";
 import {
   DndContext,
@@ -715,7 +716,17 @@ function PanelContent({
   const [unreadCounts, setUnreadCounts] = useState<Record<number, number>>({});
   const { user, signOut } = useAuth();
 
+  // Keep latest path + channel list available to the long-lived stream handler
+  // without reconnecting on every navigation.
+  const pathnameRef = useRef(pathname);
+  pathnameRef.current = pathname;
+  const channelsRef = useRef(currentChannels);
+  channelsRef.current = currentChannels;
+
   useEffect(() => {
+    let eventSource: EventSource | null = null;
+    let resync: ReturnType<typeof setInterval> | null = null;
+
     const fetchUnread = async () => {
       try {
         const res = await fetch(`/api/unread?projectId=${currentProject.id}`);
@@ -728,8 +739,52 @@ function PanelContent({
       }
     };
 
-    fetchUnread();
-    const interval = setInterval(fetchUnread, 5_000);
+    const activeChannelId = (): number | null => {
+      const m = pathnameRef.current.match(/\/channels\/(\d+)(?:$|[/?])/);
+      return m ? parseInt(m[1]) : null;
+    };
+
+    const start = async () => {
+      // Seed from server truth, then maintain via the event bus push below.
+      await fetchUnread();
+      // Slow re-sync safety net: the bus is user-agnostic, so it can drive the
+      // unread *increment* but can't know when this user's read-state changed in
+      // another tab/device. A periodic refetch self-heals that drift (see #201).
+      resync = setInterval(fetchUnread, 60_000);
+
+      // Only push events written after now — skip the stream's catch-up backlog.
+      let maxId = 0;
+      try {
+        const res = await fetch("/api/events/max-id");
+        maxId = (await res.json()).maxId ?? 0;
+      } catch {
+        // ignore
+      }
+
+      eventSource = new EventSource(
+        `/api/events/project/${currentProject.id}/event-stream?afterId=${maxId}`,
+      );
+      eventSource.addEventListener("message", (e) => {
+        let events: EventWithChannelName[];
+        try {
+          events = JSON.parse(e.data);
+        } catch {
+          return;
+        }
+        const active = activeChannelId();
+        setUnreadCounts((prev) => {
+          const next = { ...prev };
+          for (const ev of events) {
+            const channel = channelsRef.current.find((c) => c.name === ev.channelName);
+            if (!channel || channel.id === active) continue; // viewing it → stays read
+            next[channel.id] = (next[channel.id] ?? 0) + 1;
+          }
+          return next;
+        });
+      });
+    };
+
+    start();
 
     const handleChannelRead = (e: CustomEvent<{ channelId: number }>) => {
       setUnreadCounts((prev) => ({ ...prev, [e.detail.channelId]: 0 }));
@@ -737,7 +792,8 @@ function PanelContent({
 
     window.addEventListener("channel:read", handleChannelRead as EventListener);
     return () => {
-      clearInterval(interval);
+      if (eventSource) eventSource.close();
+      if (resync) clearInterval(resync);
       window.removeEventListener("channel:read", handleChannelRead as EventListener);
     };
   }, [currentProject.id]);


### PR DESCRIPTION
## Summary

Builds on the event bus from #192 to make two pieces of UI update live instead of via stale fetches / polling:

- **Event-count pill** (`event-feed.tsx`) — the feed's SSE stream is already server-filtered to the current query, so every event it receives matches the pill. We now increment the count on each pushed event instead of leaving it stale until a reload/filter change. The one-shot `/count` fetch still seeds the baseline.
- **Unread badges** (`side-panel.tsx`) — the side panel opens a project-level event-stream and increments a channel's badge when an event arrives for a channel the user isn't currently viewing. Replaces the previous `setInterval(fetchUnread, 5000)`.

## Unread re-sync — why the poll isn't fully removed

The bus is **user-agnostic**: it announces "event written to channel X," which is the same for everyone. That drives the unread *increment* fine. But it can't observe the *decrement* side — when **this user's** `lastReadAt` moves because they read a channel in another tab or on another device. The bus never sees that (it's not an event write, and it's per-user).

So unread keeps a **slow 60s re-sync** `GET /api/unread` as a safety net (down from the 5s poll). Increments are live via the bus; read-state changes originating elsewhere self-heal within 60s instead of requiring a reload. Fully removing the poll would require publishing per-user read events on the bus — tracked separately.

## Known follow-up (not this PR)

This adds a *second* per-tab `EventSource` (feed + side panel), which causes a slight badge-vs-feed render lag. The fix is one shared client-side stream + dispatcher per tab — captured as an in-tab design note on #193, which then extends it across tabs.

## Verification

- Watched live against the dev server: pill increments on matching events; non-viewed channels' badges climb; the actively-viewed channel stays at 0.
- `tsc`, `oxfmt`, `oxlint`, production build all clean.

Closes #201