### PR TITLE
fix: use composite (createdAt, id) cursor for date-sort pagination

### DIFF
--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -184,11 +184,9 @@ export default function EventFeed({
           `&cursorAction=${encodeURIComponent(lastEvent.eventAction)}` +
           `&cursorId=${lastEvent.id}`;
       } else if (order === "asc") {
-        endpoint +=
-          `&afterCreatedAt=${new Date(lastEvent.createdAt).getTime()}&afterId=${lastEvent.id}`;
+        endpoint += `&afterCreatedAt=${new Date(lastEvent.createdAt).getTime()}&afterId=${lastEvent.id}`;
       } else {
-        endpoint +=
-          `&beforeCreatedAt=${new Date(lastEvent.createdAt).getTime()}&beforeId=${lastEvent.id}`;
+        endpoint += `&beforeCreatedAt=${new Date(lastEvent.createdAt).getTime()}&beforeId=${lastEvent.id}`;
       }
     }
 

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -184,9 +184,11 @@ export default function EventFeed({
           `&cursorAction=${encodeURIComponent(lastEvent.eventAction)}` +
           `&cursorId=${lastEvent.id}`;
       } else if (order === "asc") {
-        endpoint += `&afterId=${lastEvent.id}`;
+        endpoint +=
+          `&afterCreatedAt=${new Date(lastEvent.createdAt).getTime()}&afterId=${lastEvent.id}`;
       } else {
-        endpoint += `&beforeId=${lastEvent.id}`;
+        endpoint +=
+          `&beforeCreatedAt=${new Date(lastEvent.createdAt).getTime()}&beforeId=${lastEvent.id}`;
       }
     }
 
