### PR TITLE
refactor: email notifications

### DIFF
--- a/drizzle/0013_red_captain_marvel.sql
+++ b/drizzle/0013_red_captain_marvel.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `channel_notification_subscriptions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`channel_id` integer NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `channel_notification_subscriptions_user_channel_idx` ON `channel_notification_subscriptions` (`user_id`,`channel_id`);--> statement-breakpoint
+CREATE INDEX `channel_notification_subscriptions_channel_id_idx` ON `channel_notification_subscriptions` (`channel_id`);--> statement-breakpoint
+ALTER TABLE `project_members` DROP COLUMN `notifications_enabled`;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,983 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "60cb3211-d299-4d06-a090-1b1dd7670b68",
+  "prevId": "f8727ccc-2b58-47c4-8c1a-c73abc503e81",
+  "tables": {
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1780282199132,
       "tag": "0012_tense_gressill",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1781838438602,
+      "tag": "0013_red_captain_marvel",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/notification-settings.tsx
+++ b/src/components/notification-settings.tsx
@@ -1,22 +1,23 @@
 import { useState } from "react";
+import type { Channel } from "@/lib/beaver/channel";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { BellIcon, BellOffIcon } from "lucide-react";
 
 export default function NotificationSettings({
-  projectId,
+  channels,
   initialEmail,
-  initialEnabled,
+  subscribedChannelIds,
 }: {
-  projectId: number;
+  channels: Channel[];
   initialEmail: string | null;
-  initialEnabled: boolean;
+  subscribedChannelIds: number[];
 }) {
   const [email, setEmail] = useState(initialEmail ?? "");
-  const [enabled, setEnabled] = useState(initialEnabled);
-  const [saving, setSaving] = useState(false);
   const [savedEmail, setSavedEmail] = useState(initialEmail ?? "");
+  const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [subscribed, setSubscribed] = useState(new Set(subscribedChannelIds));
 
   const saveEmail = async () => {
     setSaving(true);
@@ -41,17 +42,37 @@ export default function NotificationSettings({
     }
   };
 
-  const toggleNotifications = async (next: boolean) => {
-    if (next && !savedEmail) {
-      alert("Please save an email address before enabling notifications.");
-      return;
-    }
-    setEnabled(next);
+  const toggleChannel = async (channelId: number, next: boolean) => {
+    if (!savedEmail) return;
+    setSubscribed((prev) => {
+      const updated = new Set(prev);
+      if (next) updated.add(channelId);
+      else updated.delete(channelId);
+      return updated;
+    });
     await fetch("/api/notifications", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ projectId, enabled: next }),
-    }).catch(() => setEnabled(!next));
+      body: JSON.stringify({ channelId, enabled: next }),
+    }).catch(() => {
+      setSubscribed((prev) => {
+        const reverted = new Set(prev);
+        if (next) reverted.delete(channelId);
+        else reverted.add(channelId);
+        return reverted;
+      });
+    });
+  };
+
+  const setAll = async (next: boolean) => {
+    if (!savedEmail) return;
+    const channelIds = channels.map((c) => c.id);
+    setSubscribed(next ? new Set(channelIds) : new Set());
+    await fetch("/api/notifications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ channelIds, enabled: next }),
+    }).catch(() => setSubscribed(new Set(subscribedChannelIds)));
   };
 
   return (
@@ -83,32 +104,70 @@ export default function NotificationSettings({
         </div>
       </div>
 
-      {/* Toggle */}
-      <div className="flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2">
-        <div>
-          <h3 className="font-medium shrink-0">Event Notifications</h3>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            Receive an email when an event is posted with{" "}
-            <code className="bg-muted px-1 rounded text-xs">"notify": true</code>
-          </p>
+      {/* Channels */}
+      <div className="flex flex-col gap-2">
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="font-medium shrink-0">Channel Notifications</h3>
+            <p className="text-sm text-muted-foreground mt-0.5">
+              Receive an email when an event is posted to a channel with{" "}
+              <code className="bg-muted px-1 rounded text-xs">"notify": true</code>
+            </p>
+          </div>
+          <div className="flex gap-3 shrink-0">
+            <button
+              type="button"
+              onClick={() => setAll(true)}
+              disabled={!savedEmail}
+              className="text-sm text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50 disabled:no-underline"
+            >
+              Select all
+            </button>
+            <button
+              type="button"
+              onClick={() => setAll(false)}
+              disabled={!savedEmail}
+              className="text-sm text-blue-600 dark:text-blue-400 hover:underline disabled:opacity-50 disabled:no-underline"
+            >
+              Clear all
+            </button>
+          </div>
         </div>
-        <Button
-          variant={enabled ? "default" : "outline"}
-          onClick={() => toggleNotifications(!enabled)}
-          className="gap-2 shrink-0"
-        >
-          {enabled ? (
-            <>
-              <BellIcon className="size-4" />
-              Enabled
-            </>
-          ) : (
-            <>
-              <BellOffIcon className="size-4" />
-              Disabled
-            </>
-          )}
-        </Button>
+        {!savedEmail && (
+          <p className="text-sm text-muted-foreground">Add an email address first.</p>
+        )}
+        <div className="flex flex-col">
+          {channels.map((channel) => {
+            const isSubscribed = subscribed.has(channel.id);
+            return (
+              <div
+                key={channel.id}
+                className="flex items-center justify-between py-1.5 border-b last:border-0"
+              >
+                <span className="text-sm">{channel.name}</span>
+                <Button
+                  variant={isSubscribed ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => toggleChannel(channel.id, !isSubscribed)}
+                  disabled={!savedEmail}
+                  className="gap-2"
+                >
+                  {isSubscribed ? (
+                    <>
+                      <BellIcon className="size-4" />
+                      Enabled
+                    </>
+                  ) : (
+                    <>
+                      <BellOffIcon className="size-4" />
+                      Disabled
+                    </>
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -18,7 +18,7 @@ interface Props {
   isOwner: boolean;
   currentUserId: number;
   initialEmail: string | null;
-  initialEnabled: boolean;
+  subscribedChannelIds: number[];
 }
 
 const row = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
@@ -31,7 +31,7 @@ export default function SettingsTabs({
   isOwner,
   currentUserId,
   initialEmail,
-  initialEnabled,
+  subscribedChannelIds,
 }: Props) {
   const createdAt = project.createdAt ? new Date(project.createdAt).toLocaleDateString() : "—";
   const defaultTab = isOwner ? "general" : "channels";
@@ -98,9 +98,9 @@ export default function SettingsTabs({
       <TabsContent value="notifications" className="mt-6 md:mt-0">
         {show("notifications") && (
           <NotificationSettings
-            projectId={project.id}
+            channels={channels}
             initialEmail={initialEmail}
-            initialEnabled={initialEnabled}
+            subscribedChannelIds={subscribedChannelIds}
           />
         )}
       </TabsContent>

--- a/src/lib/beaver/channel-notification.ts
+++ b/src/lib/beaver/channel-notification.ts
@@ -1,0 +1,74 @@
+import { db } from "../db/db";
+import { channelNotificationSubscriptions, channels, users } from "../db/schema";
+import { eq, and, inArray } from "drizzle-orm";
+
+export async function getChannelSubscriptions(
+  userId: number,
+  projectId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ channelId: channelNotificationSubscriptions.channelId })
+    .from(channelNotificationSubscriptions)
+    .innerJoin(channels, eq(channelNotificationSubscriptions.channelId, channels.id))
+    .where(
+      and(eq(channelNotificationSubscriptions.userId, userId), eq(channels.projectId, projectId)),
+    );
+
+  return rows.map((r) => r.channelId);
+}
+
+export async function setChannelNotification(
+  userId: number,
+  channelId: number,
+  enabled: boolean,
+): Promise<void> {
+  if (enabled) {
+    await db
+      .insert(channelNotificationSubscriptions)
+      .values({ userId, channelId })
+      .onConflictDoNothing();
+  } else {
+    await db
+      .delete(channelNotificationSubscriptions)
+      .where(
+        and(
+          eq(channelNotificationSubscriptions.userId, userId),
+          eq(channelNotificationSubscriptions.channelId, channelId),
+        ),
+      );
+  }
+}
+
+export async function setChannelNotifications(
+  userId: number,
+  channelIds: number[],
+  enabled: boolean,
+): Promise<void> {
+  if (channelIds.length === 0) return;
+
+  if (enabled) {
+    await db
+      .insert(channelNotificationSubscriptions)
+      .values(channelIds.map((channelId) => ({ userId, channelId })))
+      .onConflictDoNothing();
+  } else {
+    await db
+      .delete(channelNotificationSubscriptions)
+      .where(
+        and(
+          eq(channelNotificationSubscriptions.userId, userId),
+          inArray(channelNotificationSubscriptions.channelId, channelIds),
+        ),
+      );
+  }
+}
+
+export async function getNotificationEmailsForChannel(channelId: number): Promise<string[]> {
+  const rows = await db
+    .select({ email: users.email })
+    .from(channelNotificationSubscriptions)
+    .innerJoin(users, eq(channelNotificationSubscriptions.userId, users.id))
+    .where(eq(channelNotificationSubscriptions.channelId, channelId));
+
+  return rows.flatMap((r) => (r.email ? [r.email] : []));
+}

--- a/src/lib/beaver/project-member.ts
+++ b/src/lib/beaver/project-member.ts
@@ -43,22 +43,6 @@ export async function getUserProjectRole(projectId: number, userId: number): Pro
   return rows[0]?.role ?? null;
 }
 
-export async function getProjectMembership(
-  projectId: number,
-  userId: number,
-): Promise<{ role: Role; notificationsEnabled: boolean } | null> {
-  const rows = await db
-    .select({
-      role: projectMembers.role,
-      notificationsEnabled: projectMembers.notificationsEnabled,
-    })
-    .from(projectMembers)
-    .where(and(eq(projectMembers.projectId, projectId), eq(projectMembers.userId, userId)))
-    .limit(1);
-
-  return rows[0] ?? null;
-}
-
 export async function addProjectMember(
   projectId: number,
   userId: number,

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/db";
-import { users, sessions, projectMembers } from "../db/schema";
-import { eq, and } from "drizzle-orm";
+import { users, sessions } from "../db/schema";
+import { eq } from "drizzle-orm";
 
 export type DatabaseUser = {
   id: number;
@@ -177,27 +177,4 @@ export async function updateUserEmail(id: number, email: string | null): Promise
 
 export async function updateUserFullName(id: number, fullName: string | null): Promise<void> {
   await db.update(users).set({ fullName }).where(eq(users.id, id));
-}
-
-export async function setProjectNotifications(
-  userId: number,
-  projectId: number,
-  enabled: boolean,
-): Promise<void> {
-  await db
-    .update(projectMembers)
-    .set({ notificationsEnabled: enabled })
-    .where(and(eq(projectMembers.userId, userId), eq(projectMembers.projectId, projectId)));
-}
-
-export async function getNotificationEmails(projectId: number): Promise<string[]> {
-  const rows = await db
-    .select({ email: users.email })
-    .from(projectMembers)
-    .innerJoin(users, eq(projectMembers.userId, users.id))
-    .where(
-      and(eq(projectMembers.projectId, projectId), eq(projectMembers.notificationsEnabled, true)),
-    );
-
-  return rows.flatMap((r) => (r.email ? [r.email] : []));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -156,9 +156,6 @@ export const projectMembers = sqliteTable(
     role: text("role", { enum: ["owner", "maintainer", "guest"] })
       .notNull()
       .default("guest"),
-    notificationsEnabled: integer("notifications_enabled", { mode: "boolean" })
-      .notNull()
-      .default(false),
     createdAt: integer("created_at", { mode: "timestamp_ms" })
       .default(sql`(unixepoch() * 1000)`)
       .notNull(),
@@ -169,6 +166,30 @@ export const projectMembers = sqliteTable(
       table.userId,
     ),
     userIdIdx: index("project_members_user_id_idx").on(table.userId),
+  }),
+);
+
+// --- CHANNEL NOTIFICATION SUBSCRIPTIONS ---
+export const channelNotificationSubscriptions = sqliteTable(
+  "channel_notification_subscriptions",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    channelId: integer("channel_id")
+      .notNull()
+      .references(() => channels.id, { onDelete: "cascade" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    userChannelIdx: uniqueIndex("channel_notification_subscriptions_user_channel_idx").on(
+      table.userId,
+      table.channelId,
+    ),
+    channelIdIdx: index("channel_notification_subscriptions_channel_id_idx").on(table.channelId),
   }),
 );
 
@@ -345,6 +366,20 @@ export const channelReadRelations = relations(channelReads, ({ one }) => ({
     references: [channels.id],
   }),
 }));
+
+export const channelNotificationSubscriptionRelations = relations(
+  channelNotificationSubscriptions,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [channelNotificationSubscriptions.userId],
+      references: [users.id],
+    }),
+    channel: one(channels, {
+      fields: [channelNotificationSubscriptions.channelId],
+      references: [channels.id],
+    }),
+  }),
+);
 
 export const metricRelations = relations(metrics, ({ one, many }) => ({
   project: one(projects, {

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -2,7 +2,7 @@ import { db } from "@/lib/db/db";
 import { events, channels, eventTags } from "@/lib/db/schema";
 import { EVENT_NAME_REGEX, RESERVED_OBJECT } from "@/lib/beaver/event";
 import { getProject } from "@/lib/beaver/project";
-import { getNotificationEmails } from "@/lib/beaver/user";
+import { getNotificationEmailsForChannel } from "@/lib/beaver/channel-notification";
 import { sendEventNotification } from "@/lib/email/resend";
 import { publishEvent } from "@/lib/beaver/event-bus";
 import { eq } from "drizzle-orm";
@@ -137,7 +137,7 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
     // Fire notifications outside the transaction
     created.forEach((event, i) => {
       if (resolved[i].payload.notify === true) {
-        getNotificationEmails(event.projectId).then((emails) => {
+        getNotificationEmailsForChannel(resolved[i].channel.id).then((emails) => {
           if (emails.length > 0) {
             sendEventNotification(event, resolved[i].project.name, emails).catch(() => {});
           }

--- a/src/pages/api/notifications.ts
+++ b/src/pages/api/notifications.ts
@@ -1,4 +1,4 @@
-import { setProjectNotifications } from "@/lib/beaver/user";
+import { setChannelNotification, setChannelNotifications } from "@/lib/beaver/channel-notification";
 import type { APIContext } from "astro";
 
 export async function POST({ locals, request }: APIContext) {
@@ -9,14 +9,26 @@ export async function POST({ locals, request }: APIContext) {
     });
   }
 
-  const { projectId, enabled } = await request.json();
-  if (typeof projectId !== "number" || typeof enabled !== "boolean") {
+  const body = await request.json();
+
+  if (Array.isArray(body.channelIds) && typeof body.enabled === "boolean") {
+    if (!body.channelIds.every((id: unknown) => typeof id === "number")) {
+      return new Response(JSON.stringify({ error: "Invalid request" }), { status: 400 });
+    }
+    await setChannelNotifications(user.id, body.channelIds, body.enabled);
+    return new Response(JSON.stringify({ ok: true }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const { channelId, enabled } = body;
+  if (typeof channelId !== "number" || typeof enabled !== "boolean") {
     return new Response(JSON.stringify({ error: "Invalid request" }), {
       status: 400,
     });
   }
 
-  await setProjectNotifications(user.id, projectId, enabled);
+  await setChannelNotification(user.id, channelId, enabled);
   return new Response(JSON.stringify({ ok: true }), {
     headers: { "Content-Type": "application/json" },
   });

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -4,8 +4,9 @@ import Layout from "@/layouts/layout.astro";
 import { getMetrics } from "@/lib/beaver/metric";
 import { getChannels } from "@/lib/beaver/channel";
 import { getProject } from "@/lib/beaver/project";
-import { getUserProjectRole, getProjectMembership } from "@/lib/beaver/project-member";
+import { getUserProjectRole } from "@/lib/beaver/project-member";
 import { getUserByUsername } from "@/lib/beaver/user";
+import { getChannelSubscriptions } from "@/lib/beaver/channel-notification";
 
 const { projectID } = Astro.params;
 const user = Astro.locals.user!;
@@ -23,7 +24,7 @@ if (userRole === "guest" || userRole === null) {
 const channels = await getChannels(parseInt(projectID!));
 const metrics = await getMetrics(parseInt(projectID!));
 const dbUser = await getUserByUsername(user.userName);
-const membership = await getProjectMembership(project.id, user.id);
+const subscribedChannelIds = await getChannelSubscriptions(user.id, project.id);
 
 const isOwner = userRole === "owner";
 ---
@@ -43,7 +44,7 @@ const isOwner = userRole === "owner";
           isOwner={isOwner}
           currentUserId={user.id}
           initialEmail={dbUser?.email ?? null}
-          initialEnabled={membership?.notificationsEnabled ?? false}
+          subscribedChannelIds={subscribedChannelIds}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the project-wide `notificationsEnabled` toggle with per-channel subscriptions (`channelNotificationSubscriptions` table), so a user only gets emails for channels they explicitly subscribe to.
- New `src/lib/beaver/channel-notification.ts` lib with `getChannelSubscriptions`, `setChannelNotification`, `setChannelNotifications`, `getNotificationEmailsForChannel`.
- `/api/notifications` now accepts either a single `{channelId, enabled}` or bulk `{channelIds, enabled}` payload.
- `/api/event.ts` notification dispatch is now scoped to the event's channel instead of the whole project.
- Notification settings UI lists every channel with its own toggle, plus "Select all" / "Clear all", and still gates on having a saved email.

Closes #172

## Test plan
- [x] `bun run build` (type-checks via Astro) passes
- [x] `bun run lint` / `bun run format:check` pass
- [x] Manually verified in browser: Settings > Notifications shows per-channel toggles, select all/clear all work, toggles are disabled until an email is saved