### PR TITLE
fix: sort SSE batch ascending so trickle drain displays newest-first

### DIFF
--- a/src/lib/beaver/event-stream.ts
+++ b/src/lib/beaver/event-stream.ts
@@ -108,7 +108,7 @@ export function streamEvents(opts: {
         const initial = await fetchInitial(afterId);
         if (initial.length > 0) {
           lastSentId = Math.max(lastSentId, ...initial.map((e) => e.id));
-          send(initial);
+          send([...initial].sort((a, b) => a.id - b.id));
         }
       } catch (err) {
         console.error("Error fetching initial events for stream:", err);
@@ -116,7 +116,7 @@ export function streamEvents(opts: {
 
       // Flush events that arrived during the catch-up read. Synchronous with
       // the caughtUp flip, so a concurrent publish can't slip past unbuffered.
-      const pending = buffer.filter((e) => e.id > lastSentId).sort((a, b) => b.id - a.id);
+      const pending = buffer.filter((e) => e.id > lastSentId).sort((a, b) => a.id - b.id);
       caughtUp = true;
       if (pending.length > 0) {
         lastSentId = Math.max(lastSentId, ...pending.map((e) => e.id));


### PR DESCRIPTION
## Summary

- The trickle drain in `event-feed.tsx` does `queue.shift()` + prepend for each event in a batch, which reverses the order relative to how the batch arrived
- The pending buffer in `event-stream.ts` was sorted descending (`b.id - a.id`), so a batch `[5, 4, 3]` was prepended as `[3, 4, 5]` on screen — oldest on top
- The initial catch-up batch from `fetchInitial` has the same issue (returns descending from the DB query)
- Fix: sort both batches ascending (`a.id - b.id`) so the trickle's prepend reverses them back to newest-first

Closes #226