### PR TITLE
feat: single event deletion

### DIFF
--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -2,9 +2,17 @@ import type { EventWithChannelName } from "@/lib/beaver/event";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
 import { getEventTime } from "@/lib/utils";
-import { ArrowLeftIcon, BookmarkIcon, CheckIcon, LinkIcon } from "lucide-react";
+import { ArrowLeftIcon, BookmarkIcon, CheckIcon, LinkIcon, Trash2Icon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "./ui/dialog";
 
 function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | boolean }) {
   const displayValue = typeof value === "boolean" ? (value ? "true" : "false") : String(value);
@@ -18,11 +26,19 @@ function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | 
   );
 }
 
-export default function EventDetail({ event }: { event: EventWithChannelName }) {
+export default function EventDetail({
+  event,
+  canDelete = false,
+}: {
+  event: EventWithChannelName;
+  canDelete?: boolean;
+}) {
   const tags = Object.entries(event.tags);
   const [bookmarked, setBookmarked] = useState(event.bookmarked);
   const [bookmarking, setBookmarking] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   const handleBookmark = async () => {
     setBookmarking(true);
@@ -43,6 +59,19 @@ export default function EventDetail({ event }: { event: EventWithChannelName }) 
     navigator.clipboard.writeText(window.location.href);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/events/${event.id}`, { method: "DELETE" });
+      if (res.ok) {
+        window.location.href = `/dashboard/${event.projectId}/feed`;
+      }
+    } finally {
+      setDeleting(false);
+      setConfirmDelete(false);
+    }
   };
 
   useEffect(() => {
@@ -136,6 +165,23 @@ export default function EventDetail({ event }: { event: EventWithChannelName }) 
                     <TooltipContent>{copied ? "Copied!" : "Copy link"}</TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
+                {canDelete && (
+                  <TooltipProvider delayDuration={300}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => setConfirmDelete(true)}
+                          className="shrink-0 hover:cursor-pointer text-destructive hover:text-destructive"
+                        >
+                          <Trash2Icon size={18} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Delete event</TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                )}
               </div>
             </div>
           </CardHeader>
@@ -163,6 +209,25 @@ export default function EventDetail({ event }: { event: EventWithChannelName }) 
           )}
         </Card>
       </div>
+
+      <Dialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete event?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete &ldquo;{event.title}&rdquo;. This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmDelete(false)} disabled={deleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? "Deleting…" : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -636,3 +636,7 @@ export async function createEvent({
     bookmarked: false,
   };
 }
+
+export async function deleteEvent(id: number): Promise<void> {
+  await db.delete(events).where(eq(events.id, id));
+}

--- a/src/pages/api/events/[eventID]/index.ts
+++ b/src/pages/api/events/[eventID]/index.ts
@@ -1,0 +1,30 @@
+import { deleteEvent, getEvent } from "@/lib/beaver/event";
+import { getUserProjectRole } from "@/lib/beaver/project-member";
+import type { APIContext } from "astro";
+
+export async function DELETE({ params, locals }: APIContext) {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const eventId = parseInt(params.eventID!);
+  if (isNaN(eventId)) {
+    return new Response(JSON.stringify({ error: "Invalid event ID" }), { status: 400 });
+  }
+
+  const event = await getEvent(eventId, user.id);
+  if (!event) {
+    return new Response(JSON.stringify({ error: "Event not found" }), { status: 404 });
+  }
+
+  const role = user.isAdmin ? "owner" : await getUserProjectRole(event.projectId, user.id);
+  if (role !== "owner" && role !== "maintainer") {
+    return new Response(JSON.stringify({ error: "Forbidden" }), { status: 403 });
+  }
+
+  await deleteEvent(eventId);
+  return new Response(JSON.stringify({ ok: true }), { status: 200 });
+}
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/events/[eventID].astro
+++ b/src/pages/dashboard/[projectID]/events/[eventID].astro
@@ -2,16 +2,21 @@
 import Layout from "@/layouts/layout.astro";
 import EventDetail from "@/components/event-detail";
 import { getEvent } from "@/lib/beaver/event";
+import { getUserProjectRole } from "@/lib/beaver/project-member";
 
 const { projectID, eventID } = Astro.params;
+const user = Astro.locals.user!;
 
-const event = await getEvent(parseInt(eventID!), Astro.locals.user?.id);
+const event = await getEvent(parseInt(eventID!), user.id);
 
 if (!event) {
   return Astro.redirect(`/dashboard/${projectID}/feed`);
 }
+
+const role = user.isAdmin ? "owner" : await getUserProjectRole(event.projectId, user.id);
+const canDelete = role === "owner" || role === "maintainer";
 ---
 
 <Layout projectID={projectID!}>
-  <EventDetail client:visible event={event} />
+  <EventDetail client:visible event={event} canDelete={canDelete} />
 </Layout>


### PR DESCRIPTION
Closes #120.

## Changes

- `DELETE /api/events/[eventID]` — validates auth and that the caller is an owner or maintainer of the event's project before deleting
- `deleteEvent()` added to `src/lib/beaver/event.ts`
- Event detail page now resolves the user's role server-side and passes `canDelete` to the component
- Trash icon button appears in the event header for owners/maintainers; triggers a confirmation dialog before deleting
- On successful delete, navigates back to the project feed

## Test plan

- [ ] As owner/maintainer: trash icon is visible on event detail, confirmation dialog appears, event is deleted and redirects to feed
- [ ] As guest: trash icon is not visible
- [ ] `DELETE /api/events/:id` returns 403 for guests and 404 for unknown events