### PR TITLE
fix: show 'no recent data' on sparklines with stale values

### DIFF
--- a/src/components/metrics-overview.tsx
+++ b/src/components/metrics-overview.tsx
@@ -137,6 +137,7 @@ function MetricCard({
               <Sparkline
                 data={bucketSparkline(sparkline ?? [], (metric.chartType ?? "line") as ChartType)}
                 chartType={(metric.chartType ?? "line") as ChartType}
+                hasAnyData={metric.currentValue !== null}
               />
             </div>
           )}

--- a/src/components/ui/sparkline.tsx
+++ b/src/components/ui/sparkline.tsx
@@ -12,9 +12,11 @@ function bounds(values: number[]): { min: number; max: number } {
 export function Sparkline({
   data,
   chartType,
+  hasAnyData = false,
 }: {
   data: { value: number }[];
   chartType: ChartType;
+  hasAnyData?: boolean;
 }) {
   const [mounted, setMounted] = useState(false);
   const gradId = useId();
@@ -24,7 +26,7 @@ export function Sparkline({
   if (data.length === 0) {
     return (
       <div className="h-16 flex items-center justify-center text-xs text-muted-foreground">
-        No data yet
+        {hasAnyData ? "No recent data" : "No data yet"}
       </div>
     );
   }


### PR DESCRIPTION
When a timeseries metric has data but none within the last 7 days, the sparkline previously showed "No data yet" — misleading since data does exist.

Now passes `hasAnyData` (based on `currentValue !== null`) to the `Sparkline` component:
- `currentValue === null` → "No data yet" (truly new metric)
- `currentValue !== null` but empty 7-day window → "No recent data"