### PR TITLE
perf: defer hydration on non-critical islands (client:load → visible/idle)

### DIFF
--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -34,6 +34,6 @@ const backUrl = projects.length > 0 ? `/dashboard/${projects[0].id}/feed` : "/";
     </script>
   </head>
   <body>
-    <AdminUsersView client:load initialUsers={allUsers} currentUserId={user.id} backUrl={backUrl} />
+    <AdminUsersView client:visible initialUsers={allUsers} currentUserId={user.id} backUrl={backUrl} />
   </body>
 </html>

--- a/src/pages/change-password.astro
+++ b/src/pages/change-password.astro
@@ -28,6 +28,6 @@ if (!user) {
     </script>
   </head>
   <body>
-    <ChangePasswordView client:load userName={user.userName} />
+    <ChangePasswordView client:idle userName={user.userName} />
   </body>
 </html>

--- a/src/pages/dashboard/[projectID]/api-docs.astro
+++ b/src/pages/dashboard/[projectID]/api-docs.astro
@@ -9,5 +9,5 @@ const project = await getProject(parseInt(projectID!));
 ---
 
 <Layout projectID={projectID!}>
-  <ApiDocsView client:load apiKey={project.apiKey} />
+  <ApiDocsView client:idle apiKey={project.apiKey} />
 </Layout>

--- a/src/pages/dashboard/[projectID]/create-channel.astro
+++ b/src/pages/dashboard/[projectID]/create-channel.astro
@@ -6,5 +6,5 @@ const { projectID } = Astro.params;
 ---
 
 <Layout projectID={projectID!}>
-  <CreateChannelView client:load projectId={parseInt(projectID!)} />
+  <CreateChannelView client:idle projectId={parseInt(projectID!)} />
 </Layout>

--- a/src/pages/dashboard/[projectID]/events/[eventID].astro
+++ b/src/pages/dashboard/[projectID]/events/[eventID].astro
@@ -13,5 +13,5 @@ if (!event) {
 ---
 
 <Layout projectID={projectID!}>
-  <EventDetail client:load event={event} />
+  <EventDetail client:visible event={event} />
 </Layout>

--- a/src/pages/dashboard/[projectID]/metrics.astro
+++ b/src/pages/dashboard/[projectID]/metrics.astro
@@ -18,7 +18,7 @@ const sparklines = await getMetricSparklines(timeseriesIds, subDays(new Date(), 
 
 <Layout projectID={projectID!}>
   <MetricsOverview
-    client:load
+    client:visible
     metrics={metrics}
     sparklines={sparklines}
     projectId={project.id}

--- a/src/pages/dashboard/[projectID]/metrics/[metricID].astro
+++ b/src/pages/dashboard/[projectID]/metrics/[metricID].astro
@@ -20,7 +20,7 @@ const initialValues =
 
 <Layout projectID={projectID!}>
   <MetricDetail
-    client:load
+    client:visible
     metric={metric}
     projectId={parseInt(projectID!)}
     initialValues={initialValues}

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -36,7 +36,7 @@ const isOwner = userRole === "owner";
     <div class="w-full flex flex-col items-center mt-8 pb-16">
       <div class="w-full px-4 md:w-3/4 md:px-0">
         <SettingsTabs
-          client:load
+          client:visible
           project={project}
           channels={channels}
           metrics={metrics}


### PR DESCRIPTION
Closes #187

## Summary

Pure directive change — no code refactoring.

**→ `client:visible`** (hydrates when element enters viewport, after first paint):
- `settings.astro` — SettingsTabs
- `events/[eventID].astro` — EventDetail
- `metrics.astro` — MetricsOverview
- `metrics/[metricID].astro` — MetricDetail
- `admin/users.astro` — AdminUsersView

**→ `client:idle`** (hydrates on browser idle, only needed on interaction):
- `api-docs.astro` — ApiDocsView
- `create-channel.astro` — CreateChannelView
- `change-password.astro` — ChangePasswordView

**Kept `client:load`**: `feed.astro`, `channels/[channelID].astro`, `bookmarks.astro` — immediate interactivity required.

## Test plan

- [ ] Visit settings, event detail, metrics, and metric detail pages — confirm they render and are interactive
- [ ] Visit api-docs, create-channel, change-password — confirm forms work correctly
- [ ] Confirm feed, channel feed, and bookmarks are unaffected