### PR TITLE
feat: one-click deploy templates (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,49 @@
 
 An event tracking and logging dashboard built with Astro, React, and SQLite.
 
+## Deploy
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/parisosuch/beaver)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template?template=https://github.com/parisosuch/beaver)
+
+### Render
+
+Click the button above. Render reads `render.yaml` from the repo root — it provisions a web service and a 1 GB persistent disk for the SQLite database automatically. `JWT_SECRET` is generated for you.
+
+> **Note:** Persistent disks require a paid Render plan. On the free tier the database resets on each deploy.
+
+### Railway
+
+Click the button above. Railway detects the Dockerfile and `railway.json` automatically. After the first deploy, add one environment variable in the Railway dashboard:
+
+| Variable | Value |
+| :------- | :---- |
+| `JWT_SECRET` | output of `openssl rand -base64 32` |
+
+Mount a Railway Volume at `/app/data` to persist the SQLite database across deploys.
+
+### Fly.io
+
+A `fly.toml` is included. Three commands to deploy:
+
+```sh
+fly auth login
+fly secrets set JWT_SECRET="$(openssl rand -base64 32)"
+fly deploy
+```
+
+A 1 GB volume named `beaver_data` is created automatically on first deploy for the SQLite database.
+
+### Coolify
+
+Beaver deploys from its Dockerfile with no extra config needed.
+
+1. In Coolify, add a new **Docker** resource and point it at this repository.
+2. Set the `JWT_SECRET` environment variable to a secure random string.
+3. Mount a persistent volume at `/app/data` so the SQLite database survives redeploys.
+
+---
+
 ## Prerequisites
 
 - [Bun](https://bun.sh/) (v1.0 or later)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Click the button above. Render reads `render.yaml` from the repo root — it pro
 
 Click the button above. Railway detects the Dockerfile and `railway.json` automatically. After the first deploy, add one environment variable in the Railway dashboard:
 
-| Variable | Value |
-| :------- | :---- |
+| Variable     | Value                               |
+| :----------- | :---------------------------------- |
 | `JWT_SECRET` | output of `openssl rand -base64 32` |
 
 Mount a Railway Volume at `/app/data` to persist the SQLite database across deploys.

--- a/fly.toml
+++ b/fly.toml
@@ -4,21 +4,21 @@ primary_region = "iad"
 [build]
 
 [env]
-  PORT = "4321"
-  HOST = "0.0.0.0"
+PORT = "4321"
+HOST = "0.0.0.0"
 
 [http_service]
-  internal_port = 4321
-  force_https = true
-  auto_stop_machines = "stop"
-  auto_start_machines = true
-  min_machines_running = 0
+internal_port = 4321
+force_https = true
+auto_stop_machines = "stop"
+auto_start_machines = true
+min_machines_running = 0
 
 [[vm]]
-  memory = "512mb"
-  cpu_kind = "shared"
-  cpus = 1
+memory = "512mb"
+cpu_kind = "shared"
+cpus = 1
 
 [[mounts]]
-  source = "beaver_data"
-  destination = "/app/data"
+source = "beaver_data"
+destination = "/app/data"

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,24 @@
+app = "beaver"
+primary_region = "iad"
+
+[build]
+
+[env]
+  PORT = "4321"
+  HOST = "0.0.0.0"
+
+[http_service]
+  internal_port = 4321
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = "512mb"
+  cpu_kind = "shared"
+  cpus = 1
+
+[[mounts]]
+  source = "beaver_data"
+  destination = "/app/data"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE"
+  },
+  "deploy": {
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,16 @@
+services:
+  - type: web
+    name: beaver
+    runtime: docker
+    plan: starter
+    envVars:
+      - key: JWT_SECRET
+        generateValue: true
+      - key: PORT
+        value: 4321
+      - key: HOST
+        value: 0.0.0.0
+    disk:
+      name: beaver-data
+      mountPath: /app/data
+      sizeGB: 1


### PR DESCRIPTION
## Summary

- **Render** — `render.yaml` Blueprint: web service + 1 GB persistent disk, `JWT_SECRET` auto-generated. Clicking the deploy button in the README is a true one-click deploy. (Persistent disk requires a paid Render plan; noted in README.)
- **Railway** — `railway.json`: tells Railway to use the Dockerfile with an on-failure restart policy. Deploy button links to Railway's template flow for this repo. One env var (`JWT_SECRET`) + a Volume mount needed after first deploy.
- **Fly.io** — `fly.toml`: shared-CPU VM, 512 MB RAM, auto-stop/start, 1 GB volume at `/app/data`. Three CLI commands to deploy.
- **Coolify** — no config file needed (uses existing Dockerfile). README documents the volume mount and env var.

README gets a `## Deploy` section near the top with both deploy buttons and per-platform instructions.

Closes #118