### PR TITLE
feat: audit log (#116)

### DIFF
--- a/drizzle/0019_striped_hex.sql
+++ b/drizzle/0019_striped_hex.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `audit_log` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`project_id` integer NOT NULL,
+	`user_id` integer NOT NULL,
+	`action` text NOT NULL,
+	`target_type` text,
+	`target_id` integer,
+	`target_name` text,
+	`metadata` text,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0019_snapshot.json
+++ b/drizzle/meta/0019_snapshot.json
@@ -1,0 +1,1352 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5abe0e0a-c59a-4f1d-b99d-09c96f2bd048",
+  "prevId": "066ebf79-35e1-412d-9aa6-6747705c8865",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_reactions": {
+      "name": "event_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_reactions_event_user_emoji_idx": {
+          "name": "event_reactions_event_user_emoji_idx",
+          "columns": ["event_id", "user_id", "emoji"],
+          "isUnique": true
+        },
+        "event_reactions_event_id_idx": {
+          "name": "event_reactions_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_reactions_event_id_events_id_fk": {
+          "name": "event_reactions_event_id_events_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reactions_user_id_users_id_fk": {
+          "name": "event_reactions_user_id_users_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_per_minute": {
+          "name": "rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1781902699342,
       "tag": "0018_mushy_silk_fever",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1781903262659,
+      "tag": "0019_striped_hex",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/audit-log.tsx
+++ b/src/components/audit-log.tsx
@@ -1,0 +1,74 @@
+import type { AuditEntry } from "@/lib/beaver/audit-log";
+
+function formatRelative(date: Date): string {
+  const now = Date.now();
+  const diff = now - new Date(date).getTime();
+  const s = Math.floor(diff / 1000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(date).toLocaleDateString();
+}
+
+function describe(entry: AuditEntry): string {
+  const meta = entry.metadata ? (JSON.parse(entry.metadata) as Record<string, unknown>) : {};
+  const name = entry.targetName ? `#${entry.targetName}` : null;
+
+  switch (entry.action) {
+    case "api_key.rotated":
+      return "rotated the API key";
+    case "project.renamed":
+      return `renamed project from "${meta.from}" to "${meta.to}"`;
+    case "rate_limit.changed":
+      return meta.to === null
+        ? "removed the rate limit"
+        : meta.from === null
+          ? `set rate limit to ${meta.to} req/min`
+          : `changed rate limit from ${meta.from} to ${meta.to} req/min`;
+    case "channel.created":
+      return `created channel ${name}`;
+    case "channel.renamed":
+      return `renamed channel #${meta.from} to #${meta.to}`;
+    case "channel.deleted":
+      return `deleted channel ${name}`;
+    case "member.added":
+      return `added @${entry.targetName} as ${meta.role}`;
+    case "member.removed":
+      return `removed @${entry.targetName}`;
+    case "member.role_changed":
+      return `changed @${entry.targetName}'s role from ${meta.from} to ${meta.to}`;
+    default:
+      return entry.action;
+  }
+}
+
+export default function AuditLog({ entries }: { entries: AuditEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No activity recorded yet. Changes to project settings, channels, and members will appear
+        here.
+      </p>
+    );
+  }
+
+  return (
+    <ol className="flex flex-col gap-3">
+      {entries.map((entry) => (
+        <li key={entry.id} className="flex items-start gap-3 text-sm">
+          <span className="text-muted-foreground shrink-0 w-16 text-right tabular-nums">
+            {formatRelative(entry.createdAt)}
+          </span>
+          <span>
+            <span className="font-medium">@{entry.actorName}</span>{" "}
+            <span className="text-muted-foreground">{describe(entry)}</span>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/src/components/audit-log.tsx
+++ b/src/components/audit-log.tsx
@@ -1,4 +1,24 @@
 import type { AuditEntry } from "@/lib/beaver/audit-log";
+import { useState, useMemo } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const ACTION_LABELS: Record<string, string> = {
+  "api_key.rotated": "API key rotated",
+  "project.renamed": "Project renamed",
+  "rate_limit.changed": "Rate limit changed",
+  "channel.created": "Channel created",
+  "channel.renamed": "Channel renamed",
+  "channel.deleted": "Channel deleted",
+  "member.added": "Member added",
+  "member.removed": "Member removed",
+  "member.role_changed": "Member role changed",
+};
 
 function formatRelative(date: Date): string {
   const now = Date.now();
@@ -47,6 +67,23 @@ function describe(entry: AuditEntry): string {
 }
 
 export default function AuditLog({ entries }: { entries: AuditEntry[] }) {
+  const [actorFilter, setActorFilter] = useState("__all__");
+  const [actionFilter, setActionFilter] = useState("__all__");
+
+  const actors = useMemo(() => [...new Set(entries.map((e) => e.actorName))].sort(), [entries]);
+
+  const actions = useMemo(() => [...new Set(entries.map((e) => e.action))].sort(), [entries]);
+
+  const filtered = useMemo(
+    () =>
+      entries.filter(
+        (e) =>
+          (actorFilter === "__all__" || e.actorName === actorFilter) &&
+          (actionFilter === "__all__" || e.action === actionFilter),
+      ),
+    [entries, actorFilter, actionFilter],
+  );
+
   if (entries.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
@@ -57,18 +94,54 @@ export default function AuditLog({ entries }: { entries: AuditEntry[] }) {
   }
 
   return (
-    <ol className="flex flex-col gap-3">
-      {entries.map((entry) => (
-        <li key={entry.id} className="flex items-start gap-3 text-sm">
-          <span className="text-muted-foreground shrink-0 w-16 text-right tabular-nums">
-            {formatRelative(entry.createdAt)}
-          </span>
-          <span>
-            <span className="font-medium">@{entry.actorName}</span>{" "}
-            <span className="text-muted-foreground">{describe(entry)}</span>
-          </span>
-        </li>
-      ))}
-    </ol>
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Select value={actorFilter} onValueChange={setActorFilter}>
+          <SelectTrigger className="w-40">
+            <SelectValue placeholder="All users" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All users</SelectItem>
+            {actors.map((actor) => (
+              <SelectItem key={actor} value={actor}>
+                @{actor}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select value={actionFilter} onValueChange={setActionFilter}>
+          <SelectTrigger className="w-52">
+            <SelectValue placeholder="All actions" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="__all__">All actions</SelectItem>
+            {actions.map((action) => (
+              <SelectItem key={action} value={action}>
+                {ACTION_LABELS[action] ?? action}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No entries match the selected filters.</p>
+      ) : (
+        <ol className="flex flex-col gap-3">
+          {filtered.map((entry) => (
+            <li key={entry.id} className="flex items-start gap-3 text-sm">
+              <span className="text-muted-foreground shrink-0 w-16 text-right tabular-nums">
+                {formatRelative(entry.createdAt)}
+              </span>
+              <span>
+                <span className="font-medium">@{entry.actorName}</span>{" "}
+                <span className="text-muted-foreground">{describe(entry)}</span>
+              </span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
   );
 }

--- a/src/components/settings-tabs.tsx
+++ b/src/components/settings-tabs.tsx
@@ -2,10 +2,12 @@ import type { Channel } from "@/lib/beaver/channel";
 import type { MetricWithValue } from "@/lib/beaver/metric";
 import type { Project } from "@/lib/beaver/project";
 import type { AlertRuleWithChannel } from "@/lib/beaver/alert-rule";
+import type { AuditEntry } from "@/lib/beaver/audit-log";
 import { useRef, useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 import APIKey from "./api-key";
 import AlertSettings from "./alert-settings";
+import AuditLog from "./audit-log";
 import ChannelSettings from "./channel-settings";
 import MetricSettings from "./metric-settings";
 import NotificationSettings from "./notification-settings";
@@ -19,6 +21,7 @@ interface Props {
   channels: Channel[];
   metrics: MetricWithValue[];
   alertRules: AlertRuleWithChannel[];
+  auditLog: AuditEntry[];
   isOwner: boolean;
   currentUserId: number;
   initialEmail: string | null;
@@ -33,6 +36,7 @@ export default function SettingsTabs({
   channels,
   metrics,
   alertRules,
+  auditLog,
   isOwner,
   currentUserId,
   initialEmail,
@@ -59,6 +63,7 @@ export default function SettingsTabs({
         <TabsTrigger value="metrics">Metrics</TabsTrigger>
         <TabsTrigger value="alerts">Alerts</TabsTrigger>
         <TabsTrigger value="notifications">Notifications</TabsTrigger>
+        {isOwner && <TabsTrigger value="audit">Audit Log</TabsTrigger>}
         {isOwner && (
           <TabsTrigger value="danger" className="text-destructive">
             Danger Zone
@@ -118,6 +123,12 @@ export default function SettingsTabs({
           />
         )}
       </TabsContent>
+
+      {isOwner && (
+        <TabsContent value="audit" className="mt-6 md:mt-0">
+          {show("audit") && <AuditLog entries={auditLog} />}
+        </TabsContent>
+      )}
 
       {isOwner && (
         <TabsContent value="danger" className="mt-6 md:mt-0">

--- a/src/lib/beaver/audit-log.ts
+++ b/src/lib/beaver/audit-log.ts
@@ -1,0 +1,56 @@
+import { db } from "../db/db";
+import { auditLog } from "../db/schema";
+import { users } from "../db/schema";
+import { eq, desc } from "drizzle-orm";
+
+export type AuditEntry = {
+  id: number;
+  action: string;
+  targetType: string | null;
+  targetId: number | null;
+  targetName: string | null;
+  metadata: string | null;
+  createdAt: Date;
+  actorName: string;
+};
+
+export async function logAuditEntry(entry: {
+  projectId: number;
+  userId: number;
+  action: string;
+  targetType?: string;
+  targetId?: number;
+  targetName?: string;
+  metadata?: Record<string, unknown>;
+}): Promise<void> {
+  await db.insert(auditLog).values({
+    projectId: entry.projectId,
+    userId: entry.userId,
+    action: entry.action,
+    targetType: entry.targetType ?? null,
+    targetId: entry.targetId ?? null,
+    targetName: entry.targetName ?? null,
+    metadata: entry.metadata ? JSON.stringify(entry.metadata) : null,
+  });
+}
+
+export async function getAuditLog(projectId: number, limit = 100): Promise<AuditEntry[]> {
+  const rows = await db
+    .select({
+      id: auditLog.id,
+      action: auditLog.action,
+      targetType: auditLog.targetType,
+      targetId: auditLog.targetId,
+      targetName: auditLog.targetName,
+      metadata: auditLog.metadata,
+      createdAt: auditLog.createdAt,
+      actorName: users.userName,
+    })
+    .from(auditLog)
+    .innerJoin(users, eq(auditLog.userId, users.id))
+    .where(eq(auditLog.projectId, projectId))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit);
+
+  return rows as AuditEntry[];
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -365,6 +365,25 @@ export const sessions = sqliteTable("sessions", {
     .notNull(),
 });
 
+// ---- AUDIT LOG ----
+export const auditLog = sqliteTable("audit_log", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  projectId: integer("project_id")
+    .notNull()
+    .references(() => projects.id, { onDelete: "cascade" }),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  action: text("action").notNull(), // e.g. "api_key.rotated", "channel.created"
+  targetType: text("target_type"), // "channel" | "member" | null (project-level)
+  targetId: integer("target_id"),
+  targetName: text("target_name"), // snapshot so deletes don't lose context
+  metadata: text("metadata"), // JSON string for extra detail (old/new values, role, etc.)
+  createdAt: integer("created_at", { mode: "timestamp_ms" })
+    .default(sql`(unixepoch() * 1000)`)
+    .notNull(),
+});
+
 // ---- RELATIONS ----
 export const projectRelations = relations(projects, ({ many }) => ({
   channels: many(channels),

--- a/src/pages/api/channel.ts
+++ b/src/pages/api/channel.ts
@@ -1,10 +1,12 @@
 import {
   createChannel,
   deleteChannel,
+  getChannel,
   getChannels,
   reorderChannels,
   updateChannel,
 } from "@/lib/beaver/channel";
+import { logAuditEntry } from "@/lib/beaver/audit-log";
 import type { APIContext, APIRoute } from "astro";
 
 export const GET: APIRoute = async ({ request }: APIContext) => {
@@ -41,9 +43,9 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async (context: APIContext) => {
   try {
-    const { name, project_id, description } = await request.json();
+    const { name, project_id, description } = await context.request.json();
 
     if (!name) {
       return new Response(JSON.stringify({ error: "name is required to create channel." }));
@@ -56,11 +58,20 @@ export const POST: APIRoute = async ({ request }) => {
 
     const channel = await createChannel(splitName, project_id, description);
 
+    if (context.locals.user) {
+      logAuditEntry({
+        projectId: project_id,
+        userId: context.locals.user.id,
+        action: "channel.created",
+        targetType: "channel",
+        targetId: channel.id,
+        targetName: channel.name,
+      });
+    }
+
     return new Response(JSON.stringify(channel), {
       status: 200,
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
     });
   } catch (err) {
     if (err instanceof Error) {
@@ -109,9 +120,9 @@ export const PATCH: APIRoute = async ({ request }) => {
   }
 };
 
-export const PUT: APIRoute = async ({ request }) => {
+export const PUT: APIRoute = async (context: APIContext) => {
   try {
-    const { channelId, name, description } = await request.json();
+    const { channelId, name, description } = await context.request.json();
 
     if (!channelId) {
       return new Response(JSON.stringify({ error: "channelId is required." }), {
@@ -120,7 +131,20 @@ export const PUT: APIRoute = async ({ request }) => {
       });
     }
 
+    const existing = await getChannel(parseInt(channelId));
     const channel = await updateChannel(parseInt(channelId), { name, description });
+
+    if (context.locals.user && existing && name && name !== existing.name) {
+      logAuditEntry({
+        projectId: existing.projectId,
+        userId: context.locals.user.id,
+        action: "channel.renamed",
+        targetType: "channel",
+        targetId: existing.id,
+        targetName: name,
+        metadata: { from: existing.name, to: name },
+      });
+    }
 
     return new Response(JSON.stringify(channel), {
       status: 200,
@@ -141,9 +165,9 @@ export const PUT: APIRoute = async ({ request }) => {
   }
 };
 
-export const DELETE: APIRoute = async ({ request }) => {
+export const DELETE: APIRoute = async (context: APIContext) => {
   try {
-    const { channelID } = await request.json();
+    const { channelID } = await context.request.json();
 
     if (!channelID) {
       return new Response(JSON.stringify({ error: "channelID is required." }), {
@@ -152,7 +176,19 @@ export const DELETE: APIRoute = async ({ request }) => {
       });
     }
 
+    const existing = await getChannel(parseInt(channelID));
     const channel = await deleteChannel(parseInt(channelID));
+
+    if (context.locals.user && existing) {
+      logAuditEntry({
+        projectId: existing.projectId,
+        userId: context.locals.user.id,
+        action: "channel.deleted",
+        targetType: "channel",
+        targetId: existing.id,
+        targetName: existing.name,
+      });
+    }
 
     return new Response(JSON.stringify({ channel }), {
       status: 200,

--- a/src/pages/api/project-members.ts
+++ b/src/pages/api/project-members.ts
@@ -7,7 +7,8 @@ import {
   getUserProjectRole,
   type Role,
 } from "@/lib/beaver/project-member";
-import { getAllUsers } from "@/lib/beaver/user";
+import { getAllUsers, getUserById } from "@/lib/beaver/user";
+import { logAuditEntry } from "@/lib/beaver/audit-log";
 
 function canManage(userRole: Role | null, isAdmin: boolean): boolean {
   return isAdmin || userRole === "owner";
@@ -76,6 +77,16 @@ export const POST: APIRoute = async (context: APIContext) => {
     }
 
     const member = await addProjectMember(projectId, userId, role as Role);
+    const targetUser = await getUserById(userId);
+    logAuditEntry({
+      projectId,
+      userId: context.locals.user.id,
+      action: "member.added",
+      targetType: "member",
+      targetId: userId,
+      targetName: targetUser?.userName ?? String(userId),
+      metadata: { role },
+    });
     return new Response(JSON.stringify(member), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -115,7 +126,18 @@ export const PATCH: APIRoute = async (context: APIContext) => {
       });
     }
 
+    const previousRole = await getUserProjectRole(projectId, userId);
     await updateMemberRole(projectId, userId, role as Role);
+    const targetUser = await getUserById(userId);
+    logAuditEntry({
+      projectId,
+      userId: context.locals.user.id,
+      action: "member.role_changed",
+      targetType: "member",
+      targetId: userId,
+      targetName: targetUser?.userName ?? String(userId),
+      metadata: { from: previousRole, to: role },
+    });
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
       headers: { "Content-Type": "application/json" },
@@ -155,7 +177,16 @@ export const DELETE: APIRoute = async (context: APIContext) => {
       });
     }
 
+    const targetUser = await getUserById(userId);
     await removeProjectMember(projectId, userId);
+    logAuditEntry({
+      projectId,
+      userId: context.locals.user.id,
+      action: "member.removed",
+      targetType: "member",
+      targetId: userId,
+      targetName: targetUser?.userName ?? String(userId),
+    });
     return new Response(JSON.stringify({ success: true }), {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/src/pages/api/project.ts
+++ b/src/pages/api/project.ts
@@ -9,6 +9,7 @@ import {
   setRateLimit,
 } from "@/lib/beaver/project";
 import { getUserProjectRole, getProjectsForUser } from "@/lib/beaver/project-member";
+import { logAuditEntry } from "@/lib/beaver/audit-log";
 
 export const GET: APIRoute = async (context: APIContext) => {
   if (!context.locals.user) {
@@ -132,6 +133,12 @@ export const PATCH: APIRoute = async (context: APIContext) => {
         });
       }
       updated = await renameProject(parseInt(projectID), name.trim());
+      logAuditEntry({
+        projectId: parseInt(projectID),
+        userId: context.locals.user.id,
+        action: "project.renamed",
+        metadata: { from: project.name, to: name.trim() },
+      });
     }
 
     if (rateLimitPerMinute !== undefined) {
@@ -147,6 +154,12 @@ export const PATCH: APIRoute = async (context: APIContext) => {
         );
       }
       updated = await setRateLimit(parseInt(projectID), rateLimitPerMinute);
+      logAuditEntry({
+        projectId: parseInt(projectID),
+        userId: context.locals.user.id,
+        action: "rate_limit.changed",
+        metadata: { from: project.rateLimitPerMinute, to: rateLimitPerMinute },
+      });
     }
 
     return new Response(JSON.stringify(updated), {
@@ -268,6 +281,11 @@ export const PUT: APIRoute = async (context: APIContext) => {
     }
 
     const { newKey, previousKeyExpiresAt } = await rotateApiKey(parseInt(projectID));
+    logAuditEntry({
+      projectId: parseInt(projectID),
+      userId: context.locals.user.id,
+      action: "api_key.rotated",
+    });
     return new Response(
       JSON.stringify({ apiKey: newKey, previousKeyExpiresAt: previousKeyExpiresAt.toISOString() }),
       { status: 200, headers: { "Content-Type": "application/json" } },

--- a/src/pages/dashboard/[projectID]/settings.astro
+++ b/src/pages/dashboard/[projectID]/settings.astro
@@ -8,6 +8,7 @@ import { getUserProjectRole } from "@/lib/beaver/project-member";
 import { getUserByUsername } from "@/lib/beaver/user";
 import { getChannelSubscriptions } from "@/lib/beaver/channel-notification";
 import { getAlertRulesForProject } from "@/lib/beaver/alert-rule";
+import { getAuditLog } from "@/lib/beaver/audit-log";
 
 const { projectID } = Astro.params;
 const user = Astro.locals.user!;
@@ -29,6 +30,7 @@ const subscribedChannelIds = await getChannelSubscriptions(user.id, project.id);
 const alertRules = await getAlertRulesForProject(project.id);
 
 const isOwner = userRole === "owner";
+const auditLog = isOwner ? await getAuditLog(project.id) : [];
 ---
 
 <Layout projectID={projectID!}>
@@ -44,6 +46,7 @@ const isOwner = userRole === "owner";
           channels={channels}
           metrics={metrics}
           alertRules={alertRules}
+          auditLog={auditLog}
           isOwner={isOwner}
           currentUserId={user.id}
           initialEmail={dbUser?.email ?? null}


### PR DESCRIPTION
## Summary

- New \`audit_log\` table (migration \`0019\`) tracks who changed what and when
- \`logAuditEntry\` / \`getAuditLog\` in \`src/lib/beaver/audit-log.ts\`
- Logs written on: API key rotation, project rename, rate limit change, channel create/rename/delete, member add/role change/remove
- New **Audit Log** tab in Project Settings (owner-only) — server-rendered entries passed as prop, no extra fetch needed
- User and action type filter dropdowns — filters compose, only show values present in the log
- \`channel.ts\` updated to use full \`APIContext\` so \`locals.user\` is accessible (also tightens the implicit auth reliance)

Closes #116