### PR TITLE
feat: event reactions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,6 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@emoji-mart/data": "^1.2.1",
-        "@emoji-mart/react": "^1.1.1",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -275,8 +274,6 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.6.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA=="],
 
     "@emoji-mart/data": ["@emoji-mart/data@1.2.1", "", {}, "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="],
-
-    "@emoji-mart/react": ["@emoji-mart/react@1.1.1", "", { "peerDependencies": { "emoji-mart": "^5.2", "react": "^16.8 || ^17 || ^18" } }, "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -955,8 +952,6 @@
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.240", "", {}, "sha512-OBwbZjWgrCOH+g6uJsA2/7Twpas2OlepS9uvByJjR2datRDuKGYeD+nP8lBBks2qnB7bGJNHDUx7c/YLaT3QMQ=="],
-
-    "emoji-mart": ["emoji-mart@5.6.0", "", {}, "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,8 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@emoji-mart/data": "^1.2.1",
+        "@emoji-mart/react": "^1.1.1",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-context-menu": "^2.2.16",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -271,6 +273,10 @@
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.6.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA=="],
+
+    "@emoji-mart/data": ["@emoji-mart/data@1.2.1", "", {}, "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="],
+
+    "@emoji-mart/react": ["@emoji-mart/react@1.1.1", "", { "peerDependencies": { "emoji-mart": "^5.2", "react": "^16.8 || ^17 || ^18" } }, "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 
@@ -949,6 +955,8 @@
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.240", "", {}, "sha512-OBwbZjWgrCOH+g6uJsA2/7Twpas2OlepS9uvByJjR2datRDuKGYeD+nP8lBBks2qnB7bGJNHDUx7c/YLaT3QMQ=="],
+
+    "emoji-mart": ["emoji-mart@5.6.0", "", {}, "sha512-eJp3QRe79pjwa+duv+n7+5YsNhRcMl812EcFVwrnRvYKoNPoQb5qxU8DG6Bgwji0akHdp6D4Ln6tYLG58MFSow=="],
 
     "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 

--- a/drizzle/0016_lyrical_iron_lad.sql
+++ b/drizzle/0016_lyrical_iron_lad.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `event_reactions` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`event_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`emoji` text NOT NULL,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`event_id`) REFERENCES `events`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `event_reactions_event_user_emoji_idx` ON `event_reactions` (`event_id`,`user_id`,`emoji`);--> statement-breakpoint
+CREATE INDEX `event_reactions_event_id_idx` ON `event_reactions` (`event_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1781840086052,
       "tag": "0015_goofy_lilith",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1781845386803,
+      "tag": "0016_lyrical_iron_lad",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@emoji-mart/data": "^1.2.1",
-    "@emoji-mart/react": "^1.1.1",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@emoji-mart/data": "^1.2.1",
+    "@emoji-mart/react": "^1.1.1",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-context-menu": "^2.2.16",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -19,7 +19,6 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
   const handleMouseEnter = () => {
     if (prefetched.current) return;
     prefetched.current = true;
-
     const link = document.createElement("link");
     link.rel = "prefetch";
     link.href = eventUrl;
@@ -34,43 +33,47 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div>
-          <a href={eventUrl} onMouseEnter={handleMouseEnter}>
-            <Card className="p-4 md:p-8 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors cursor-pointer">
-              <div className="flex items-center space-x-4">
-                <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
-                  <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
+        <Card className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer">
+          <a href={eventUrl} onMouseEnter={handleMouseEnter} className="block p-4 md:p-8">
+            <div className="flex items-center space-x-4">
+              <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
+                <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
+                  <span>{event.eventObject}</span>
+                  <span>·</span>
+                  <span>{event.eventAction}</span>
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
-                    <span>{event.eventObject}</span>
-                    <span>·</span>
-                    <span>{event.eventAction}</span>
-                  </div>
-                  <h2 className="text-xl font-medium truncate">{event.title}</h2>
-                  <div className="flex space-x-2 items-center text-sm text-muted-foreground">
-                    <p># {event.channelName}</p>
-                    <p>{getEventTime(new Date(event.createdAt))}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2 flex-shrink-0">
-                  {event.bookmarked && (
-                    <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
-                  )}
-                  {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
+                <h2 className="text-xl font-medium truncate">{event.title}</h2>
+                <div className="flex space-x-2 items-center text-sm text-muted-foreground">
+                  <p># {event.channelName}</p>
+                  <p>{getEventTime(new Date(event.createdAt))}</p>
                 </div>
               </div>
-            </Card>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                {event.bookmarked && (
+                  <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
+                )}
+                {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
+              </div>
+            </div>
           </a>
           {reactions.length > 0 && (
-            <div className="px-1 pt-1.5 pb-0.5">
+            <div
+              className="px-4 pb-3 md:px-8"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+            >
               <ReactionBar eventId={event.id} initialReactions={reactions} />
             </div>
           )}
-        </div>
+        </Card>
       </ContextMenuTrigger>
-      <ContextMenuContent className="w-auto p-0">
-        <ContextMenuLabel className="px-2 pt-2 pb-1 text-xs text-muted-foreground font-normal">
+      <ContextMenuContent className="p-0 overflow-hidden">
+        <ContextMenuLabel className="px-3 pt-2 pb-1 text-xs text-muted-foreground font-normal">
           React
         </ContextMenuLabel>
         <EmojiPicker onSelect={handleReact} />

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -3,12 +3,7 @@ import { Card } from "./ui/card";
 import { getEventTime } from "@/lib/utils";
 import { BookmarkIcon } from "lucide-react";
 import { memo, useRef, useState } from "react";
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuLabel,
-  ContextMenuTrigger,
-} from "./ui/context-menu";
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "./ui/context-menu";
 import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
 const EventCard = memo(function EventCard({ event }: { event: EventWithChannelName }) {
@@ -33,8 +28,17 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Card className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer">
-          <a href={eventUrl} onMouseEnter={handleMouseEnter} className="block p-4 md:p-8">
+        <Card className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer relative">
+          {/* Stretched link: the anchor covers the whole card so the card stays
+              clickable, while the content sits above it with pointer-events disabled
+              so clicks fall through. Interactive bits (reactions) opt back in. */}
+          <a
+            href={eventUrl}
+            onMouseEnter={handleMouseEnter}
+            aria-label={event.title}
+            className="absolute inset-0 z-0"
+          />
+          <div className="relative z-10 pointer-events-none p-4 md:p-8">
             <div className="flex items-center space-x-4">
               <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
                 <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
@@ -50,6 +54,17 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
                   <p># {event.channelName}</p>
                   <p>{getEventTime(new Date(event.createdAt))}</p>
                 </div>
+                {reactions.length > 0 && (
+                  <div
+                    className="mt-1.5 pointer-events-auto"
+                    onClick={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                    }}
+                  >
+                    <ReactionBar reactions={reactions} onToggle={handleReact} />
+                  </div>
+                )}
               </div>
               <div className="flex items-center gap-2 flex-shrink-0">
                 {event.bookmarked && (
@@ -58,24 +73,14 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
                 {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
               </div>
             </div>
-          </a>
-          {reactions.length > 0 && (
-            <div
-              className="px-4 pb-3 md:px-8"
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-            >
-              <ReactionBar eventId={event.id} initialReactions={reactions} />
-            </div>
-          )}
+          </div>
         </Card>
       </ContextMenuTrigger>
-      <ContextMenuContent className="p-0 overflow-hidden">
-        <ContextMenuLabel className="px-3 pt-2 pb-1 text-xs text-muted-foreground font-normal">
-          React
-        </ContextMenuLabel>
+      {/* Disable the open/close animation: the fade/zoom drops frames while the emoji
+          glyphs rasterize on first paint, which reads as a stutter. It must be a class,
+          not an inline style — Radix's popper owns the inline `animation` property and
+          overwrites any inline override once the content is positioned. */}
+      <ContextMenuContent className="p-0 overflow-hidden [animation:none]!">
         <EmojiPicker onSelect={handleReact} />
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -1,10 +1,18 @@
-import type { EventWithChannelName } from "@/lib/beaver/event";
+import type { EventWithChannelName, ReactionSummary } from "@/lib/beaver/event";
 import { Card } from "./ui/card";
 import { getEventTime } from "@/lib/utils";
 import { BookmarkIcon } from "lucide-react";
-import { memo, useRef } from "react";
+import { memo, useRef, useState } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuLabel,
+  ContextMenuTrigger,
+} from "./ui/context-menu";
+import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
 const EventCard = memo(function EventCard({ event }: { event: EventWithChannelName }) {
+  const [reactions, setReactions] = useState<ReactionSummary[]>(event.reactions);
   const eventUrl = `/dashboard/${event.projectId}/events/${event.id}`;
   const prefetched = useRef(false);
 
@@ -18,34 +26,56 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
     document.head.appendChild(link);
   };
 
+  const handleReact = async (emoji: string) => {
+    const updated = await postReaction(event.id, emoji);
+    if (updated) setReactions((prev) => applyToggle(prev, updated));
+  };
+
   return (
-    <a href={eventUrl} onMouseEnter={handleMouseEnter}>
-      <Card className="p-4 md:p-8 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors cursor-pointer">
-        <div className="flex items-center space-x-4">
-          <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
-            <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
-          </div>
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
-              <span>{event.eventObject}</span>
-              <span>·</span>
-              <span>{event.eventAction}</span>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div>
+          <a href={eventUrl} onMouseEnter={handleMouseEnter}>
+            <Card className="p-4 md:p-8 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors cursor-pointer">
+              <div className="flex items-center space-x-4">
+                <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
+                  <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
+                    <span>{event.eventObject}</span>
+                    <span>·</span>
+                    <span>{event.eventAction}</span>
+                  </div>
+                  <h2 className="text-xl font-medium truncate">{event.title}</h2>
+                  <div className="flex space-x-2 items-center text-sm text-muted-foreground">
+                    <p># {event.channelName}</p>
+                    <p>{getEventTime(new Date(event.createdAt))}</p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {event.bookmarked && (
+                    <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
+                  )}
+                  {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
+                </div>
+              </div>
+            </Card>
+          </a>
+          {reactions.length > 0 && (
+            <div className="px-1 pt-1.5 pb-0.5">
+              <ReactionBar eventId={event.id} initialReactions={reactions} />
             </div>
-            <h2 className="text-xl font-medium truncate">{event.title}</h2>
-            <div className="flex space-x-2 items-center text-sm text-muted-foreground">
-              <p># {event.channelName}</p>
-              <p>{getEventTime(new Date(event.createdAt))}</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {event.bookmarked && (
-              <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
-            )}
-            {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
-          </div>
+          )}
         </div>
-      </Card>
-    </a>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-auto p-0">
+        <ContextMenuLabel className="px-2 pt-2 pb-1 text-xs text-muted-foreground font-normal">
+          React
+        </ContextMenuLabel>
+        <EmojiPicker onSelect={handleReact} />
+      </ContextMenuContent>
+    </ContextMenu>
   );
 });
 

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -227,14 +227,14 @@ export default function EventDetail({
 
           <CardContent>
             <div className="flex flex-wrap items-center gap-2">
-              <ReactionBar eventId={event.id} initialReactions={reactions} />
+              <ReactionBar reactions={reactions} onToggle={handleReact} />
               <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
                 <PopoverTrigger asChild>
                   <Button variant="outline" size="sm" className="h-7 px-2 rounded-full">
                     <SmilePlusIcon size={14} />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
+                <PopoverContent className="w-auto p-0 [animation:none]!" align="start">
                   <EmojiPicker onSelect={handleReact} />
                 </PopoverContent>
               </Popover>

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -1,8 +1,15 @@
-import type { EventWithChannelName } from "@/lib/beaver/event";
+import type { EventWithChannelName, ReactionSummary } from "@/lib/beaver/event";
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "./ui/card";
 import { Button } from "./ui/button";
 import { getEventTime } from "@/lib/utils";
-import { ArrowLeftIcon, BookmarkIcon, CheckIcon, LinkIcon, Trash2Icon } from "lucide-react";
+import {
+  ArrowLeftIcon,
+  BookmarkIcon,
+  CheckIcon,
+  LinkIcon,
+  SmilePlusIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
@@ -13,6 +20,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "./ui/dialog";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
 function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | boolean }) {
   const displayValue = typeof value === "boolean" ? (value ? "true" : "false") : String(value);
@@ -39,6 +48,14 @@ export default function EventDetail({
   const [copied, setCopied] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  const [reactions, setReactions] = useState<ReactionSummary[]>(event.reactions);
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  const handleReact = async (emoji: string) => {
+    setPickerOpen(false);
+    const updated = await postReaction(event.id, emoji);
+    if (updated) setReactions((prev) => applyToggle(prev, updated));
+  };
 
   const handleBookmark = async () => {
     setBookmarking(true);
@@ -207,6 +224,22 @@ export default function EventDetail({
               </div>
             </CardContent>
           )}
+
+          <CardContent>
+            <div className="flex flex-wrap items-center gap-2">
+              <ReactionBar eventId={event.id} initialReactions={reactions} />
+              <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+                <PopoverTrigger asChild>
+                  <Button variant="outline" size="sm" className="h-7 px-2 rounded-full">
+                    <SmilePlusIcon size={14} />
+                  </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <EmojiPicker onSelect={handleReact} />
+                </PopoverContent>
+              </Popover>
+            </div>
+          </CardContent>
         </Card>
       </div>
 

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -1,26 +1,13 @@
 import type { ReactionSummary } from "@/lib/beaver/event";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+// @ts-ignore — no bundled types for @emoji-mart/react
+import Picker from "@emoji-mart/react";
+import data from "@emoji-mart/data";
 
-export const EMOJI_LIST = [
-  "👍",
-  "👎",
-  "❤️",
-  "😄",
-  "😮",
-  "😢",
-  "😡",
-  "🎉",
-  "🔥",
-  "✅",
-  "❌",
-  "🚀",
-  "💯",
-  "👏",
-  "🤔",
-  "💡",
-];
-
-async function postReaction(eventId: number, emoji: string): Promise<ReactionSummary | null> {
+export async function postReaction(
+  eventId: number,
+  emoji: string,
+): Promise<ReactionSummary | null> {
   const res = await fetch(`/api/events/${eventId}/reactions`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -30,30 +17,27 @@ async function postReaction(eventId: number, emoji: string): Promise<ReactionSum
   return res.json();
 }
 
-function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): ReactionSummary[] {
+export function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): ReactionSummary[] {
   const filtered = prev.filter((r) => r.emoji !== updated.emoji);
   if (updated.count === 0) return filtered;
   return [...filtered, updated];
 }
 
 export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
+  }, []);
+
   return (
-    <div className="grid grid-cols-8 gap-0.5 p-1">
-      {EMOJI_LIST.map((emoji) => (
-        <button
-          key={emoji}
-          type="button"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onSelect(emoji);
-          }}
-          className="text-base p-1.5 rounded hover:bg-gray-100 dark:hover:bg-white/10 transition-colors leading-none"
-        >
-          {emoji}
-        </button>
-      ))}
-    </div>
+    <Picker
+      data={data}
+      theme={theme}
+      previewPosition="none"
+      skinTonePosition="search"
+      onEmojiSelect={(emoji: { native: string }) => onSelect(emoji.native)}
+    />
   );
 }
 
@@ -99,5 +83,3 @@ export function ReactionBar({
     </div>
   );
 }
-
-export { postReaction, applyToggle };

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -1,8 +1,38 @@
 import type { ReactionSummary } from "@/lib/beaver/event";
-import { useEffect, useState } from "react";
-// @ts-ignore — no bundled types for @emoji-mart/react
-import Picker from "@emoji-mart/react";
-import data from "@emoji-mart/data";
+import type { EmojiMartData } from "@emoji-mart/data";
+import { useMemo, useRef, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import emojiData from "@emoji-mart/data";
+import { Input } from "./ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+
+const data = emojiData as EmojiMartData;
+
+type EmojiEntry = {
+  id: string;
+  native: string;
+  name: string;
+  keywords: string[];
+};
+
+const ALL_EMOJIS: EmojiEntry[] = data.categories.flatMap((category) =>
+  category.emojis.map((id) => {
+    const emoji = data.emojis[id];
+    return {
+      id: emoji.id,
+      native: emoji.skins[0].native,
+      name: emoji.name,
+      keywords: emoji.keywords,
+    };
+  }),
+);
+
+const EMOJI_COLUMNS = 8;
+const EMOJI_ROW_HEIGHT = 34;
+// Seeds the virtualizer's first render so rows paint immediately instead of
+// flashing in after the scroll container is measured. Matches the scroll
+// container's inner box (w-72 / max-h-56 minus p-2 padding).
+const EMOJI_VIEWPORT = { width: 272, height: 208 };
 
 export async function postReaction(
   eventId: number,
@@ -24,62 +54,125 @@ export function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): 
 }
 
 export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {
-  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [query, setQuery] = useState("");
+  const scrollRef = useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    setTheme(document.documentElement.classList.contains("dark") ? "dark" : "light");
-  }, []);
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return ALL_EMOJIS;
+    return ALL_EMOJIS.filter(
+      (e) => e.name.toLowerCase().includes(q) || e.keywords.some((k) => k.includes(q)),
+    );
+  }, [query]);
+
+  const rowCount = Math.ceil(filtered.length / EMOJI_COLUMNS);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rowCount,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => EMOJI_ROW_HEIGHT,
+    overscan: 6,
+    initialRect: EMOJI_VIEWPORT,
+  });
 
   return (
-    <Picker
-      data={data}
-      theme={theme}
-      previewPosition="none"
-      skinTonePosition="search"
-      onEmojiSelect={(emoji: { native: string }) => onSelect(emoji.native)}
-    />
+    <div className="w-72">
+      <div className="border-b p-2">
+        <Input
+          autoFocus
+          placeholder="Search emoji…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="h-8"
+        />
+      </div>
+      <div ref={scrollRef} className="max-h-56 overflow-y-auto p-2">
+        {filtered.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">No emoji found</p>
+        ) : (
+          <div className="relative w-full" style={{ height: rowVirtualizer.getTotalSize() }}>
+            {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+              const start = virtualRow.index * EMOJI_COLUMNS;
+              const rowEmojis = filtered.slice(start, start + EMOJI_COLUMNS);
+              return (
+                <div
+                  key={virtualRow.key}
+                  className="absolute left-0 top-0 grid w-full grid-cols-8 gap-0.5"
+                  style={{ transform: `translateY(${virtualRow.start}px)` }}
+                >
+                  {rowEmojis.map((e) => (
+                    <button
+                      key={e.id}
+                      type="button"
+                      title={e.name}
+                      onClick={() => onSelect(e.native)}
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-lg hover:bg-gray-100 dark:hover:bg-white/10"
+                    >
+                      {e.native}
+                    </button>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
+// Builds a Discord/Slack-style reactor list, e.g. "alice", "alice and bob",
+// "alice, bob and carol".
+function formatReactors(names: string[]): string {
+  if (names.length === 0) return "";
+  if (names.length === 1) return names[0];
+  return `${names.slice(0, -1).join(", ")} and ${names[names.length - 1]}`;
+}
+
+// Controlled: the parent owns the reaction state (a single source of truth shared
+// with the emoji picker), so adding several reactions in a row stays in sync.
 export function ReactionBar({
-  eventId,
-  initialReactions,
+  reactions,
+  onToggle,
 }: {
-  eventId: number;
-  initialReactions: ReactionSummary[];
+  reactions: ReactionSummary[];
+  onToggle: (emoji: string) => void;
 }) {
-  const [reactions, setReactions] = useState(initialReactions);
-
-  const toggle = async (emoji: string) => {
-    const updated = await postReaction(eventId, emoji);
-    if (updated) setReactions((prev) => applyToggle(prev, updated));
-  };
-
   if (reactions.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-1">
-      {[...reactions]
-        .sort((a, b) => b.count - a.count)
-        .map((r) => (
-          <button
-            key={r.emoji}
-            type="button"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              toggle(r.emoji);
-            }}
-            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm border transition-colors ${
-              r.userReacted
-                ? "bg-blue-50 border-blue-300 dark:bg-blue-950 dark:border-blue-700"
-                : "bg-gray-50 border-gray-200 dark:bg-white/5 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/10"
-            }`}
-          >
-            <span>{r.emoji}</span>
-            <span className="text-xs text-muted-foreground">{r.count}</span>
-          </button>
-        ))}
-    </div>
+    <TooltipProvider delayDuration={200}>
+      <div className="flex flex-wrap gap-1">
+        {[...reactions]
+          .sort((a, b) => b.count - a.count)
+          .map((r) => (
+            <Tooltip key={r.emoji}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onToggle(r.emoji);
+                  }}
+                  className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-sm transition-colors ${
+                    r.userReacted
+                      ? "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300"
+                      : "bg-gray-100 text-foreground hover:bg-gray-200 dark:bg-white/10 dark:hover:bg-white/20"
+                  }`}
+                >
+                  <span>{r.emoji}</span>
+                  <span className="text-xs text-muted-foreground">{r.count}</span>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-56">
+                <span className="font-medium">{formatReactors(r.users)}</span>
+                <span className="text-primary-foreground/70"> reacted with </span>
+                <span>{r.emoji}</span>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+      </div>
+    </TooltipProvider>
   );
 }

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -1,0 +1,103 @@
+import type { ReactionSummary } from "@/lib/beaver/event";
+import { useState } from "react";
+
+export const EMOJI_LIST = [
+  "👍",
+  "👎",
+  "❤️",
+  "😄",
+  "😮",
+  "😢",
+  "😡",
+  "🎉",
+  "🔥",
+  "✅",
+  "❌",
+  "🚀",
+  "💯",
+  "👏",
+  "🤔",
+  "💡",
+];
+
+async function postReaction(eventId: number, emoji: string): Promise<ReactionSummary | null> {
+  const res = await fetch(`/api/events/${eventId}/reactions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ emoji }),
+  });
+  if (!res.ok) return null;
+  return res.json();
+}
+
+function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): ReactionSummary[] {
+  const filtered = prev.filter((r) => r.emoji !== updated.emoji);
+  if (updated.count === 0) return filtered;
+  return [...filtered, updated];
+}
+
+export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {
+  return (
+    <div className="grid grid-cols-8 gap-0.5 p-1">
+      {EMOJI_LIST.map((emoji) => (
+        <button
+          key={emoji}
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onSelect(emoji);
+          }}
+          className="text-base p-1.5 rounded hover:bg-gray-100 dark:hover:bg-white/10 transition-colors leading-none"
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function ReactionBar({
+  eventId,
+  initialReactions,
+}: {
+  eventId: number;
+  initialReactions: ReactionSummary[];
+}) {
+  const [reactions, setReactions] = useState(initialReactions);
+
+  const toggle = async (emoji: string) => {
+    const updated = await postReaction(eventId, emoji);
+    if (updated) setReactions((prev) => applyToggle(prev, updated));
+  };
+
+  if (reactions.length === 0) return null;
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {[...reactions]
+        .sort((a, b) => b.count - a.count)
+        .map((r) => (
+          <button
+            key={r.emoji}
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              toggle(r.emoji);
+            }}
+            className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm border transition-colors ${
+              r.userReacted
+                ? "bg-blue-50 border-blue-300 dark:bg-blue-950 dark:border-blue-700"
+                : "bg-gray-50 border-gray-200 dark:bg-white/5 dark:border-white/10 hover:bg-gray-100 dark:hover:bg-white/10"
+            }`}
+          >
+            <span>{r.emoji}</span>
+            <span className="text-xs text-muted-foreground">{r.count}</span>
+          </button>
+        ))}
+    </div>
+  );
+}
+
+export { postReaction, applyToggle };

--- a/src/lib/beaver/bookmark.ts
+++ b/src/lib/beaver/bookmark.ts
@@ -75,5 +75,6 @@ export async function getBookmarkedEvents(
     tags: fetchedTags[e.id] || {},
     read: true,
     bookmarked: true,
+    reactions: [],
   }));
 }

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -1,6 +1,7 @@
 import { db } from "../db/db";
 import { events, channels, eventTags, channelReads, bookmarks } from "../db/schema";
 import { getEventTags } from "./event-tags";
+import { getEventReactions } from "./reaction";
 import { eq, ne, and, or, asc, desc, like, gt, lt, gte, lte, exists, max, sql } from "drizzle-orm";
 import { getProject } from "./project";
 
@@ -35,6 +36,8 @@ export type Event = {
   createdAt: Date;
 };
 
+export type ReactionSummary = { emoji: string; count: number; userReacted: boolean };
+
 export type EventWithChannelName = {
   id: number;
   eventObject: string;
@@ -48,6 +51,7 @@ export type EventWithChannelName = {
   tags: TagPrimitive;
   read: boolean;
   bookmarked: boolean;
+  reactions: ReactionSummary[];
 };
 
 export type TagFilter = {
@@ -267,11 +271,15 @@ export async function getChannelEvents(
     .limit(options.limit ?? 100);
 
   const eventIds = eventData.map((event) => event.id);
-  const fetchedTags = await getEventTags(eventIds);
+  const [fetchedTags, fetchedReactions] = await Promise.all([
+    getEventTags(eventIds),
+    getEventReactions(eventIds, userId),
+  ]);
 
   return eventData.map((event) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
+    reactions: fetchedReactions[event.id] || [],
     read: Boolean(event.read),
     bookmarked: Boolean(event.bookmarked),
   }));
@@ -336,11 +344,15 @@ export async function getProjectEvents(
     .limit(options.limit ?? 100);
 
   const eventIds = eventData.map((event) => event.id);
-  const fetchedTags = await getEventTags(eventIds);
+  const [fetchedTags, fetchedReactions] = await Promise.all([
+    getEventTags(eventIds),
+    getEventReactions(eventIds, userId),
+  ]);
 
   return eventData.map((event) => ({
     ...event,
     tags: fetchedTags[event.id] || {},
+    reactions: fetchedReactions[event.id] || [],
     read: Boolean(event.read),
     bookmarked: Boolean(event.bookmarked),
   })) as EventWithChannelName[];
@@ -436,11 +448,15 @@ export async function getEvent(
   }
 
   const event = eventData[0];
-  const tags = await getEventTags([event.id]);
+  const [tags, reactions] = await Promise.all([
+    getEventTags([event.id]),
+    getEventReactions([event.id], userId),
+  ]);
 
   return {
     ...event,
     tags: tags[event.id] || {},
+    reactions: reactions[event.id] || [],
     read: Boolean(event.read),
     bookmarked: Boolean(event.bookmarked),
   };
@@ -491,6 +507,7 @@ export async function exportChannelEvents(
     tags: fetchedTags[e.id] || {},
     read: false,
     bookmarked: false,
+    reactions: [],
   }));
 }
 
@@ -523,6 +540,7 @@ export async function exportProjectEvents(
     tags: fetchedTags[e.id] || {},
     read: false,
     bookmarked: false,
+    reactions: [],
   }));
 }
 
@@ -634,6 +652,7 @@ export async function createEvent({
     createdAt: event.createdAt,
     read: false,
     bookmarked: false,
+    reactions: [],
   };
 }
 

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -36,7 +36,12 @@ export type Event = {
   createdAt: Date;
 };
 
-export type ReactionSummary = { emoji: string; count: number; userReacted: boolean };
+export type ReactionSummary = {
+  emoji: string;
+  count: number;
+  userReacted: boolean;
+  users: string[];
+};
 
 export type EventWithChannelName = {
   id: number;

--- a/src/lib/beaver/reaction.ts
+++ b/src/lib/beaver/reaction.ts
@@ -1,0 +1,68 @@
+import { db } from "../db/db";
+import { eventReactions } from "../db/schema";
+import { eq, and, inArray, count as countFn } from "drizzle-orm";
+import type { ReactionSummary } from "./event";
+
+export async function toggleReaction(
+  userId: number,
+  eventId: number,
+  emoji: string,
+): Promise<ReactionSummary> {
+  const existing = await db
+    .select({ id: eventReactions.id })
+    .from(eventReactions)
+    .where(
+      and(
+        eq(eventReactions.userId, userId),
+        eq(eventReactions.eventId, eventId),
+        eq(eventReactions.emoji, emoji),
+      ),
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    await db.delete(eventReactions).where(eq(eventReactions.id, existing[0].id));
+  } else {
+    await db.insert(eventReactions).values({ userId, eventId, emoji });
+  }
+
+  const [{ total }] = await db
+    .select({ total: countFn() })
+    .from(eventReactions)
+    .where(and(eq(eventReactions.eventId, eventId), eq(eventReactions.emoji, emoji)));
+
+  return { emoji, count: total, userReacted: existing.length === 0 };
+}
+
+export async function getEventReactions(
+  eventIds: number[],
+  userId?: number,
+): Promise<Record<number, ReactionSummary[]>> {
+  if (eventIds.length === 0) return {};
+
+  const rows = await db
+    .select()
+    .from(eventReactions)
+    .where(inArray(eventReactions.eventId, eventIds));
+
+  const grouped: Record<number, Record<string, { count: number; userReacted: boolean }>> = {};
+  for (const row of rows) {
+    if (!grouped[row.eventId]) grouped[row.eventId] = {};
+    if (!grouped[row.eventId][row.emoji]) {
+      grouped[row.eventId][row.emoji] = { count: 0, userReacted: false };
+    }
+    grouped[row.eventId][row.emoji].count++;
+    if (userId !== undefined && row.userId === userId) {
+      grouped[row.eventId][row.emoji].userReacted = true;
+    }
+  }
+
+  const result: Record<number, ReactionSummary[]> = {};
+  for (const [eventIdStr, emojis] of Object.entries(grouped)) {
+    result[Number(eventIdStr)] = Object.entries(emojis).map(([emoji, data]) => ({
+      emoji,
+      ...data,
+    }));
+  }
+  return result;
+}

--- a/src/lib/beaver/reaction.ts
+++ b/src/lib/beaver/reaction.ts
@@ -1,6 +1,6 @@
 import { db } from "../db/db";
-import { eventReactions } from "../db/schema";
-import { eq, and, inArray, count as countFn } from "drizzle-orm";
+import { eventReactions, users } from "../db/schema";
+import { eq, and, inArray } from "drizzle-orm";
 import type { ReactionSummary } from "./event";
 
 export async function toggleReaction(
@@ -26,12 +26,18 @@ export async function toggleReaction(
     await db.insert(eventReactions).values({ userId, eventId, emoji });
   }
 
-  const [{ total }] = await db
-    .select({ total: countFn() })
+  const reactors = await db
+    .select({ userId: eventReactions.userId, userName: users.userName })
     .from(eventReactions)
+    .innerJoin(users, eq(eventReactions.userId, users.id))
     .where(and(eq(eventReactions.eventId, eventId), eq(eventReactions.emoji, emoji)));
 
-  return { emoji, count: total, userReacted: existing.length === 0 };
+  return {
+    emoji,
+    count: reactors.length,
+    userReacted: reactors.some((r) => r.userId === userId),
+    users: reactors.map((r) => r.userName),
+  };
 }
 
 export async function getEventReactions(
@@ -41,28 +47,38 @@ export async function getEventReactions(
   if (eventIds.length === 0) return {};
 
   const rows = await db
-    .select()
+    .select({
+      eventId: eventReactions.eventId,
+      emoji: eventReactions.emoji,
+      userId: eventReactions.userId,
+      userName: users.userName,
+    })
     .from(eventReactions)
+    .innerJoin(users, eq(eventReactions.userId, users.id))
     .where(inArray(eventReactions.eventId, eventIds));
 
-  const grouped: Record<number, Record<string, { count: number; userReacted: boolean }>> = {};
+  const grouped: Record<number, Record<string, ReactionSummary>> = {};
   for (const row of rows) {
     if (!grouped[row.eventId]) grouped[row.eventId] = {};
     if (!grouped[row.eventId][row.emoji]) {
-      grouped[row.eventId][row.emoji] = { count: 0, userReacted: false };
+      grouped[row.eventId][row.emoji] = {
+        emoji: row.emoji,
+        count: 0,
+        userReacted: false,
+        users: [],
+      };
     }
-    grouped[row.eventId][row.emoji].count++;
+    const summary = grouped[row.eventId][row.emoji];
+    summary.count++;
+    summary.users.push(row.userName);
     if (userId !== undefined && row.userId === userId) {
-      grouped[row.eventId][row.emoji].userReacted = true;
+      summary.userReacted = true;
     }
   }
 
   const result: Record<number, ReactionSummary[]> = {};
   for (const [eventIdStr, emojis] of Object.entries(grouped)) {
-    result[Number(eventIdStr)] = Object.entries(emojis).map(([emoji, data]) => ({
-      emoji,
-      ...data,
-    }));
+    result[Number(eventIdStr)] = Object.values(emojis);
   }
   return result;
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -211,6 +211,32 @@ export const channelReads = sqliteTable(
   }),
 );
 
+// --- EVENT REACTIONS ---
+export const eventReactions = sqliteTable(
+  "event_reactions",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    eventId: integer("event_id")
+      .notNull()
+      .references(() => events.id, { onDelete: "cascade" }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    emoji: text("emoji").notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    eventUserEmojiIdx: uniqueIndex("event_reactions_event_user_emoji_idx").on(
+      table.eventId,
+      table.userId,
+      table.emoji,
+    ),
+    eventIdIdx: index("event_reactions_event_id_idx").on(table.eventId),
+  }),
+);
+
 // --- BOOKMARKS ---
 export const bookmarks = sqliteTable(
   "bookmarks",
@@ -447,5 +473,16 @@ export const metricValueRelations = relations(metricValues, ({ one }) => ({
   metric: one(metrics, {
     fields: [metricValues.metricId],
     references: [metrics.id],
+  }),
+}));
+
+export const eventReactionRelations = relations(eventReactions, ({ one }) => ({
+  event: one(events, {
+    fields: [eventReactions.eventId],
+    references: [events.id],
+  }),
+  user: one(users, {
+    fields: [eventReactions.userId],
+    references: [users.id],
   }),
 }));

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -123,6 +123,7 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
             createdAt: event.createdAt,
             read: false,
             bookmarked: false,
+            reactions: [],
           };
         }),
       );

