### PR TITLE
feat: compact UI mode (#134)

### DIFF
--- a/drizzle/0020_yielding_nightcrawler.sql
+++ b/drizzle/0020_yielding_nightcrawler.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `compact_mode` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "6acbc1e4-edb9-42ec-91e7-7f14a646c6c3",
-  "prevId": "e4686d0f-0ec5-4daa-92c7-466ba2d01dd0",
+  "id": "0028eeb7-3fa7-4e0f-8337-691da0edaaa3",
+  "prevId": "5abe0e0a-c59a-4f1d-b99d-09c96f2bd048",
   "tables": {
     "alert_rules": {
       "name": "alert_rules",
@@ -98,6 +98,99 @@
           "tableFrom": "alert_rules",
           "tableTo": "channels",
           "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
@@ -1033,6 +1126,20 @@
           "type": "text",
           "primaryKey": false,
           "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
           "autoincrement": false
         },
         "rate_limit_per_minute": {

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1781903262659,
       "tag": "0019_striped_hex",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1781889853936,
+      "tag": "0020_yielding_nightcrawler",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/account-settings.tsx
+++ b/src/components/account-settings.tsx
@@ -2,19 +2,24 @@ import { useState } from "react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
+import { Switch } from "./ui/switch";
 import ChangePasswordForm from "./change-password-form";
 
 export default function AccountSettings({
   initialFullName,
+  initialCompactMode,
   username,
 }: {
   initialFullName: string | null;
+  initialCompactMode: boolean;
   username: string;
 }) {
   const [fullName, setFullName] = useState(initialFullName ?? "");
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [compactMode, setCompactMode] = useState(initialCompactMode);
+  const [compactError, setCompactError] = useState<string | null>(null);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -38,6 +43,26 @@ export default function AccountSettings({
       setError("Failed to save.");
     } finally {
       setSaving(false);
+    }
+  };
+
+  const handleCompactModeChange = async (next: boolean) => {
+    setCompactMode(next);
+    setCompactError(null);
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ compactMode: next }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setCompactMode(!next);
+        setCompactError(data.error || "Failed to save.");
+      }
+    } catch {
+      setCompactMode(!next);
+      setCompactError("Failed to save.");
     }
   };
 
@@ -70,6 +95,20 @@ export default function AccountSettings({
           </div>
         </form>
         {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      <div className="flex flex-col space-y-4">
+        <h2 className="font-mono">Preferences</h2>
+        <div className={row}>
+          <div>
+            <p className={label}>Compact UI mode</p>
+            <p className="text-sm text-muted-foreground">
+              Show events in a denser, more compact layout.
+            </p>
+          </div>
+          <Switch checked={compactMode} onCheckedChange={handleCompactModeChange} />
+        </div>
+        {compactError && <p className="text-sm text-destructive">{compactError}</p>}
       </div>
 
       <div className="flex flex-col space-y-4">

--- a/src/components/bookmarks-feed.tsx
+++ b/src/components/bookmarks-feed.tsx
@@ -17,6 +17,7 @@ export default function BookmarksFeed({
   endDate,
   tags,
   channelId,
+  compact = false,
 }: {
   projectID: number;
   channels: Channel[];
@@ -27,6 +28,7 @@ export default function BookmarksFeed({
   endDate?: string | null;
   tags?: string | null;
   channelId?: string | null;
+  compact?: boolean;
 }) {
   const [events, setEvents] = useState<EventWithChannelName[]>([]);
   const [loading, setLoading] = useState(true);
@@ -136,9 +138,11 @@ export default function BookmarksFeed({
             <p>No bookmarks yet.</p>
           </div>
         ) : (
-          <div className="px-4 md:px-8 py-4 md:py-8 w-full lg:w-1/2 mx-auto flex flex-col gap-4">
+          <div
+            className={`px-4 md:px-8 py-4 md:py-8 w-full lg:w-1/2 mx-auto flex flex-col ${compact ? "gap-2" : "gap-4"}`}
+          >
             {events.map((event) => (
-              <EventCard key={event.id} event={event} />
+              <EventCard key={event.id} event={event} compact={compact} />
             ))}
           </div>
         )}

--- a/src/components/event-card.tsx
+++ b/src/components/event-card.tsx
@@ -6,7 +6,13 @@ import { memo, useRef, useState } from "react";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "./ui/context-menu";
 import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
-const EventCard = memo(function EventCard({ event }: { event: EventWithChannelName }) {
+const EventCard = memo(function EventCard({
+  event,
+  compact = false,
+}: {
+  event: EventWithChannelName;
+  compact?: boolean;
+}) {
   const [reactions, setReactions] = useState<ReactionSummary[]>(event.reactions);
   const eventUrl = `/dashboard/${event.projectId}/events/${event.id}`;
   const prefetched = useRef(false);
@@ -25,10 +31,28 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
     if (updated) setReactions((prev) => applyToggle(prev, updated));
   };
 
+  const reactionsBlock = reactions.length > 0 && (
+    <div
+      className="pointer-events-auto shrink-0"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+      }}
+    >
+      <ReactionBar reactions={reactions} onToggle={handleReact} max={compact ? 3 : undefined} />
+    </div>
+  );
+
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <Card className="hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer relative">
+        <Card
+          className={
+            compact
+              ? "py-0 outline-none hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer relative"
+              : "outline-none hover:bg-gray-50 dark:hover:bg-white/5 transition-colors overflow-hidden cursor-pointer relative"
+          }
+        >
           {/* Stretched link: the anchor covers the whole card so the card stays
               clickable, while the content sits above it with pointer-events disabled
               so clicks fall through. Interactive bits (reactions) opt back in. */}
@@ -38,42 +62,53 @@ const EventCard = memo(function EventCard({ event }: { event: EventWithChannelNa
             aria-label={event.title}
             className="absolute inset-0 z-0"
           />
-          <div className="relative z-10 pointer-events-none p-4 md:p-8">
-            <div className="flex items-center space-x-4">
-              <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
-                <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
-                  <span>{event.eventObject}</span>
-                  <span>·</span>
-                  <span>{event.eventAction}</span>
+          {compact ? (
+            // Single-line row, à la Discord/Slack compact mode: icon and metadata sit
+            // inline with the title instead of stacked underneath it, and the title is
+            // the only element that truncates so the trailing metadata stays visible.
+            <div className="relative z-10 pointer-events-none flex items-center gap-2 px-3 py-1.5">
+              <span className="shrink-0">{event.icon || "🪵"}</span>
+              <h2 className="text-sm font-medium truncate min-w-0">{event.title}</h2>
+              {reactionsBlock}
+              <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                # {event.channelName}
+              </span>
+              <span className="shrink-0 text-xs text-muted-foreground tabular-nums">
+                {getEventTime(new Date(event.createdAt))}
+              </span>
+              {event.bookmarked && (
+                <BookmarkIcon size={12} className="shrink-0 fill-current text-muted-foreground" />
+              )}
+              {!event.read && <div className="h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500" />}
+            </div>
+          ) : (
+            <div className="relative z-10 pointer-events-none p-4 md:p-8">
+              <div className="flex items-center space-x-4">
+                <div className="bg-gray-100 dark:bg-white/10 p-2 rounded-md">
+                  <p className="text-xl">{event.icon ? `${event.icon} ` : "🪵"}</p>
                 </div>
-                <h2 className="text-xl font-medium truncate">{event.title}</h2>
-                <div className="flex space-x-2 items-center text-sm text-muted-foreground">
-                  <p># {event.channelName}</p>
-                  <p>{getEventTime(new Date(event.createdAt))}</p>
-                </div>
-                {reactions.length > 0 && (
-                  <div
-                    className="mt-1.5 pointer-events-auto"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                    }}
-                  >
-                    <ReactionBar reactions={reactions} onToggle={handleReact} />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground font-mono mb-0.5">
+                    <span>{event.eventObject}</span>
+                    <span>·</span>
+                    <span>{event.eventAction}</span>
                   </div>
-                )}
-              </div>
-              <div className="flex items-center gap-2 flex-shrink-0">
-                {event.bookmarked && (
-                  <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
-                )}
-                {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
+                  <h2 className="text-xl font-medium truncate">{event.title}</h2>
+                  <div className="flex space-x-2 items-center text-sm text-muted-foreground">
+                    <p># {event.channelName}</p>
+                    <p>{getEventTime(new Date(event.createdAt))}</p>
+                  </div>
+                  {reactions.length > 0 && <div className="mt-1.5">{reactionsBlock}</div>}
+                </div>
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  {event.bookmarked && (
+                    <BookmarkIcon size={14} className="fill-current text-muted-foreground" />
+                  )}
+                  {!event.read && <div className="w-2 h-2 rounded-full bg-blue-500" />}
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </Card>
       </ContextMenuTrigger>
       {/* Disable the open/close animation: the fade/zoom drops frames while the emoji

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -60,6 +60,7 @@ export default function EventFeed({
   tags,
   sortBy,
   sortOrder,
+  compact = false,
 }: {
   type: "channel" | "project";
   projectID?: number;
@@ -72,6 +73,7 @@ export default function EventFeed({
   tags?: string | null;
   sortBy?: string | null;
   sortOrder?: string | null;
+  compact?: boolean;
 }) {
   const [events, setEvents] = useState<EventWithChannelName[]>([]);
   const [loading, setLoading] = useState(true);
@@ -409,7 +411,7 @@ export default function EventFeed({
   const virtualizer = useVirtualizer({
     count: rows.length,
     getScrollElement: () => scrollContainerRef.current,
-    estimateSize: (i) => (rows[i]?.kind === "divider" ? 32 : 112),
+    estimateSize: (i) => (rows[i]?.kind === "divider" ? 32 : compact ? 42 : 112),
     overscan: 5,
     getItemKey: (i) =>
       rows[i]?.kind === "divider" ? "divider" : rows[i]?.kind === "event" ? rows[i].event.id : i,
@@ -636,7 +638,7 @@ export default function EventFeed({
                       left: 0,
                       width: "100%",
                       transform: `translateY(${virtualRow.start}px)`,
-                      paddingBottom: "16px",
+                      paddingBottom: compact ? "8px" : "16px",
                     }}
                   >
                     {row.kind === "divider" ? (
@@ -649,11 +651,14 @@ export default function EventFeed({
                       <div
                         className={
                           row.isNew
-                            ? "animate-in fade-in slide-in-from-bottom-10 duration-300 ease-out"
+                            ? `animate-in fade-in duration-300 ease-out ${compact ? "slide-in-from-bottom-2" : "slide-in-from-bottom-10"}`
                             : undefined
                         }
+                        onAnimationEnd={
+                          row.isNew ? () => newEventIdsRef.current.delete(row.event.id) : undefined
+                        }
                       >
-                        <EventCard event={row.event} />
+                        <EventCard event={row.event} compact={compact} />
                       </div>
                     )}
                   </div>

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -131,47 +131,68 @@ function formatReactors(names: string[]): string {
 
 // Controlled: the parent owns the reaction state (a single source of truth shared
 // with the emoji picker), so adding several reactions in a row stays in sync.
+//
+// `max` bounds how many pills render — needed in single-line layouts (the compact
+// card row) where the bar sits in a non-shrinking flex slot and an unbounded number
+// of distinct emoji would push the rest of the row out past the card's clipped edge
+// instead of wrapping. Omit it where wrapping onto extra lines is fine.
 export function ReactionBar({
   reactions,
   onToggle,
+  max,
 }: {
   reactions: ReactionSummary[];
   onToggle: (emoji: string) => void;
+  max?: number;
 }) {
   if (reactions.length === 0) return null;
+
+  const sorted = [...reactions].sort((a, b) => b.count - a.count);
+  const visible = max ? sorted.slice(0, max) : sorted;
+  const overflow = max ? sorted.slice(max) : [];
 
   return (
     <TooltipProvider delayDuration={200}>
       <div className="flex flex-wrap gap-1">
-        {[...reactions]
-          .sort((a, b) => b.count - a.count)
-          .map((r) => (
-            <Tooltip key={r.emoji}>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    onToggle(r.emoji);
-                  }}
-                  className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-sm transition-colors ${
-                    r.userReacted
-                      ? "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300"
-                      : "bg-gray-100 text-foreground hover:bg-gray-200 dark:bg-white/10 dark:hover:bg-white/20"
-                  }`}
-                >
-                  <span>{r.emoji}</span>
-                  <span className="text-xs text-muted-foreground">{r.count}</span>
-                </button>
-              </TooltipTrigger>
-              <TooltipContent className="max-w-56">
-                <span className="font-medium">{formatReactors(r.users)}</span>
-                <span className="text-primary-foreground/70"> reacted with </span>
+        {visible.map((r) => (
+          <Tooltip key={r.emoji}>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onToggle(r.emoji);
+                }}
+                className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-sm transition-colors ${
+                  r.userReacted
+                    ? "bg-blue-100 text-blue-700 dark:bg-blue-500/20 dark:text-blue-300"
+                    : "bg-gray-100 text-foreground hover:bg-gray-200 dark:bg-white/10 dark:hover:bg-white/20"
+                }`}
+              >
                 <span>{r.emoji}</span>
-              </TooltipContent>
-            </Tooltip>
-          ))}
+                <span className="text-xs text-muted-foreground">{r.count}</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-56">
+              <span className="font-medium">{formatReactors(r.users)}</span>
+              <span className="text-primary-foreground/70"> reacted with </span>
+              <span>{r.emoji}</span>
+            </TooltipContent>
+          </Tooltip>
+        ))}
+        {overflow.length > 0 && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center rounded-md bg-gray-100 px-1.5 py-0.5 text-xs text-muted-foreground dark:bg-white/10">
+                +{overflow.length}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-56">
+              {overflow.map((r) => `${r.emoji} ${r.count}`).join("  ")}
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
     </TooltipProvider>
   );

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { Switch as SwitchPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -12,6 +12,7 @@ export type DatabaseUser = {
   password: string;
   mustChangePassword: boolean;
   tempPassword: string | null;
+  compactMode: boolean;
   createdAt: Date | null;
 };
 
@@ -24,6 +25,7 @@ export type User = {
   canCreateProjects: boolean;
   mustChangePassword: boolean;
   tempPassword: string | null;
+  compactMode: boolean;
   createdAt: Date | null;
 };
 
@@ -36,6 +38,7 @@ const userSelect = {
   canCreateProjects: users.canCreateProjects,
   mustChangePassword: users.mustChangePassword,
   tempPassword: users.tempPassword,
+  compactMode: users.compactMode,
   createdAt: users.createdAt,
 };
 
@@ -177,4 +180,8 @@ export async function updateUserEmail(id: number, email: string | null): Promise
 
 export async function updateUserFullName(id: number, fullName: string | null): Promise<void> {
   await db.update(users).set({ fullName }).where(eq(users.id, id));
+}
+
+export async function updateUserCompactMode(id: number, compactMode: boolean): Promise<void> {
+  await db.update(users).set({ compactMode }).where(eq(users.id, id));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -140,6 +140,7 @@ export const users = sqliteTable("users", {
   password: text("password").notNull(),
   mustChangePassword: integer("must_change_password", { mode: "boolean" }).notNull().default(false),
   tempPassword: text("temp_password"),
+  compactMode: integer("compact_mode", { mode: "boolean" }).notNull().default(false),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),

--- a/src/pages/api/users/me.ts
+++ b/src/pages/api/users/me.ts
@@ -1,4 +1,4 @@
-import { updateUserEmail, updateUserFullName } from "@/lib/beaver/user";
+import { updateUserCompactMode, updateUserEmail, updateUserFullName } from "@/lib/beaver/user";
 import type { APIContext } from "astro";
 
 export async function PATCH({ locals, request }: APIContext) {
@@ -16,6 +16,9 @@ export async function PATCH({ locals, request }: APIContext) {
   }
   if ("fullName" in body) {
     await updateUserFullName(user.id, body.fullName?.trim() || null);
+  }
+  if ("compactMode" in body) {
+    await updateUserCompactMode(user.id, !!body.compactMode);
   }
 
   return new Response(JSON.stringify({ ok: true }), {

--- a/src/pages/dashboard/[projectID]/account.astro
+++ b/src/pages/dashboard/[projectID]/account.astro
@@ -31,6 +31,7 @@ const dbUser = await getUserByUsername(user.userName);
         <AccountSettings
           client:load
           initialFullName={dbUser?.fullName ?? null}
+          initialCompactMode={dbUser?.compactMode ?? false}
           username={user.userName}
         />
       </div>

--- a/src/pages/dashboard/[projectID]/bookmarks.astro
+++ b/src/pages/dashboard/[projectID]/bookmarks.astro
@@ -2,9 +2,12 @@
 import Layout from "@/layouts/layout.astro";
 import BookmarksFeed from "@/components/bookmarks-feed";
 import { getChannels } from "@/lib/beaver/channel";
+import { getUserByUsername } from "@/lib/beaver/user";
 
 const { projectID } = Astro.params;
 const channels = await getChannels(parseInt(projectID!));
+const user = Astro.locals.user!;
+const dbUser = await getUserByUsername(user.userName);
 
 const title = Astro.url.searchParams.get("title");
 const object = Astro.url.searchParams.get("object");
@@ -27,5 +30,6 @@ const channelId = Astro.url.searchParams.get("channelId");
     endDate={endDate}
     tags={tags}
     channelId={channelId}
+    compact={dbUser?.compactMode ?? false}
   />
 </Layout>

--- a/src/pages/dashboard/[projectID]/channels/[channelID].astro
+++ b/src/pages/dashboard/[projectID]/channels/[channelID].astro
@@ -2,8 +2,11 @@
 import Layout from "@/layouts/layout.astro";
 import EventFeed from "@/components/event-feed";
 import { getChannel } from "@/lib/beaver/channel";
+import { getUserByUsername } from "@/lib/beaver/user";
 
 const { projectID, channelID } = Astro.params;
+const user = Astro.locals.user!;
+const dbUser = await getUserByUsername(user.userName);
 
 const url = new URL(Astro.request.url);
 const searchParams = url.searchParams;
@@ -34,5 +37,6 @@ const channel = await getChannel(parseInt(channelID!));
     tags={tags}
     sortBy={sortBy}
     sortOrder={sortOrder}
+    compact={dbUser?.compactMode ?? false}
   />
 </Layout>

--- a/src/pages/dashboard/[projectID]/feed.astro
+++ b/src/pages/dashboard/[projectID]/feed.astro
@@ -1,8 +1,11 @@
 ---
 import Layout from "@/layouts/layout.astro";
 import EventFeed from "@/components/event-feed";
+import { getUserByUsername } from "@/lib/beaver/user";
 
 const { projectID } = Astro.params;
+const user = Astro.locals.user!;
+const dbUser = await getUserByUsername(user.userName);
 
 const url = new URL(Astro.request.url);
 const searchParams = url.searchParams;
@@ -31,5 +34,6 @@ const sortOrder = searchParams.get("sortOrder");
     tags={tags}
     sortBy={sortBy}
     sortOrder={sortOrder}
+    compact={dbUser?.compactMode ?? false}
   />
 </Layout>


### PR DESCRIPTION
## Summary

- New \`compact_mode\` boolean column on \`users\` (migration \`0020_yielding_nightcrawler\`)
- Toggle in Account Settings → Preferences; persisted via \`PATCH /api/users/me\`
- When enabled, event cards render in a denser layout (reduced padding, smaller reactions, tighter metadata)
- Applies across the feed, channel view, and bookmarks

## Migration note

Adds \`0020_yielding_nightcrawler.sql\` cleanly after \`v2.1.0\`'s existing \`0018_mushy_silk_fever\` and \`0019_striped_hex\` migrations.

Closes #134