@@ -325,7 +327,10 @@ export default function EventFeed({
     fetch("/api/unread", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ channelName: channel.name, projectId: channel.projectId }),
+      body: JSON.stringify({
+        channelName: channel.name,
+        projectId: channel.projectId,
+      }),
     })
       .then((res) => res.json())
       .then((data) => {
@@ -383,6 +388,8 @@ export default function EventFeed({
   });
 
   const virtualItems = virtualizer.getVirtualItems();
+  const lastVisibleIndex =
+    virtualItems.length > 0 ? virtualItems[virtualItems.length - 1].index : -1;
 
   useEffect(() => {
     if (loading || didScrollToDivider.current || dividerRowIndex === -1) return;
@@ -390,27 +397,42 @@ export default function EventFeed({
     virtualizer.scrollToIndex(dividerRowIndex, { align: "center" });
   }, [loading, dividerRowIndex]);
 
+  // Depend on the primitive last-visible-index, not `virtualItems` itself — that
+  // array gets a new reference on nearly every render (including ones unrelated to
+  // scrolling, like the loading-state flips below), which would otherwise re-run
+  // this effect far more often than the scroll position actually changes.
   useEffect(() => {
-    if (loading || virtualItems.length === 0) return;
-    const lastItem = virtualItems[virtualItems.length - 1];
+    if (loading || lastVisibleIndex === -1) return;
     if (
-      lastItem.index >= rows.length - 5 &&
+      lastVisibleIndex >= rows.length - 5 &&
       !loadingMoreRef.current &&
       hasMoreRef.current &&
       eventsRef.current.length > 0
     ) {
+      // Set the ref synchronously, not just the state — `loadingMoreRef.current` is
+      // otherwise only synced from `loadingMore` on the next render, leaving a window
+      // where this effect can re-fire on a subsequent scroll-driven render and kick
+      // off a second fetch with the same cursor before the first one's guard takes
+      // effect.
+      loadingMoreRef.current = true;
       setLoadingMore(true);
       getEvents().then((res) => {
-        if (res.length > 0) {
-          res.forEach((e) => eventIdsRef.current.add(e.id));
-          setEvents((prev) => [...prev, ...res]);
-        } else {
+        const unique = res.filter((e) => !eventIdsRef.current.has(e.id));
+        if (unique.length > 0) {
+          unique.forEach((e) => eventIdsRef.current.add(e.id));
+          setEvents((prev) => [...prev, ...unique]);
+        }
+        // Treat "nothing new" the same as "no more data". Otherwise a page that
+        // comes back fully duplicate (cursor not advancing) leaves hasMoreRef
+        // stuck true while state never grows, so the proximity check below
+        // immediately re-triggers the same fetch forever.
+        if (unique.length === 0) {
           hasMoreRef.current = false;
         }
         setLoadingMore(false);
       });
     }
-  }, [virtualItems, loading]);
+  }, [lastVisibleIndex, rows.length, loading]);
 
   const handleExport = (format: "json" | "csv") => {
     const base =

--- a/src/lib/beaver/event.ts
+++ b/src/lib/beaver/event.ts
@@ -67,6 +67,8 @@ type QueryOptions = {
   action?: string | null;
   afterId?: number;
   beforeId?: number;
+  afterCreatedAt?: Date;
+  beforeCreatedAt?: Date;
   cursorObject?: string;
   cursorAction?: string;
   cursorId?: number;
@@ -124,8 +126,29 @@ function applyFilterConditions(conditions: any[], options: QueryOptions) {
 }
 
 function applyCursorAndPagination(conditions: any[], options: QueryOptions) {
-  if (options.afterId) conditions.push(gt(events.id, options.afterId));
-  if (options.beforeId) conditions.push(lt(events.id, options.beforeId));
+  // Composite (createdAt, id) cursor for date-sort pagination. Falls back to
+  // plain id comparison when no date is provided (used by the SSE stream).
+  if (options.afterCreatedAt !== undefined && options.afterId !== undefined) {
+    conditions.push(
+      or(
+        gt(events.createdAt, options.afterCreatedAt),
+        and(eq(events.createdAt, options.afterCreatedAt), gt(events.id, options.afterId)),
+      ),
+    );
+  } else if (options.afterId) {
+    conditions.push(gt(events.id, options.afterId));
+  }
+
+  if (options.beforeCreatedAt !== undefined && options.beforeId !== undefined) {
+    conditions.push(
+      or(
+        lt(events.createdAt, options.beforeCreatedAt),
+        and(eq(events.createdAt, options.beforeCreatedAt), lt(events.id, options.beforeId)),
+      ),
+    );
+  } else if (options.beforeId) {
+    conditions.push(lt(events.id, options.beforeId));
+  }
 
   if (
     options.cursorObject !== undefined &&

--- a/src/pages/api/events/channel/[channelID]/index.ts
+++ b/src/pages/api/events/channel/[channelID]/index.ts
@@ -23,6 +23,8 @@ export async function GET({
     let limit;
     let beforeId;
     let afterId;
+    let beforeCreatedAt: Date | undefined;
+    let afterCreatedAt: Date | undefined;
     let cursorObject: string | undefined;
     let cursorAction: string | undefined;
     let cursorId: number | undefined;
@@ -35,6 +37,12 @@ export async function GET({
     }
     if (url.searchParams.get("afterId")) {
       afterId = parseInt(url.searchParams.get("afterId")!);
+    }
+    if (url.searchParams.get("beforeCreatedAt")) {
+      beforeCreatedAt = new Date(Number(url.searchParams.get("beforeCreatedAt")!));
+    }
+    if (url.searchParams.get("afterCreatedAt")) {
+      afterCreatedAt = new Date(Number(url.searchParams.get("afterCreatedAt")!));
     }
     if (
       url.searchParams.get("cursorObject") &&
@@ -76,6 +84,8 @@ export async function GET({
         limit,
         beforeId,
         afterId,
+        beforeCreatedAt,
+        afterCreatedAt,
         cursorObject,
         cursorAction,
         cursorId,

--- a/src/pages/api/events/project/[projectID]/index.ts
+++ b/src/pages/api/events/project/[projectID]/index.ts
@@ -23,6 +23,8 @@ export async function GET({
     let limit;
     let beforeId;
     let afterId;
+    let beforeCreatedAt: Date | undefined;
+    let afterCreatedAt: Date | undefined;
     let cursorObject: string | undefined;
     let cursorAction: string | undefined;
     let cursorId: number | undefined;
@@ -35,6 +37,12 @@ export async function GET({
     }
     if (url.searchParams.get("afterId")) {
       afterId = parseInt(url.searchParams.get("afterId")!);
+    }
+    if (url.searchParams.get("beforeCreatedAt")) {
+      beforeCreatedAt = new Date(Number(url.searchParams.get("beforeCreatedAt")!));
+    }
+    if (url.searchParams.get("afterCreatedAt")) {
+      afterCreatedAt = new Date(Number(url.searchParams.get("afterCreatedAt")!));
     }
     if (
       url.searchParams.get("cursorObject") &&
@@ -76,6 +84,8 @@ export async function GET({
         limit,
         beforeId,
         afterId,
+        beforeCreatedAt,
+        afterCreatedAt,
         cursorObject,
         cursorAction,
         cursorId,


### PR DESCRIPTION
## Summary

- Replaces the `id`-only pagination cursor for date-sorted feeds with a composite `(createdAt, id)` keyset cursor: `(createdAt < cursor_ts) OR (createdAt = cursor_ts AND id < cursor_id)`
- The old `id < lastEvent.id` cursor assumed id order correlates with createdAt order — true for real-time events, but broken for bulk-imported historical events (coming in v2.1.0) where high new IDs carry old timestamps
- The SSE stream's plain `afterId` path is unchanged since new events always get monotonically higher IDs

## Root cause

On a channel with bulk-imported events, the first page fetch (sorted `createdAt DESC`) could return events whose IDs are *lower* than the cursor ID used for the next page. The second page's `WHERE id < lastEvent.id` would then return events already shown, the duplicate guard set `hasMoreRef = false`, and pagination stopped after page 1.

## Test plan

- [ ] Load a channel/feed with more than 20 events and scroll to the bottom — all events should load
- [ ] Verify SSE still delivers new real-time events at the top of the feed
- [ ] Verify oldest-first (`date_asc`) sort also paginates correctly

Closes #223