--- a/src/pages/api/events/[eventID]/reactions.ts
+++ b/src/pages/api/events/[eventID]/reactions.ts
@@ -1,0 +1,26 @@
+import { toggleReaction } from "@/lib/beaver/reaction";
+import type { APIContext, APIRoute } from "astro";
+
+export const POST: APIRoute = async ({ locals, request, params }: APIContext) => {
+  const user = locals.user;
+  if (!user) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+  }
+
+  const eventId = parseInt(params.eventID!);
+  if (isNaN(eventId)) {
+    return new Response(JSON.stringify({ error: "Invalid event ID" }), { status: 400 });
+  }
+
+  const { emoji } = await request.json();
+  if (!emoji || typeof emoji !== "string") {
+    return new Response(JSON.stringify({ error: "emoji is required" }), { status: 400 });
+  }
+
+  const reaction = await toggleReaction(user.id, eventId, emoji);
+  return new Response(JSON.stringify(reaction), {
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+export const prerender = false;


### PR DESCRIPTION
## Summary

- Reactions via right-click context menu picker on event cards, or button in event detail
- Custom lightweight emoji picker (searchable, virtualized, supports full emoji-mart dataset)
- No animation stutter on menu open (CSS animation disabled, virtualizer seeded for immediate render)
- Multiple reactions in sequence now sync live without page refresh
- Hover any reaction to see who reacted: Discord/Slack style ("alice, bob and carol reacted with 👍")
- Reactions display inline with channel/datetime metadata, so card height stays constant

## Implementation

- `event_reactions` table: eventId, userId, emoji with unique constraint per user+event+emoji
- `POST /api/events/[eventID]/reactions` toggles a reaction and returns updated summary with reactor list
- Reactions fetched alongside events; `ReactionSummary` now includes `users: string[]` for reactor names
- `ReactionBar` is controlled by parent, ensuring state stays in sync with emoji picker
- Virtualized emoji grid (via @tanstack/react-virtual) for fast rendering on first paint
- Stretched-link card layout so reactions stay interactive while whole card remains clickable

Closes #199