### PR TITLE
perf: lazy-mount settings tab content on first visit

### DIFF
--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -1,6 +1,7 @@
 import type { Channel } from "@/lib/beaver/channel";
 import type { MetricWithValue } from "@/lib/beaver/metric";
 import type { Project } from "@/lib/beaver/project";
+import { useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import APIKey from "./api-key";
 import ChangePasswordForm from "./change-password-form";
@@ -34,9 +35,19 @@ export default function SettingsTabs({
   initialEnabled,
 }: Props) {
   const createdAt = project.createdAt ? new Date(project.createdAt).toLocaleDateString() : "—";
+  const defaultTab = isOwner ? "general" : "channels";
+  const [tab, setTab] = useState(defaultTab);
+  // Track which tabs have been visited so their content stays mounted after first render.
+  const visited = useRef(new Set([defaultTab]));
+  const show = (t: string) => tab === t || visited.current.has(t);
+
+  const handleTabChange = (value: string) => {
+    visited.current.add(value);
+    setTab(value);
+  };
 
   return (
-    <Tabs defaultValue={isOwner ? "general" : "channels"} className="w-full">
+    <Tabs value={tab} onValueChange={handleTabChange} className="w-full">
       <TabsList className="mb-6 mt-6 md:mt-0 flex flex-wrap h-auto w-auto gap-1">
         {isOwner && <TabsTrigger value="general">General</TabsTrigger>}
         <TabsTrigger value="channels">Channels</TabsTrigger>
@@ -71,34 +82,38 @@ export default function SettingsTabs({
       )}
 
       <TabsContent value="channels" className="mt-6 md:mt-0">
-        <ChannelSettings channels={channels} project={project} />
+        {show("channels") && <ChannelSettings channels={channels} project={project} />}
       </TabsContent>
 
       {isOwner && (
         <TabsContent value="members" className="mt-6 md:mt-0">
-          <ProjectMembers projectId={project.id} currentUserId={currentUserId} />
+          {show("members") && (
+            <ProjectMembers projectId={project.id} currentUserId={currentUserId} />
+          )}
         </TabsContent>
       )}
 
       <TabsContent value="metrics" className="mt-6 md:mt-0">
-        <MetricSettings metrics={metrics} projectId={project.id} />
+        {show("metrics") && <MetricSettings metrics={metrics} projectId={project.id} />}
       </TabsContent>
 
       <TabsContent value="notifications" className="mt-6 md:mt-0">
-        <NotificationSettings
-          projectId={project.id}
-          initialEmail={initialEmail}
-          initialEnabled={initialEnabled}
-        />
+        {show("notifications") && (
+          <NotificationSettings
+            projectId={project.id}
+            initialEmail={initialEmail}
+            initialEnabled={initialEnabled}
+          />
+        )}
       </TabsContent>
 
       <TabsContent value="account" className="mt-6 md:mt-0">
-        <ChangePasswordForm />
+        {show("account") && <ChangePasswordForm />}
       </TabsContent>
 
       {isOwner && (
         <TabsContent value="danger" className="mt-6 md:mt-0">
-          <ProjectDangerZone project={project} />
+          {show("danger") && <ProjectDangerZone project={project} />}
         </TabsContent>
       )}
     </Tabs>


### PR DESCRIPTION
Closes #190

## Summary

Settings tabs previously mounted all sub-components simultaneously on page load — `ChannelSettings` (470 lines + dialogs), `MetricSettings` (528 lines), `ProjectMembers` (271 lines), etc. all hydrated even if the user never clicked those tabs.

Now each tab's content only mounts when first visited, and stays mounted after (so form state isn't lost on tab switch). A `useRef` tracks which tabs have been opened; a `show(tab)` helper gates each `TabsContent`.

On page load only the default tab hydrates (General for owners, Channels for guests). All other sections are deferred-forever for users who don't visit them.

## Test plan

- [ ] Default tab content renders correctly on page load
- [ ] Clicking each tab renders its content correctly
- [ ] Switching away and back to a tab does not reset form state
- [ ] Works for both owners (General default) and non-owners (Channels default)