### PR TITLE
feat: user account settings page

### DIFF
--- a/src/components/account-settings.tsx
+++ b/src/components/account-settings.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import ChangePasswordForm from "./change-password-form";
+
+export default function AccountSettings({
+  initialFullName,
+  username,
+}: {
+  initialFullName: string | null;
+  username: string;
+}) {
+  const [fullName, setFullName] = useState(initialFullName ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSaved(false);
+    setSaving(true);
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ fullName: fullName.trim() || null }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to save.");
+        return;
+      }
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch {
+      setError("Failed to save.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const row = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
+  const label = "font-medium shrink-0";
+
+  return (
+    <div className="flex flex-col space-y-10">
+      <div className="flex flex-col space-y-4">
+        <h2 className="font-mono">Profile</h2>
+        <div className={row}>
+          <p className={label}>Username</p>
+          <p className="text-muted-foreground font-mono">@{username}</p>
+        </div>
+        <form onSubmit={handleSave} className={row}>
+          <Label htmlFor="full-name" className={label}>
+            Display name
+          </Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="full-name"
+              value={fullName}
+              onChange={(e) => setFullName(e.target.value)}
+              placeholder="Your name"
+              className="w-48"
+            />
+            <Button type="submit" variant="outline" size="sm" disabled={saving}>
+              {saved ? "Saved!" : saving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        </form>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      <div className="flex flex-col space-y-4">
+        <h2 className="font-mono">Password</h2>
+        <ChangePasswordForm />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -4,7 +4,6 @@ import type { Project } from "@/lib/beaver/project";
 import { useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import APIKey from "./api-key";
-import ChangePasswordForm from "./change-password-form";
 import ChannelSettings from "./channel-settings";
 import MetricSettings from "./metric-settings";
 import NotificationSettings from "./notification-settings";
@@ -54,7 +53,6 @@ export default function SettingsTabs({
         {isOwner && <TabsTrigger value="members">Members</TabsTrigger>}
         <TabsTrigger value="metrics">Metrics</TabsTrigger>
         <TabsTrigger value="notifications">Notifications</TabsTrigger>
-        <TabsTrigger value="account">Account</TabsTrigger>
         {isOwner && (
           <TabsTrigger value="danger" className="text-destructive">
             Danger Zone
@@ -105,10 +103,6 @@ export default function SettingsTabs({
             initialEnabled={initialEnabled}
           />
         )}
-      </TabsContent>
-
-      <TabsContent value="account" className="mt-6 md:mt-0">
-        {show("account") && <ChangePasswordForm />}
       </TabsContent>
 
       {isOwner && (

--- a/src/components/side-panel.tsx
+++ b/src/components/side-panel.tsx
@@ -38,6 +38,7 @@ import {
   MenuIcon,
   PlusIcon,
   Settings,
+  UserIcon,
   UsersIcon,
   XIcon,
 } from "lucide-react";
@@ -840,6 +841,7 @@ function PanelContent({
   const isMetricsActive = () => pathname.startsWith(`/dashboard/${project.id}/metrics`);
   const isSettingsActive = () => pathname === `/dashboard/${project.id}/settings`;
   const isApiDocsActive = () => pathname === `/dashboard/${project.id}/api-docs`;
+  const isAccountActive = () => pathname === `/dashboard/${project.id}/account`;
 
   const navCss =
     "flex px-3 py-2 space-x-2 items-center hover:bg-gray-100 dark:hover:bg-white/8 hover:cursor-pointer hover:font-medium rounded ";
@@ -945,6 +947,14 @@ function PanelContent({
             <p>API Docs</p>
           </a>
         )}
+        <a
+          className={isAccountActive() ? activeNavCss : navCss}
+          href={`/dashboard/${project.id}/account`}
+          onClick={() => onNavigate?.()}
+        >
+          <UserIcon size={20} />
+          <p>Account</p>
+        </a>
         {user?.isAdmin && (
           <a
             className={pathname === "/admin/users" ? activeNavCss : navCss}

--- a/src/pages/dashboard/[projectID]/account.astro
+++ b/src/pages/dashboard/[projectID]/account.astro
@@ -1,0 +1,39 @@
+---
+import AccountSettings from "@/components/account-settings";
+import Layout from "@/layouts/layout.astro";
+import { getUserByUsername } from "@/lib/beaver/user";
+import { getProject } from "@/lib/beaver/project";
+import { getUserProjectRole } from "@/lib/beaver/project-member";
+
+const { projectID } = Astro.params;
+const user = Astro.locals.user!;
+
+const project = await getProject(parseInt(projectID!));
+
+const userRole = user.isAdmin
+  ? "owner"
+  : await getUserProjectRole(project.id, user.id);
+
+if (userRole === null) {
+  return Astro.redirect(`/dashboard/${projectID}/feed`);
+}
+
+const dbUser = await getUserByUsername(user.userName);
+---
+
+<Layout projectID={projectID!}>
+  <div class="w-full">
+    <div class="p-4 md:p-8 border-b text-2xl font-semibold">
+      <h1>Account Settings</h1>
+    </div>
+    <div class="w-full flex flex-col items-center mt-8 pb-16">
+      <div class="w-full px-4 md:w-3/4 md:px-0">
+        <AccountSettings
+          client:load
+          initialFullName={dbUser?.fullName ?? null}
+          username={user.userName}
+        />
+      </div>
+    </div>
+  </div>
+</Layout>


### PR DESCRIPTION
Closes #136

## Changes

- **New page** `/dashboard/[projectID]/account` — dedicated Account Settings page with Profile (display name, username) and Change Password sections
- **New component** `AccountSettings` — display name form wired to `PATCH /api/users/me`, reuses `ChangePasswordForm`
- **Side panel** — adds Account nav link (UserIcon) below API Docs, visible to all users
- **Project settings** — removes the Account tab from `SettingsTabs` entirely

## Test plan

- [ ] Navigate to Account via the sidebar link
- [ ] Edit display name and confirm it saves (check `PATCH /api/users/me` returns 200)
- [ ] Change password round-trip
- [ ] Confirm the Account tab is gone from Project Settings
- [ ] Verify the sidebar Account link highlights when on the account page