### PR TITLE
feat: add threshold-based alert rules for events

### DIFF
--- a/drizzle/0015_goofy_lilith.sql
+++ b/drizzle/0015_goofy_lilith.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `alert_rules` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`channel_id` integer NOT NULL,
+	`name` text NOT NULL,
+	`event_object` text NOT NULL,
+	`event_action` text NOT NULL,
+	`threshold` integer NOT NULL,
+	`window_minutes` integer NOT NULL,
+	`enabled` integer DEFAULT true NOT NULL,
+	`last_triggered_at` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`channel_id`) REFERENCES `channels`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `alert_rules_channel_id_idx` ON `alert_rules` (`channel_id`);--> statement-breakpoint
+CREATE INDEX `alert_rules_channel_id_event_object_event_action_idx` ON `alert_rules` (`channel_id`,`event_object`,`event_action`);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1162 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "63fba0c5-3bb5-4553-9c34-6020c7e7180b",
+  "prevId": "133596e7-4927-4979-adb9-0b6b9a422e6e",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1781839162229,
       "tag": "0014_fixed_shiver_man",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1781840086052,
+      "tag": "0015_goofy_lilith",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/alert-settings.tsx
+++ b/src/components/alert-settings.tsx
@@ -1,0 +1,316 @@
+import type { Channel } from "@/lib/beaver/channel";
+import type { AlertRuleWithChannel } from "@/lib/beaver/alert-rule";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogClose,
+} from "./ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { Input } from "./ui/input";
+import { Button } from "./ui/button";
+import { Label } from "./ui/label";
+import { Trash2Icon, PlusIcon, BellRingIcon } from "lucide-react";
+import { useState } from "react";
+
+const EVENT_NAME_REGEX = /^[a-z][a-z_]*\.[a-z][a-z_]*$/;
+
+function sanitizeEventName(value: string): string {
+  return value.toLowerCase().replace(/[^a-z._]/g, "");
+}
+
+export default function AlertSettings({
+  channels,
+  initialRules,
+}: {
+  channels: Channel[];
+  initialRules: AlertRuleWithChannel[];
+}) {
+  const [rules, setRules] = useState<AlertRuleWithChannel[]>(initialRules);
+
+  // Create state
+  const [createOpen, setCreateOpen] = useState(false);
+  const [createChannelId, setCreateChannelId] = useState<string>(
+    channels[0] ? String(channels[0].id) : "",
+  );
+  const [createName, setCreateName] = useState("");
+  const [createEventName, setCreateEventName] = useState("");
+  const [createThreshold, setCreateThreshold] = useState("5");
+  const [createWindowMinutes, setCreateWindowMinutes] = useState("10");
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState("");
+
+  const eventNameValid = EVENT_NAME_REGEX.test(createEventName);
+
+  const resetCreateForm = () => {
+    setCreateChannelId(channels[0] ? String(channels[0].id) : "");
+    setCreateName("");
+    setCreateEventName("");
+    setCreateThreshold("5");
+    setCreateWindowMinutes("10");
+    setCreateError("");
+  };
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setCreateError("");
+    try {
+      const [eventObject, eventAction] = createEventName.split(".");
+      const res = await fetch("/api/alert-rules", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          channelId: parseInt(createChannelId),
+          name: createName.trim(),
+          eventObject,
+          eventAction,
+          threshold: parseInt(createThreshold),
+          windowMinutes: parseInt(createWindowMinutes),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setCreateError(data.error || "Failed to create alert rule.");
+        return;
+      }
+      const channelName = channels.find((c) => c.id === data.channelId)?.name ?? "";
+      setRules((prev) => [...prev, { ...data, channelName }]);
+      setCreateOpen(false);
+      resetCreateForm();
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const toggleEnabled = async (rule: AlertRuleWithChannel) => {
+    const next = !rule.enabled;
+    setRules((prev) => prev.map((r) => (r.id === rule.id ? { ...r, enabled: next } : r)));
+    await fetch("/api/alert-rules", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: rule.id, enabled: next }),
+    });
+  };
+
+  // Delete state
+  const [deleteTarget, setDeleteTarget] = useState<AlertRuleWithChannel | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleting(true);
+    try {
+      await fetch("/api/alert-rules", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: deleteTarget.id }),
+      });
+      setRules((prev) => prev.filter((r) => r.id !== deleteTarget.id));
+      setDeleteTarget(null);
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <h2 className="font-mono">Alerts</h2>
+        <Button
+          size="sm"
+          disabled={channels.length === 0}
+          onClick={() => {
+            resetCreateForm();
+            setCreateOpen(true);
+          }}
+        >
+          <PlusIcon size={14} className="mr-1.5" />
+          New alert
+        </Button>
+      </div>
+
+      {channels.length === 0 && (
+        <p className="text-sm text-muted-foreground mt-4">
+          Create a channel first to start setting up alerts.
+        </p>
+      )}
+
+      {channels.length > 0 && rules.length === 0 && (
+        <p className="text-sm text-muted-foreground mt-4">
+          No alerts yet. Get notified when an event type crosses a threshold within a time window.
+        </p>
+      )}
+
+      {rules.map((rule) => (
+        <div
+          key={rule.id}
+          className="rounded border p-3 md:p-4 mt-4 flex justify-between items-center gap-2"
+        >
+          <div className="min-w-0 flex items-start gap-3">
+            <BellRingIcon size={16} className="mt-0.5 shrink-0 text-muted-foreground" />
+            <div>
+              <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <h3 className="font-medium">{rule.name}</h3>
+                <span className="text-xs text-muted-foreground"># {rule.channelName}</span>
+              </div>
+              <p className="font-light text-xs text-muted-foreground mt-0.5 font-mono">
+                {rule.eventObject}.{rule.eventAction} &ge; {rule.threshold} in {rule.windowMinutes}m
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-1 flex-shrink-0">
+            <Button
+              variant={rule.enabled ? "default" : "outline"}
+              size="sm"
+              onClick={() => toggleEnabled(rule)}
+            >
+              {rule.enabled ? "Enabled" : "Disabled"}
+            </Button>
+            <button
+              onClick={() => setDeleteTarget(rule)}
+              className="p-1.5 rounded hover:bg-muted text-muted-foreground hover:text-destructive transition-colors"
+            >
+              <Trash2Icon size={15} />
+            </button>
+          </div>
+        </div>
+      ))}
+
+      {/* Create dialog */}
+      <Dialog
+        open={createOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCreateOpen(false);
+            setCreateError("");
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>New alert</DialogTitle>
+            <DialogDescription>
+              Fire an email alert when an event type crosses a threshold within a time window.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-4 mt-1">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="alert-channel">Channel</Label>
+              <Select value={createChannelId} onValueChange={setCreateChannelId}>
+                <SelectTrigger id="alert-channel" className="w-full">
+                  <SelectValue placeholder="Select a channel" />
+                </SelectTrigger>
+                <SelectContent>
+                  {channels.map((channel) => (
+                    <SelectItem key={channel.id} value={String(channel.id)}>
+                      # {channel.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="alert-name">Name</Label>
+              <Input
+                id="alert-name"
+                value={createName}
+                placeholder="e.g. High payment failures"
+                onChange={(e) => setCreateName(e.target.value)}
+              />
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="alert-event-name">Event name</Label>
+              <Input
+                id="alert-event-name"
+                value={createEventName}
+                placeholder="e.g. payment.failed"
+                className="font-mono"
+                onChange={(e) => setCreateEventName(sanitizeEventName(e.target.value))}
+              />
+              {createEventName !== "" && !eventNameValid && (
+                <p className="text-xs text-destructive">
+                  Must follow the object.action convention (e.g. payment.failed).
+                </p>
+              )}
+            </div>
+
+            <div className="flex gap-4">
+              <div className="flex flex-col gap-1.5 flex-1">
+                <Label htmlFor="alert-threshold">Threshold</Label>
+                <Input
+                  id="alert-threshold"
+                  type="number"
+                  min={1}
+                  value={createThreshold}
+                  onChange={(e) => setCreateThreshold(e.target.value)}
+                />
+              </div>
+              <div className="flex flex-col gap-1.5 flex-1">
+                <Label htmlFor="alert-window">Window (minutes)</Label>
+                <Input
+                  id="alert-window"
+                  type="number"
+                  min={1}
+                  value={createWindowMinutes}
+                  onChange={(e) => setCreateWindowMinutes(e.target.value)}
+                />
+              </div>
+            </div>
+
+            {createError && <p className="text-sm text-destructive">{createError}</p>}
+
+            <div className="flex gap-2 justify-end">
+              <Button variant="secondary" onClick={() => setCreateOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                disabled={
+                  !createChannelId ||
+                  !createName.trim() ||
+                  !eventNameValid ||
+                  !createThreshold ||
+                  !createWindowMinutes ||
+                  creating
+                }
+                onClick={handleCreate}
+              >
+                {creating ? "Creating…" : "Create"}
+              </Button>
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete dialog */}
+      <Dialog
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete alert</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete{" "}
+              <span className="font-bold">{deleteTarget?.name}</span>? This cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2 justify-end mt-2">
+            <DialogClose asChild>
+              <Button variant="secondary">Cancel</Button>
+            </DialogClose>
+            <Button variant="destructive" disabled={deleting} onClick={handleDelete}>
+              {deleting ? "Deleting…" : "Delete"}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -1,9 +1,11 @@
 import type { Channel } from "@/lib/beaver/channel";
 import type { MetricWithValue } from "@/lib/beaver/metric";
 import type { Project } from "@/lib/beaver/project";
+import type { AlertRuleWithChannel } from "@/lib/beaver/alert-rule";
 import { useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import APIKey from "./api-key";
+import AlertSettings from "./alert-settings";
 import ChannelSettings from "./channel-settings";
 import MetricSettings from "./metric-settings";
 import NotificationSettings from "./notification-settings";
@@ -15,6 +17,7 @@ interface Props {
   project: Project;
   channels: Channel[];
   metrics: MetricWithValue[];
+  alertRules: AlertRuleWithChannel[];
   isOwner: boolean;
   currentUserId: number;
   initialEmail: string | null;
@@ -28,6 +31,7 @@ export default function SettingsTabs({
   project,
   channels,
   metrics,
+  alertRules,
   isOwner,
   currentUserId,
   initialEmail,
@@ -52,6 +56,7 @@ export default function SettingsTabs({
         <TabsTrigger value="channels">Channels</TabsTrigger>
         {isOwner && <TabsTrigger value="members">Members</TabsTrigger>}
         <TabsTrigger value="metrics">Metrics</TabsTrigger>
+        <TabsTrigger value="alerts">Alerts</TabsTrigger>
         <TabsTrigger value="notifications">Notifications</TabsTrigger>
         {isOwner && (
           <TabsTrigger value="danger" className="text-destructive">
@@ -93,6 +98,10 @@ export default function SettingsTabs({
 
       <TabsContent value="metrics" className="mt-6 md:mt-0">
         {show("metrics") && <MetricSettings metrics={metrics} projectId={project.id} />}
+      </TabsContent>
+
+      <TabsContent value="alerts" className="mt-6 md:mt-0">
+        {show("alerts") && <AlertSettings channels={channels} initialRules={alertRules} />}
       </TabsContent>
 
       <TabsContent value="notifications" className="mt-6 md:mt-0">

--- a/src/lib/beaver/alert-rule.ts
+++ b/src/lib/beaver/alert-rule.ts
@@ -1,0 +1,159 @@
+import { db } from "../db/db";
+import { alertRules, channels, events } from "../db/schema";
+import { eq, and, gte, count } from "drizzle-orm";
+import type { Channel } from "./channel";
+import type { Project } from "./project";
+import { getNotificationEmailsForChannel } from "./channel-notification";
+import { sendAlertEmail } from "../email/send";
+
+export type AlertRule = {
+  id: number;
+  channelId: number;
+  name: string;
+  eventObject: string;
+  eventAction: string;
+  threshold: number;
+  windowMinutes: number;
+  enabled: boolean;
+  lastTriggeredAt: Date | null;
+  createdAt: Date | null;
+};
+
+export type AlertRuleWithChannel = AlertRule & {
+  channelName: string;
+};
+
+export async function getAlertRulesForProject(projectId: number): Promise<AlertRuleWithChannel[]> {
+  const rows = await db
+    .select({
+      id: alertRules.id,
+      channelId: alertRules.channelId,
+      name: alertRules.name,
+      eventObject: alertRules.eventObject,
+      eventAction: alertRules.eventAction,
+      threshold: alertRules.threshold,
+      windowMinutes: alertRules.windowMinutes,
+      enabled: alertRules.enabled,
+      lastTriggeredAt: alertRules.lastTriggeredAt,
+      createdAt: alertRules.createdAt,
+      channelName: channels.name,
+    })
+    .from(alertRules)
+    .innerJoin(channels, eq(alertRules.channelId, channels.id))
+    .where(eq(channels.projectId, projectId));
+
+  return rows;
+}
+
+export async function getAlertRulesForChannelEvent(
+  channelId: number,
+  eventObject: string,
+  eventAction: string,
+): Promise<AlertRule[]> {
+  return await db
+    .select()
+    .from(alertRules)
+    .where(
+      and(
+        eq(alertRules.channelId, channelId),
+        eq(alertRules.eventObject, eventObject),
+        eq(alertRules.eventAction, eventAction),
+        eq(alertRules.enabled, true),
+      ),
+    );
+}
+
+export async function createAlertRule(input: {
+  channelId: number;
+  name: string;
+  eventObject: string;
+  eventAction: string;
+  threshold: number;
+  windowMinutes: number;
+}): Promise<AlertRule> {
+  const [row] = await db.insert(alertRules).values(input).returning();
+  return row as AlertRule;
+}
+
+export async function updateAlertRule(
+  id: number,
+  patch: Partial<{
+    name: string;
+    eventObject: string;
+    eventAction: string;
+    threshold: number;
+    windowMinutes: number;
+    enabled: boolean;
+  }>,
+): Promise<void> {
+  await db.update(alertRules).set(patch).where(eq(alertRules.id, id));
+}
+
+export async function deleteAlertRule(id: number): Promise<void> {
+  await db.delete(alertRules).where(eq(alertRules.id, id));
+}
+
+// Returns the rule's event count within its window if the rule should fire
+// (threshold met and not still within its own debounce window), else null.
+export async function checkAlertRule(rule: AlertRule): Promise<number | null> {
+  if (rule.lastTriggeredAt) {
+    const debounceUntil = new Date(rule.lastTriggeredAt.getTime() + rule.windowMinutes * 60_000);
+    if (debounceUntil > new Date()) return null;
+  }
+
+  const windowStart = new Date(Date.now() - rule.windowMinutes * 60_000);
+  const [{ value }] = await db
+    .select({ value: count() })
+    .from(events)
+    .where(
+      and(
+        eq(events.channelId, rule.channelId),
+        eq(events.eventObject, rule.eventObject),
+        eq(events.eventAction, rule.eventAction),
+        gte(events.createdAt, windowStart),
+      ),
+    );
+
+  if (value < rule.threshold) return null;
+
+  await db
+    .update(alertRules)
+    .set({ lastTriggeredAt: new Date() })
+    .where(eq(alertRules.id, rule.id));
+
+  return value;
+}
+
+export async function checkAndDispatchAlerts(
+  channel: Channel,
+  project: Project,
+  event: { eventObject: string; eventAction: string },
+): Promise<void> {
+  const rules = await getAlertRulesForChannelEvent(
+    channel.id,
+    event.eventObject,
+    event.eventAction,
+  );
+
+  for (const rule of rules) {
+    const matchedCount = await checkAlertRule(rule);
+    if (matchedCount === null) continue;
+
+    const emails = await getNotificationEmailsForChannel(channel.id);
+    if (emails.length === 0) continue;
+
+    await sendAlertEmail(
+      {
+        ruleName: rule.name,
+        eventObject: rule.eventObject,
+        eventAction: rule.eventAction,
+        count: matchedCount,
+        threshold: rule.threshold,
+        windowMinutes: rule.windowMinutes,
+        projectName: project.name,
+        channelName: channel.name,
+      },
+      emails,
+    );
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -294,6 +294,35 @@ export const emailSettings = sqliteTable("email_settings", {
     .notNull(),
 });
 
+// --- ALERT RULES ---
+export const alertRules = sqliteTable(
+  "alert_rules",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    channelId: integer("channel_id")
+      .notNull()
+      .references(() => channels.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    eventObject: text("event_object").notNull(),
+    eventAction: text("event_action").notNull(),
+    threshold: integer("threshold").notNull(),
+    windowMinutes: integer("window_minutes").notNull(),
+    enabled: integer("enabled", { mode: "boolean" }).notNull().default(true),
+    lastTriggeredAt: integer("last_triggered_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    channelIdx: index("alert_rules_channel_id_idx").on(table.channelId),
+    channelObjActIdx: index("alert_rules_channel_id_event_object_event_action_idx").on(
+      table.channelId,
+      table.eventObject,
+      table.eventAction,
+    ),
+  }),
+);
+
 // --- SESSIONS ----
 export const sessions = sqliteTable("sessions", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -332,6 +361,7 @@ export const channelRelations = relations(channels, ({ one, many }) => ({
     references: [channelGroups.id],
   }),
   events: many(events),
+  alertRules: many(alertRules),
 }));
 
 export const eventRelations = relations(events, ({ one }) => ({
@@ -397,6 +427,13 @@ export const channelNotificationSubscriptionRelations = relations(
     }),
   }),
 );
+
+export const alertRuleRelations = relations(alertRules, ({ one }) => ({
+  channel: one(channels, {
+    fields: [alertRules.channelId],
+    references: [channels.id],
+  }),
+}));
 
 export const metricRelations = relations(metrics, ({ one, many }) => ({
   project: one(projects, {

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,6 +1,6 @@
 import { Resend } from "resend";
 import type { EventWithChannelName } from "../beaver/event";
-import { buildEmailHtml } from "./template";
+import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
 
 const apiKey = process.env.RESEND_API_KEY;
 const fromEmail = process.env.RESEND_FROM_EMAIL ?? "notifications@beaver.app";
@@ -19,6 +19,22 @@ export async function sendEventNotification(
     to: recipientEmails,
     subject: `${event.icon ? `${event.icon} ` : ""}${event.title} — ${projectName}`,
     html: buildEmailHtml(event, projectName),
+  });
+}
+
+export async function sendAlertEmail(
+  params: AlertEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!apiKey || recipientEmails.length === 0) return;
+
+  const resend = new Resend(apiKey);
+
+  await resend.emails.send({
+    from: fromEmail,
+    to: recipientEmails,
+    subject: `🚨 ${params.ruleName} — ${params.projectName}`,
+    html: buildAlertEmailHtml(params),
   });
 }
 

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -1,7 +1,11 @@
 import type { EventWithChannelName } from "../beaver/event";
 import { getEmailSettings } from "../beaver/email-settings";
-import { sendEventNotification as sendViaResend } from "./resend";
-import { sendEventNotificationSmtp } from "./smtp";
+import type { AlertEmailParams } from "./template";
+import {
+  sendEventNotification as sendViaResend,
+  sendAlertEmail as sendAlertEmailViaResend,
+} from "./resend";
+import { sendEventNotificationSmtp, sendAlertEmailSmtp } from "./smtp";
 
 export async function sendEventNotification(
   event: EventWithChannelName,
@@ -16,4 +20,18 @@ export async function sendEventNotification(
   }
 
   await sendViaResend(event, projectName, recipientEmails);
+}
+
+export async function sendAlertEmail(
+  params: AlertEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  const settings = await getEmailSettings();
+
+  if (settings?.provider === "smtp") {
+    await sendAlertEmailSmtp(settings, params, recipientEmails);
+    return;
+  }
+
+  await sendAlertEmailViaResend(params, recipientEmails);
 }

--- a/src/lib/email/smtp.ts
+++ b/src/lib/email/smtp.ts
@@ -1,7 +1,18 @@
 import nodemailer from "nodemailer";
 import type { EventWithChannelName } from "../beaver/event";
 import type { EmailSettings } from "../beaver/email-settings";
-import { buildEmailHtml } from "./template";
+import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
+
+function buildTransport(settings: EmailSettings) {
+  return nodemailer.createTransport({
+    host: settings.smtpHost ?? undefined,
+    port: settings.smtpPort ?? undefined,
+    secure: settings.smtpSecure,
+    auth: settings.smtpUsername
+      ? { user: settings.smtpUsername, pass: settings.smtpPassword ?? "" }
+      : undefined,
+  });
+}
 
 export async function sendEventNotificationSmtp(
   settings: EmailSettings,
@@ -11,20 +22,30 @@ export async function sendEventNotificationSmtp(
 ): Promise<void> {
   if (!settings.smtpHost || !settings.smtpPort || recipientEmails.length === 0) return;
 
-  const transport = nodemailer.createTransport({
-    host: settings.smtpHost,
-    port: settings.smtpPort,
-    secure: settings.smtpSecure,
-    auth: settings.smtpUsername
-      ? { user: settings.smtpUsername, pass: settings.smtpPassword ?? "" }
-      : undefined,
-  });
+  const transport = buildTransport(settings);
 
   await transport.sendMail({
     from: settings.smtpFromEmail ?? "notifications@beaver.app",
     to: recipientEmails,
     subject: `${event.icon ? `${event.icon} ` : ""}${event.title} — ${projectName}`,
     html: buildEmailHtml(event, projectName),
+  });
+}
+
+export async function sendAlertEmailSmtp(
+  settings: EmailSettings,
+  params: AlertEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!settings.smtpHost || !settings.smtpPort || recipientEmails.length === 0) return;
+
+  const transport = buildTransport(settings);
+
+  await transport.sendMail({
+    from: settings.smtpFromEmail ?? "notifications@beaver.app",
+    to: recipientEmails,
+    subject: `🚨 ${params.ruleName} — ${params.projectName}`,
+    html: buildAlertEmailHtml(params),
   });
 }
 

--- a/src/lib/email/template.ts
+++ b/src/lib/email/template.ts
@@ -92,3 +92,70 @@ export function buildEmailHtml(event: EventWithChannelName, projectName: string)
 </body>
 </html>`;
 }
+
+export type AlertEmailParams = {
+  ruleName: string;
+  eventObject: string;
+  eventAction: string;
+  count: number;
+  threshold: number;
+  windowMinutes: number;
+  projectName: string;
+  channelName: string;
+};
+
+export function buildAlertEmailHtml(params: AlertEmailParams): string {
+  const eventName = `${params.eventObject}.${params.eventAction}`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${params.ruleName}</title>
+</head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#7c2d12;padding:24px 32px;border-radius:12px 12px 0 0;">
+              <p style="margin:0;font-size:13px;font-weight:600;color:#fed7aa;letter-spacing:0.08em;text-transform:uppercase;">Beaver Alert</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#fdba74;">
+                ${params.projectName} &middot; #${params.channelName}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background:#ffffff;padding:32px;border-left:1px solid #e5e7eb;border-right:1px solid #e5e7eb;">
+              <p style="margin:0 0 6px;font-size:12px;font-family:monospace;color:#9ca3af;letter-spacing:0.05em;">${eventName}</p>
+              <h1 style="margin:0;font-size:22px;font-weight:700;color:#111827;line-height:1.3;">${params.ruleName}</h1>
+              <p style="margin:8px 0 0;font-size:15px;color:#6b7280;line-height:1.6;">
+                ${params.count} events matched in the last ${params.windowMinutes} minute${params.windowMinutes === 1 ? "" : "s"}, exceeding the threshold of ${params.threshold}.
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f4f4f5;padding:20px 32px;border-radius:0 0 12px 12px;border:1px solid #e5e7eb;border-top:none;">
+              <p style="margin:0;font-size:12px;color:#9ca3af;line-height:1.6;">
+                You're receiving this because you enabled event notifications for
+                <strong style="color:#6b7280;">#${params.channelName}</strong> in
+                <strong style="color:#6b7280;">${params.projectName}</strong>.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}

--- a/src/pages/api/alert-rules.ts
+++ b/src/pages/api/alert-rules.ts
@@ -1,0 +1,113 @@
+import {
+  createAlertRule,
+  deleteAlertRule,
+  getAlertRulesForProject,
+  updateAlertRule,
+} from "@/lib/beaver/alert-rule";
+import { EVENT_SEGMENT_REGEX } from "@/lib/beaver/event";
+import type { APIContext, APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ request }: APIContext) => {
+  try {
+    const url = new URL(request.url);
+    const projectId = url.searchParams.get("projectId");
+
+    if (!projectId) return json({ error: "projectId is a required query parameter." }, 400);
+
+    const rules = await getAlertRulesForProject(parseInt(projectId));
+    return json(rules);
+  } catch (err) {
+    return handleError(err);
+  }
+};
+
+export const POST: APIRoute = async ({ request }: APIContext) => {
+  try {
+    const { channelId, name, eventObject, eventAction, threshold, windowMinutes } =
+      await request.json();
+
+    if (!channelId) return json({ error: "channelId is required." }, 400);
+    if (!name || typeof name !== "string" || name.trim() === "")
+      return json({ error: "name is required." }, 400);
+    if (!EVENT_SEGMENT_REGEX.test(eventObject))
+      return json({ error: "eventObject must be a lowercase, underscore-separated word." }, 400);
+    if (!EVENT_SEGMENT_REGEX.test(eventAction))
+      return json({ error: "eventAction must be a lowercase, underscore-separated word." }, 400);
+    if (!Number.isInteger(threshold) || threshold < 1)
+      return json({ error: "threshold must be a positive integer." }, 400);
+    if (!Number.isInteger(windowMinutes) || windowMinutes < 1)
+      return json({ error: "windowMinutes must be a positive integer." }, 400);
+
+    const rule = await createAlertRule({
+      channelId: parseInt(channelId),
+      name: name.trim(),
+      eventObject,
+      eventAction,
+      threshold,
+      windowMinutes,
+    });
+
+    return json(rule);
+  } catch (err) {
+    return handleError(err);
+  }
+};
+
+export const PATCH: APIRoute = async ({ request }: APIContext) => {
+  try {
+    const { id, name, eventObject, eventAction, threshold, windowMinutes, enabled } =
+      await request.json();
+
+    if (!id) return json({ error: "id is required." }, 400);
+    if (eventObject !== undefined && !EVENT_SEGMENT_REGEX.test(eventObject))
+      return json({ error: "eventObject must be a lowercase, underscore-separated word." }, 400);
+    if (eventAction !== undefined && !EVENT_SEGMENT_REGEX.test(eventAction))
+      return json({ error: "eventAction must be a lowercase, underscore-separated word." }, 400);
+    if (threshold !== undefined && (!Number.isInteger(threshold) || threshold < 1))
+      return json({ error: "threshold must be a positive integer." }, 400);
+    if (windowMinutes !== undefined && (!Number.isInteger(windowMinutes) || windowMinutes < 1))
+      return json({ error: "windowMinutes must be a positive integer." }, 400);
+
+    await updateAlertRule(parseInt(id), {
+      name: name?.trim(),
+      eventObject,
+      eventAction,
+      threshold,
+      windowMinutes,
+      enabled,
+    });
+
+    return json({ ok: true });
+  } catch (err) {
+    return handleError(err);
+  }
+};
+
+export const DELETE: APIRoute = async ({ request }: APIContext) => {
+  try {
+    const { id } = await request.json();
+
+    if (!id) return json({ error: "id is required." }, 400);
+
+    await deleteAlertRule(parseInt(id));
+    return json({ ok: true });
+  } catch (err) {
+    return handleError(err);
+  }
+};
+
+function json(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function handleError(err: unknown) {
+  if (err instanceof Error) {
+    return json({ error: err.message }, 400);
+  }
+  return json({ error: "An unknown error has occurred." }, 500);
+}
+
+export const prerender = false;

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -3,6 +3,7 @@ import { events, channels, eventTags } from "@/lib/db/schema";
 import { EVENT_NAME_REGEX, RESERVED_OBJECT } from "@/lib/beaver/event";
 import { getProject } from "@/lib/beaver/project";
 import { getNotificationEmailsForChannel } from "@/lib/beaver/channel-notification";
+import { checkAndDispatchAlerts } from "@/lib/beaver/alert-rule";
 import { sendEventNotification } from "@/lib/email/send";
 import { publishEvent } from "@/lib/beaver/event-bus";
 import { eq } from "drizzle-orm";
@@ -143,6 +144,12 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
           }
         });
       }
+    });
+
+    // Check alert rules outside the transaction
+    created.forEach((event, i) => {
+      const { channel, project } = resolved[i];
+      checkAndDispatchAlerts(channel, project, event).catch(() => {});
     });
 
     return new Response(JSON.stringify(created), {

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -7,6 +7,7 @@ import { getProject } from "@/lib/beaver/project";
 import { getUserProjectRole } from "@/lib/beaver/project-member";
 import { getUserByUsername } from "@/lib/beaver/user";
 import { getChannelSubscriptions } from "@/lib/beaver/channel-notification";
+import { getAlertRulesForProject } from "@/lib/beaver/alert-rule";
 
 const { projectID } = Astro.params;
 const user = Astro.locals.user!;
@@ -25,6 +26,7 @@ const channels = await getChannels(parseInt(projectID!));
 const metrics = await getMetrics(parseInt(projectID!));
 const dbUser = await getUserByUsername(user.userName);
 const subscribedChannelIds = await getChannelSubscriptions(user.id, project.id);
+const alertRules = await getAlertRulesForProject(project.id);
 
 const isOwner = userRole === "owner";
 ---
@@ -41,6 +43,7 @@ const isOwner = userRole === "owner";
           project={project}
           channels={channels}
           metrics={metrics}
+          alertRules={alertRules}
           isOwner={isOwner}
           currentUserId={user.id}
           initialEmail={dbUser?.email ?? null}


### PR DESCRIPTION
## Summary
- New `alert_rules` table: per-channel rules matching an event name (`object.action`) with a count threshold and time window
- Checked on event ingestion (`/api/event.ts`); when a rule crosses threshold, emails the channel's existing notification subscribers (via the channel-subscription list from #172), debounced via `lastTriggeredAt` so it only fires once per window
- New "Alerts" tab in project settings for managing rules (visible to all members, same as Metrics/Channels/Notifications)
- Reuses the email provider dispatcher (Resend/SMTP) added in #217 via a new `sendAlertEmail`

Webhooks-out (Slack/Discord/PagerDuty), mentioned in the issue as a future direction, is intentionally out of scope here.

Closes #111

## Test plan
- [x] `bun run build` (type-checks + builds cleanly)
- [x] `bun run lint`, `bun run format:check`
- [ ] Manually create a channel + alert rule, send matching events past the threshold via the ingestion API, confirm a single alert email is sent and a second burst within the window is debounced