### PR TITLE
perf: coalesce client-side pollers across tabs via BroadcastChannel

### DIFF
--- a/src/components/metrics-overview.tsx
+++ b/src/components/metrics-overview.tsx
@@ -6,6 +6,7 @@ import { BarChart2Icon } from "lucide-react";
 import { formatDistanceToNow } from "date-fns";
 import { useEffect, useRef, useState } from "react";
 import { Skeleton } from "./ui/skeleton";
+import { useTabLeader } from "@/lib/tab-leader";
 
 const VALUE_TWEEN_MS = 600;
 
@@ -221,28 +222,41 @@ export default function MetricsOverview({
 }) {
   const [metrics, setMetrics] = useState(initialMetrics);
   const [sparklines, setSparklines] = useState(initialSparklines);
+  const isLeader = useTabLeader(`metrics:${projectId}`);
 
   useEffect(() => {
+    const bc = new BroadcastChannel(`beaver:metrics:${projectId}`);
     let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
-    const poll = async () => {
-      try {
-        const res = await fetch(`/api/metrics?projectId=${projectId}&includeSparklines=true`);
-        if (!res.ok) return;
-        const data = await res.json();
+    if (isLeader) {
+      const poll = async () => {
+        try {
+          const res = await fetch(`/api/metrics?projectId=${projectId}&includeSparklines=true`);
+          if (!res.ok || cancelled) return;
+          const data = await res.json();
+          if (cancelled) return;
+          setMetrics(data.metrics);
+          setSparklines(data.sparklines);
+          bc.postMessage({ metrics: data.metrics, sparklines: data.sparklines });
+        } catch {}
+      };
+      poll();
+      intervalId = setInterval(poll, POLL_INTERVAL_MS);
+    } else {
+      bc.onmessage = (e: MessageEvent) => {
         if (cancelled) return;
-        setMetrics(data.metrics);
-        setSparklines(data.sparklines);
-      } catch {}
-    };
+        setMetrics(e.data.metrics);
+        setSparklines(e.data.sparklines);
+      };
+    }
 
-    poll();
-    const id = setInterval(poll, POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
-      clearInterval(id);
+      if (intervalId) clearInterval(intervalId);
+      bc.close();
     };
-  }, [projectId]);
+  }, [projectId, isLeader]);
 
   return (
     <div className="px-4 md:px-8 py-4 md:py-8 w-full">

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -2,6 +2,7 @@ import type { Channel } from "@/lib/beaver/channel";
 import type { ChannelGroupWithChannels } from "@/lib/beaver/channel-group";
 import type { Project } from "@/lib/beaver/project";
 import type { EventWithChannelName } from "@/lib/beaver/event";
+import { useTabLeader } from "@/lib/tab-leader";
 import { useEffect, useRef, useState } from "react";
 import {
   DndContext,
@@ -715,6 +716,7 @@ function PanelContent({
   const [triggerCreateGroup, setTriggerCreateGroup] = useState(false);
   const [unreadCounts, setUnreadCounts] = useState<Record<number, number>>({});
   const { user, signOut } = useAuth();
+  const isLeader = useTabLeader(`unread:${currentProject.id}`);
 
   // Keep latest path + channel list available to the long-lived stream handler
   // without reconnecting on every navigation.
@@ -724,67 +726,93 @@ function PanelContent({
   channelsRef.current = currentChannels;
 
   useEffect(() => {
+    const bc = new BroadcastChannel(`beaver:unread:${currentProject.id}`);
     let eventSource: EventSource | null = null;
     let resync: ReturnType<typeof setInterval> | null = null;
-
-    const fetchUnread = async () => {
-      try {
-        const res = await fetch(`/api/unread?projectId=${currentProject.id}`);
-        if (res.ok) {
-          const data = await res.json();
-          setUnreadCounts(data.counts);
-        }
-      } catch {
-        // ignore
-      }
-    };
 
     const activeChannelId = (): number | null => {
       const m = pathnameRef.current.match(/\/channels\/(\d+)(?:$|[/?])/);
       return m ? parseInt(m[1]) : null;
     };
 
-    const start = async () => {
-      // Seed from server truth, then maintain via the event bus push below.
-      await fetchUnread();
-      // Slow re-sync safety net: the bus is user-agnostic, so it can drive the
-      // unread *increment* but can't know when this user's read-state changed in
-      // another tab/device. A periodic refetch self-heals that drift (see #201).
-      resync = setInterval(fetchUnread, 60_000);
-
-      // Only push events written after now — skip the stream's catch-up backlog.
-      let maxId = 0;
-      try {
-        const res = await fetch("/api/events/max-id");
-        maxId = (await res.json()).maxId ?? 0;
-      } catch {
-        // ignore
-      }
-
-      eventSource = new EventSource(
-        `/api/events/project/${currentProject.id}/event-stream?afterId=${maxId}`,
-      );
-      eventSource.addEventListener("message", (e) => {
-        let events: EventWithChannelName[];
-        try {
-          events = JSON.parse(e.data);
-        } catch {
-          return;
+    const applyEvents = (events: EventWithChannelName[]) => {
+      const active = activeChannelId();
+      setUnreadCounts((prev) => {
+        const next = { ...prev };
+        for (const ev of events) {
+          const channel = channelsRef.current.find((c) => c.name === ev.channelName);
+          if (!channel || channel.id === active) continue; // viewing it → stays read
+          next[channel.id] = (next[channel.id] ?? 0) + 1;
         }
-        const active = activeChannelId();
-        setUnreadCounts((prev) => {
-          const next = { ...prev };
-          for (const ev of events) {
-            const channel = channelsRef.current.find((c) => c.name === ev.channelName);
-            if (!channel || channel.id === active) continue; // viewing it → stays read
-            next[channel.id] = (next[channel.id] ?? 0) + 1;
-          }
-          return next;
-        });
+        return next;
       });
     };
 
-    start();
+    if (isLeader) {
+      const fetchUnread = async () => {
+        try {
+          const res = await fetch(`/api/unread?projectId=${currentProject.id}`);
+          if (res.ok) {
+            const data = await res.json();
+            setUnreadCounts(data.counts);
+            bc.postMessage({ type: "unread-snapshot", counts: data.counts });
+          }
+        } catch {
+          // ignore
+        }
+      };
+
+      const start = async () => {
+        // Seed from server truth, then maintain via the event bus push below.
+        await fetchUnread();
+        // Slow re-sync safety net: the bus is user-agnostic, so it can drive the
+        // unread *increment* but can't know when this user's read-state changed in
+        // another tab/device. A periodic refetch self-heals that drift (see #201).
+        resync = setInterval(fetchUnread, 60_000);
+
+        // Only push events written after now — skip the stream's catch-up backlog.
+        let maxId = 0;
+        try {
+          const res = await fetch("/api/events/max-id");
+          maxId = (await res.json()).maxId ?? 0;
+        } catch {
+          // ignore
+        }
+
+        eventSource = new EventSource(
+          `/api/events/project/${currentProject.id}/event-stream?afterId=${maxId}`,
+        );
+        eventSource.addEventListener("message", (e) => {
+          let events: EventWithChannelName[];
+          try {
+            events = JSON.parse(e.data);
+          } catch {
+            return;
+          }
+          applyEvents(events);
+          bc.postMessage({ type: "project-events", events });
+        });
+      };
+
+      start();
+    } else {
+      // Follower: seed from server so the sidebar isn't blank while waiting for
+      // the leader's first broadcast, then keep in sync via BroadcastChannel.
+      fetch(`/api/unread?projectId=${currentProject.id}`)
+        .then((r) => (r.ok ? r.json() : null))
+        .then((data) => {
+          if (data) setUnreadCounts(data.counts);
+        })
+        .catch(() => {});
+
+      bc.onmessage = (e: MessageEvent) => {
+        if (e.data.type === "unread-snapshot") {
+          setUnreadCounts(e.data.counts);
+        } else if (e.data.type === "project-events") {
+          applyEvents(e.data.events);
+        }
+      };
+    }
 
     const handleChannelRead = (e: CustomEvent<{ channelId: number }>) => {
       setUnreadCounts((prev) => ({ ...prev, [e.detail.channelId]: 0 }));
@@ -795,8 +823,9 @@ function PanelContent({
       if (eventSource) eventSource.close();
       if (resync) clearInterval(resync);
       window.removeEventListener("channel:read", handleChannelRead as EventListener);
+      bc.close();
     };
-  }, [currentProject.id]);
+  }, [currentProject.id, isLeader]);
 
   const canEdit = userRole === "owner" || userRole === "maintainer";
 

--- a/src/lib/tab-leader.ts
+++ b/src/lib/tab-leader.ts
@@ -1,0 +1,63 @@
+import { useEffect, useRef, useState } from "react";
+
+const HEARTBEAT_MS = 2_000;
+const LEADER_TIMEOUT_MS = 5_000;
+
+/**
+ * Elects one leader tab per `scope` string. The leader returns `true`; all
+ * other tabs return `false`. Leadership passes to another tab within
+ * LEADER_TIMEOUT_MS when the leader tab closes or navigates away.
+ *
+ * Uses localStorage for persistence (so the storage event gives instant
+ * cross-tab notification on close) and a heartbeat to detect frozen tabs.
+ */
+export function useTabLeader(scope: string): boolean {
+  const [isLeader, setIsLeader] = useState(false);
+  const tabId = useRef(`${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+  useEffect(() => {
+    const key = `tab-leader:${scope}`;
+    const id = tabId.current;
+
+    const tryClaimLeadership = () => {
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        try {
+          const { id: storedId, ts } = JSON.parse(raw) as { id: string; ts: number };
+          if (Date.now() - ts < LEADER_TIMEOUT_MS) {
+            setIsLeader(storedId === id);
+            return storedId === id;
+          }
+        } catch {
+          // corrupt entry — fall through and claim
+        }
+      }
+      localStorage.setItem(key, JSON.stringify({ id, ts: Date.now() }));
+      setIsLeader(true);
+      return true;
+    };
+
+    tryClaimLeadership();
+
+    const interval = setInterval(tryClaimLeadership, HEARTBEAT_MS);
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === key) tryClaimLeadership();
+    };
+    window.addEventListener("storage", onStorage);
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("storage", onStorage);
+      const raw = localStorage.getItem(key);
+      if (raw) {
+        try {
+          const { id: storedId } = JSON.parse(raw) as { id: string };
+          if (storedId === id) localStorage.removeItem(key);
+        } catch {}
+      }
+    };
+  }, [scope]);
+
+  return isLeader;
+}


### PR DESCRIPTION
Closes #193

## Summary

- Adds `src/lib/tab-leader.ts` — a `useTabLeader(scope)` hook that elects one leader tab per scope using a localStorage heartbeat (2s interval). The `storage` event gives instant handoff when the leader tab closes; otherwise followers take over within 5s if the heartbeat goes stale.
- `MetricsOverview`: leader tab polls `/api/metrics` every 10s and broadcasts results via `BroadcastChannel`; follower tabs skip the interval and update from the broadcast instead.
- `SidePanel`: leader tab holds the project-level SSE connection and the 60s unread resync; it broadcasts raw project events and unread snapshots to followers. Followers do a single seed fetch on mount (so the sidebar isn't blank before the first broadcast) then stay in sync via `BroadcastChannel`.

The event-feed SSE is left unchanged — it's parameterized per channel, so coalescing it would require multiplexing multiple streams from the leader, which is a separate problem.

## Test plan

- [ ] Open two tabs on the metrics page; confirm only one tab fires `/api/metrics` requests every 10s in the Network panel
- [ ] Open two tabs on any channel feed; confirm only one `event-stream` connection is open across both tabs
- [ ] Close the leader tab; confirm the remaining tab opens its own `event-stream` and resumes polling within ~5s
- [ ] Verify unread badge counts stay consistent across both tabs when new events arrive