### PR TITLE
feat: assign projects and roles when creating a user

### DIFF
--- a/src/components/admin-users-view.tsx
+++ b/src/components/admin-users-view.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect } from "react";
 import type { User } from "@/lib/beaver/user";
+import type { Role } from "@/lib/beaver/project-member";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "./ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+import { RoleSelectItem } from "./role-select-item";
 import {
   ArrowLeftIcon,
   CheckIcon,
@@ -16,7 +19,11 @@ import {
   ShieldIcon,
   ShieldOffIcon,
   Trash2Icon,
+  XIcon,
 } from "lucide-react";
+
+type ProjectOption = { id: number; name: string };
+type Assignment = { projectId: string; role: Role };
 
 function TempPasswordCell({ tempPassword }: { tempPassword: string }) {
   const [copied, setCopied] = useState(false);
@@ -136,10 +143,12 @@ export default function AdminUsersView({
   initialUsers,
   currentUserId,
   backUrl,
+  allProjects,
 }: {
   initialUsers: User[];
   currentUserId: number;
   backUrl: string;
+  allProjects: ProjectOption[];
 }) {
   const [users, setUsers] = useState<User[]>(initialUsers);
   const [resolvedBackUrl, setResolvedBackUrl] = useState(backUrl);
@@ -153,8 +162,31 @@ export default function AdminUsersView({
   const [createOpen, setCreateOpen] = useState(false);
   const [newUsername, setNewUsername] = useState("");
   const [newCanCreateProjects, setNewCanCreateProjects] = useState(false);
+  const [newAssignments, setNewAssignments] = useState<Assignment[]>([]);
   const [createError, setCreateError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+
+  const addAssignmentRow = () => {
+    const taken = new Set(newAssignments.map((a) => a.projectId));
+    const next = allProjects.find((p) => !taken.has(String(p.id)));
+    if (!next) return;
+    setNewAssignments((prev) => [...prev, { projectId: String(next.id), role: "guest" }]);
+  };
+
+  const updateAssignment = (index: number, patch: Partial<Assignment>) => {
+    setNewAssignments((prev) => prev.map((a, i) => (i === index ? { ...a, ...patch } : a)));
+  };
+
+  const removeAssignment = (index: number) => {
+    setNewAssignments((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const projectOptionsFor = (index: number) => {
+    const takenByOthers = new Set(
+      newAssignments.filter((_, i) => i !== index).map((a) => a.projectId),
+    );
+    return allProjects.filter((p) => !takenByOthers.has(String(p.id)));
+  };
 
   // Delete confirmation
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
@@ -175,6 +207,10 @@ export default function AdminUsersView({
         body: JSON.stringify({
           userName: newUsername.trim(),
           canCreateProjects: newCanCreateProjects,
+          projectAssignments: newAssignments.map((a) => ({
+            projectId: parseInt(a.projectId),
+            role: a.role,
+          })),
         }),
       });
       const data = await res.json();
@@ -185,6 +221,7 @@ export default function AdminUsersView({
       setUsers((prev) => [...prev, data]);
       setNewUsername("");
       setNewCanCreateProjects(false);
+      setNewAssignments([]);
       setCreateOpen(false);
     } finally {
       setCreating(false);
@@ -311,6 +348,63 @@ export default function AdminUsersView({
                       />
                       <Label htmlFor="canCreateProjects">Can create projects</Label>
                     </div>
+                    {allProjects.length > 0 && (
+                      <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                          <Label>Project assignment</Label>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            onClick={addAssignmentRow}
+                            disabled={newAssignments.length >= allProjects.length}
+                          >
+                            <PlusIcon size={14} />
+                            Add project
+                          </Button>
+                        </div>
+                        {newAssignments.map((assignment, i) => (
+                          <div key={i} className="flex items-center gap-2">
+                            <Select
+                              value={assignment.projectId}
+                              onValueChange={(val) => updateAssignment(i, { projectId: val })}
+                            >
+                              <SelectTrigger className="flex-1">
+                                <SelectValue placeholder="Select a project…" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {projectOptionsFor(i).map((p) => (
+                                  <SelectItem key={p.id} value={String(p.id)}>
+                                    {p.name}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
+                            <Select
+                              value={assignment.role}
+                              onValueChange={(val) => updateAssignment(i, { role: val as Role })}
+                            >
+                              <SelectTrigger className="w-36">
+                                <SelectValue />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <RoleSelectItem role="owner" />
+                                <RoleSelectItem role="maintainer" />
+                                <RoleSelectItem role="guest" />
+                              </SelectContent>
+                            </Select>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeAssignment(i)}
+                            >
+                              <XIcon size={14} />
+                            </Button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                     <p className="text-sm text-muted-foreground">
                       A temporary password will be generated. Share it with the user — they'll be
                       prompted to set a new one on first login.

--- a/src/components/project-members.tsx
+++ b/src/components/project-members.tsx
@@ -3,47 +3,9 @@ import { Button } from "./ui/button";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "./ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
-import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, UserMinusIcon, UserPlusIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
-
-type Role = "owner" | "maintainer" | "guest";
-
-const ROLE_INFO: Record<Role, { label: string; description: string }> = {
-  owner: {
-    label: "Owner",
-    description: "Full control: manage members, project settings, channels, and events.",
-  },
-  maintainer: {
-    label: "Maintainer",
-    description: "Manage channels and channel groups; view all events.",
-  },
-  guest: {
-    label: "Guest",
-    description: "View-only access to channels and events.",
-  },
-};
-
-function RoleSelectItem({ role }: { role: Role }) {
-  const info = ROLE_INFO[role];
-  return (
-    <SelectPrimitive.Item
-      value={role}
-      textValue={info.label}
-      className={cn(
-        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default flex-col items-start gap-0.5 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      )}
-    >
-      <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
-        <SelectPrimitive.ItemIndicator>
-          <CheckIcon className="size-4" />
-        </SelectPrimitive.ItemIndicator>
-      </span>
-      <SelectPrimitive.ItemText>{info.label}</SelectPrimitive.ItemText>
-      <span className="text-xs text-muted-foreground pr-2">{info.description}</span>
-    </SelectPrimitive.Item>
-  );
-}
+import { RoleSelectItem } from "./role-select-item";
+import { UserMinusIcon, UserPlusIcon } from "lucide-react";
+import type { Role } from "@/lib/beaver/project-member";
 
 type Member = {
   id: number;

--- a/src/components/role-select-item.tsx
+++ b/src/components/role-select-item.tsx
@@ -1,0 +1,40 @@
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { CheckIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { Role } from "@/lib/beaver/project-member";
+
+export const ROLE_INFO: Record<Role, { label: string; description: string }> = {
+  owner: {
+    label: "Owner",
+    description: "Full control: manage members, project settings, channels, and events.",
+  },
+  maintainer: {
+    label: "Maintainer",
+    description: "Manage channels and channel groups; view all events.",
+  },
+  guest: {
+    label: "Guest",
+    description: "View-only access to channels and events.",
+  },
+};
+
+export function RoleSelectItem({ role }: { role: Role }) {
+  const info = ROLE_INFO[role];
+  return (
+    <SelectPrimitive.Item
+      value={role}
+      textValue={info.label}
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground relative flex w-full cursor-default flex-col items-start gap-0.5 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      )}
+    >
+      <span className="absolute right-2 top-2 flex size-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className="size-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{info.label}</SelectPrimitive.ItemText>
+      <span className="text-xs text-muted-foreground pr-2">{info.description}</span>
+    </SelectPrimitive.Item>
+  );
+}

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -34,6 +34,12 @@ const backUrl = projects.length > 0 ? `/dashboard/${projects[0].id}/feed` : "/";
     </script>
   </head>
   <body>
-    <AdminUsersView client:visible initialUsers={allUsers} currentUserId={user.id} backUrl={backUrl} />
+    <AdminUsersView
+      client:visible
+      initialUsers={allUsers}
+      currentUserId={user.id}
+      backUrl={backUrl}
+      allProjects={projects.map((p) => ({ id: p.id, name: p.name }))}
+    />
   </body>
 </html>

--- a/src/pages/api/users.ts
+++ b/src/pages/api/users.ts
@@ -6,6 +6,25 @@ import {
   setUserAdmin,
   setCanCreateProjects,
 } from "@/lib/beaver/user";
+import { addProjectMember, type Role } from "@/lib/beaver/project-member";
+
+const VALID_ROLES: Role[] = ["owner", "maintainer", "guest"];
+
+type ProjectAssignment = { projectId: number; role: Role };
+
+function parseProjectAssignments(input: unknown): ProjectAssignment[] | null {
+  if (input === undefined) return [];
+  if (!Array.isArray(input)) return null;
+
+  const assignments: ProjectAssignment[] = [];
+  for (const entry of input) {
+    const projectId = Number(entry?.projectId);
+    const role = entry?.role;
+    if (!Number.isInteger(projectId) || !VALID_ROLES.includes(role)) return null;
+    assignments.push({ projectId, role });
+  }
+  return assignments;
+}
 
 function requireAdmin(context: APIContext): Response | null {
   if (!context.locals.user?.isAdmin) {
@@ -40,7 +59,7 @@ export const POST: APIRoute = async (context) => {
   if (denied) return denied;
 
   try {
-    const { userName, canCreateProjects } = await context.request.json();
+    const { userName, canCreateProjects, projectAssignments } = await context.request.json();
 
     if (!userName?.trim()) {
       return new Response(JSON.stringify({ error: "userName is required." }), {
@@ -49,7 +68,20 @@ export const POST: APIRoute = async (context) => {
       });
     }
 
+    const assignments = parseProjectAssignments(projectAssignments);
+    if (assignments === null) {
+      return new Response(JSON.stringify({ error: "Invalid project assignments." }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
     const user = await createUserAccount(userName.trim(), canCreateProjects ?? false);
+
+    for (const { projectId, role } of assignments) {
+      await addProjectMember(projectId, user.id, role);
+    }
+
     return new Response(JSON.stringify(user), {
       status: 200,
       headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- Create-user dialog now has an optional "Project assignment" section where an admin can add one or more project + role rows before submitting
- `POST /api/users` accepts a `projectAssignments` array and adds the new user as a member of each selected project with the chosen role
- Extracted `RoleSelectItem`/`ROLE_INFO` out of `project-members.tsx` into a shared `role-select-item.tsx` so the same role dropdown (with descriptions) is reused in the create-user dialog

## Issue
Closes #131

## Test plan
- [x] Admin → Users → New user: "Project assignment" section appears with an "Add project" button
- [x] Add a row, pick a project + role, create the user — user is created and added as a member of that project with that role
- [x] Add multiple rows — each row only offers projects not already selected in another row
- [x] Existing project-members.tsx role dropdown (Members tab) still renders/functions the same after the shared-component extraction