### PR TITLE
feat: better animations

### DIFF
--- a/src/components/channel-groups-dnd.tsx
+++ b/src/components/channel-groups-dnd.tsx
@@ -20,6 +20,7 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { ChevronDownIcon, ChevronRightIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
+import { motion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
 import { Input } from "./ui/input";
 import {
@@ -81,9 +82,15 @@ function SortableChannel({
       >
         <span className="truncate"># {channel.name}</span>
         {unreadCount > 0 && !isActive && (
-          <span className="ml-2 shrink-0 text-xs font-semibold bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center leading-tight">
+          <motion.span
+            key={unreadCount}
+            initial={{ scale: 0.4, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            transition={{ type: "spring", stiffness: 600, damping: 22 }}
+            className="ml-2 shrink-0 text-xs font-semibold bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center leading-tight"
+          >
             {unreadCount > 99 ? "99+" : unreadCount}
-          </span>
+          </motion.span>
         )}
       </a>
     </div>

--- a/src/components/create-channel-view.tsx
+++ b/src/components/create-channel-view.tsx
@@ -5,6 +5,7 @@ import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Textarea } from "./ui/textarea";
 import { useState } from "react";
+import { navigate } from "astro:transitions/client";
 
 interface CreateChannelViewProps {
   projectId: number;
@@ -39,7 +40,8 @@ function CreateChannelView({ projectId }: CreateChannelViewProps) {
         return;
       }
 
-      window.location.href = `/dashboard/${projectId}/channels/${data.id}`;
+      window.dispatchEvent(new CustomEvent("channel:created", { detail: { channel: data } }));
+      navigate(`/dashboard/${projectId}/channels/${data.id}`);
     } catch {
       setError("An error occurred. Please try again.");
     } finally {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all duration-150 active:scale-[0.97] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -9,7 +9,7 @@ import {
   getProjectsForUser,
   getUserProjectRole,
 } from "@/lib/beaver/project-member";
-import { ClientRouter } from "astro:transitions";
+import { ClientRouter, fade } from "astro:transitions";
 
 interface Props {
   projectID: string;
@@ -76,7 +76,7 @@ const userRole = user.isAdmin
         isAdmin={user.isAdmin}
         canCreateProjects={user.canCreateProjects}
       />
-      <div class="flex-1 min-w-0">
+      <div class="flex-1 min-w-0" transition:animate={fade({ duration: "0.18s" })}>
         <slot />
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds subtle, tasteful motion to three areas called out in the issue to make the app feel more alive.

### 1. Button interaction
- All buttons now scale down slightly on press (`active:scale-[0.97]`) with a 150ms transition, giving tactile press feedback. Applied at the base `buttonVariants` level so every button benefits.

### 2. Page transitions
- The main content region now fades during client-side navigation via Astro's `transition:animate={fade(...)}` (180ms).
- **Create channel** previously did a hard `window.location.href` reload on submit, which bypassed the router entirely. Switched to client-side `navigate()` so the fade applies, and dispatched `channel:created` so the persisted sidebar picks up the new channel without a full reload.

### 3. Channel unread count increments
- The unread badge is now a `motion.span` that springs in (scale + fade) each time the count changes, keyed on the count value — so increments visibly pop.

## Changed files
- `src/components/ui/button.tsx` — press-scale on base variants
- `src/layouts/layout.astro` — `fade` transition on main content slot
- `src/components/create-channel-view.tsx` — `navigate()` + `channel:created` dispatch instead of hard reload
- `src/components/channel-groups-dnd.tsx` — animated unread badge via framer-motion

## Test plan
- [ ] Press any button — confirm subtle scale-down feedback
- [ ] Navigate between dashboard pages — confirm content fades in
- [ ] Click "create channel", submit — confirm smooth transition to the new channel and that it appears in the sidebar without a full reload
- [ ] Trigger a new event in a non-active channel — confirm the unread badge pops as it increments

Closes #127