### PR TITLE
fix: enforce project authorization across all project-scoped routes (broken access control)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaver",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "type": "module",
   "scripts": {
     "format": "bun oxfmt",

--- a/src/lib/beaver/authz.ts
+++ b/src/lib/beaver/authz.ts
@@ -1,0 +1,64 @@
+import { db } from "../db/db";
+import { channels, channelGroups, metrics } from "../db/schema";
+import { eq } from "drizzle-orm";
+import { getUserProjectRole, type Role } from "./project-member";
+
+export type AuthUser = { id: number; isAdmin: boolean };
+
+/** Resolve a user's role on a project. Admins implicitly act as owner. */
+export async function getProjectRole(user: AuthUser, projectId: number): Promise<Role | null> {
+  if (user.isAdmin) return "owner";
+  return getUserProjectRole(projectId, user.id);
+}
+
+/** True if the user is a member of (or admin over) the project. */
+export async function canAccessProject(user: AuthUser, projectId: number): Promise<boolean> {
+  return (await getProjectRole(user, projectId)) !== null;
+}
+
+/** True if the user can mutate the project (owner or maintainer, or admin). */
+export async function canManageProject(user: AuthUser, projectId: number): Promise<boolean> {
+  const role = await getProjectRole(user, projectId);
+  return role === "owner" || role === "maintainer";
+}
+
+export async function projectIdForChannel(channelId: number): Promise<number | null> {
+  const [row] = await db
+    .select({ projectId: channels.projectId })
+    .from(channels)
+    .where(eq(channels.id, channelId))
+    .limit(1);
+  return row?.projectId ?? null;
+}
+
+export async function projectIdForChannelGroup(groupId: number): Promise<number | null> {
+  const [row] = await db
+    .select({ projectId: channelGroups.projectId })
+    .from(channelGroups)
+    .where(eq(channelGroups.id, groupId))
+    .limit(1);
+  return row?.projectId ?? null;
+}
+
+export async function projectIdForMetric(metricId: number): Promise<number | null> {
+  const [row] = await db
+    .select({ projectId: metrics.projectId })
+    .from(metrics)
+    .where(eq(metrics.id, metricId))
+    .limit(1);
+  return row?.projectId ?? null;
+}
+
+export function forbidden(): Response {
+  return new Response(JSON.stringify({ error: "Forbidden" }), {
+    status: 403,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export function unauthorized(): Response {
+  return new Response(JSON.stringify({ error: "Unauthorized" }), {
+    status: 401,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,7 @@ import { defineMiddleware } from "astro:middleware";
 import { getAdminUsers } from "./lib/beaver/user";
 import { verifyToken } from "./lib/auth/jwt";
 import { getSessionByToken } from "./lib/auth/session";
-import { getProjectsForUser } from "./lib/beaver/project-member";
+import { getProjectsForUser, getUserProjectRole } from "./lib/beaver/project-member";
 import { logRequest, logError } from "./lib/logger";
 
 // Routes that don't require authentication
@@ -16,6 +16,23 @@ const AUTH_REDIRECT_ROUTES = ["/login", "/onboarding"];
 
 // Route for forced password change
 const CHANGE_PASSWORD_ROUTE = "/change-password";
+
+// Pull the project id out of a path that is scoped to a single project, so the
+// middleware can verify membership before the request reaches the page/handler.
+// Covers dashboard pages (/dashboard/{id}/...) and project-scoped API routes
+// (/api/.../project/{id}/...). Routes that carry the project id in the body or
+// query (e.g. /api/project, /api/project-members) authorize themselves.
+function extractProjectId(pathname: string): number | null {
+  const dashboard = pathname.match(/^\/dashboard\/(\d+)(?:\/|$)/);
+  if (dashboard) return parseInt(dashboard[1]);
+
+  if (pathname.startsWith("/api/")) {
+    const api = pathname.match(/\/project\/(\d+)(?:\/|$)/);
+    if (api) return parseInt(api[1]);
+  }
+
+  return null;
+}
 
 function isPublicRoute(pathname: string): boolean {
   // Check exact public routes
@@ -148,6 +165,25 @@ export const onRequest = defineMiddleware(async (context, next) => {
     pathname !== CHANGE_PASSWORD_ROUTE
   ) {
     return context.redirect(CHANGE_PASSWORD_ROUTE);
+  }
+
+  // Project-level authorization. Authentication alone is not enough: a user may
+  // only access a project they belong to. Admins may access any project. This
+  // is enforced centrally here so every project-scoped page and API route is
+  // covered, rather than relying on each handler to remember to check.
+  const projectId = extractProjectId(pathname);
+  if (projectId !== null && !payload.isAdmin) {
+    const role = await getUserProjectRole(projectId, payload.userId);
+    if (role === null) {
+      if (isApi) {
+        return new Response(JSON.stringify({ error: "Forbidden" }), {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Send non-members back to a project they can actually see.
+      return context.redirect((await getAuthedRedirect(context)) ?? "/login");
+    }
   }
 
   if (isApi) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { getAdminUsers } from "./lib/beaver/user";
 import { verifyToken } from "./lib/auth/jwt";
 import { getSessionByToken } from "./lib/auth/session";
 import { getProjectsForUser, getUserProjectRole } from "./lib/beaver/project-member";
+import { projectIdForChannel, projectIdForMetric } from "./lib/beaver/authz";
 import { logRequest, logError } from "./lib/logger";
 
 // Routes that don't require authentication
@@ -17,19 +18,29 @@ const AUTH_REDIRECT_ROUTES = ["/login", "/onboarding"];
 // Route for forced password change
 const CHANGE_PASSWORD_ROUTE = "/change-password";
 
-// Pull the project id out of a path that is scoped to a single project, so the
-// middleware can verify membership before the request reaches the page/handler.
-// Covers dashboard pages (/dashboard/{id}/...) and project-scoped API routes
-// (/api/.../project/{id}/...). Routes that carry the project id in the body or
-// query (e.g. /api/project, /api/project-members) authorize themselves.
-function extractProjectId(pathname: string): number | null {
+// Resolve the project a request is scoped to from its path, so the middleware
+// can verify membership before the request reaches the page/handler. Covers:
+//   - dashboard pages          /dashboard/{id}/...
+//   - project-scoped APIs       /api/.../project/{id}/...
+//   - channel-scoped APIs       /api/.../channel/{id}/...   (channel → project)
+//   - metric value APIs         /api/metrics/{id}/...       (metric  → project)
+// Returns null when the path is not project-scoped (those routes carry the id
+// in the body/query and authorize themselves). Channel/metric ids that don't
+// resolve return null and fall through to the handler's own 404.
+async function resolveProjectId(pathname: string): Promise<number | null> {
   const dashboard = pathname.match(/^\/dashboard\/(\d+)(?:\/|$)/);
   if (dashboard) return parseInt(dashboard[1]);
 
-  if (pathname.startsWith("/api/")) {
-    const api = pathname.match(/\/project\/(\d+)(?:\/|$)/);
-    if (api) return parseInt(api[1]);
-  }
+  if (!pathname.startsWith("/api/")) return null;
+
+  const project = pathname.match(/\/project\/(\d+)(?:\/|$)/);
+  if (project) return parseInt(project[1]);
+
+  const channel = pathname.match(/\/channel\/(\d+)(?:\/|$)/);
+  if (channel) return projectIdForChannel(parseInt(channel[1]));
+
+  const metric = pathname.match(/^\/api\/metrics\/(\d+)(?:\/|$)/);
+  if (metric) return projectIdForMetric(parseInt(metric[1]));
 
   return null;
 }
@@ -171,10 +182,9 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // only access a project they belong to. Admins may access any project. This
   // is enforced centrally here so every project-scoped page and API route is
   // covered, rather than relying on each handler to remember to check.
-  const projectId = extractProjectId(pathname);
-  if (projectId !== null && !payload.isAdmin) {
-    const role = await getUserProjectRole(projectId, payload.userId);
-    if (role === null) {
+  if (!payload.isAdmin) {
+    const projectId = await resolveProjectId(pathname);
+    if (projectId !== null && (await getUserProjectRole(projectId, payload.userId)) === null) {
       if (isApi) {
         return new Response(JSON.stringify({ error: "Forbidden" }), {
           status: 403,

--- a/src/pages/api/channel-group.ts
+++ b/src/pages/api/channel-group.ts
@@ -5,9 +5,17 @@ import {
   renameChannelGroup,
   reorderGroups,
 } from "@/lib/beaver/channel-group";
+import {
+  canAccessProject,
+  canManageProject,
+  forbidden,
+  projectIdForChannelGroup,
+  unauthorized,
+} from "@/lib/beaver/authz";
 import type { APIContext, APIRoute } from "astro";
 
-export const GET: APIRoute = async ({ request }: APIContext) => {
+export const GET: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const url = new URL(request.url);
     const project_id = url.searchParams.get("project_id");
@@ -18,6 +26,8 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    if (!(await canAccessProject(locals.user, parseInt(project_id)))) return forbidden();
 
     const groups = await getChannelGroups(parseInt(project_id));
 
@@ -39,7 +49,8 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { name, project_id } = await request.json();
 
@@ -49,6 +60,8 @@ export const POST: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    if (!(await canManageProject(locals.user, parseInt(project_id)))) return forbidden();
 
     const group = await createChannelGroup(name, parseInt(project_id));
 
@@ -71,7 +84,8 @@ export const POST: APIRoute = async ({ request }) => {
 };
 
 // Reorder groups
-export const PATCH: APIRoute = async ({ request }) => {
+export const PATCH: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { groups } = await request.json();
 
@@ -80,6 +94,17 @@ export const PATCH: APIRoute = async ({ request }) => {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    // Every group referenced must belong to a project the user can manage.
+    const projectIds = new Set<number>();
+    for (const item of groups) {
+      const pid = await projectIdForChannelGroup(parseInt(item.id));
+      if (pid === null) return forbidden();
+      projectIds.add(pid);
+    }
+    for (const pid of projectIds) {
+      if (!(await canManageProject(locals.user, pid))) return forbidden();
     }
 
     await reorderGroups(groups);
@@ -103,7 +128,8 @@ export const PATCH: APIRoute = async ({ request }) => {
 };
 
 // Rename group
-export const PUT: APIRoute = async ({ request }) => {
+export const PUT: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { id, name } = await request.json();
 
@@ -113,6 +139,10 @@ export const PUT: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    const projectId = await projectIdForChannelGroup(parseInt(id));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     await renameChannelGroup(parseInt(id), name);
 
@@ -134,7 +164,8 @@ export const PUT: APIRoute = async ({ request }) => {
   }
 };
 
-export const DELETE: APIRoute = async ({ request }) => {
+export const DELETE: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { id } = await request.json();
 
@@ -144,6 +175,10 @@ export const DELETE: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    const projectId = await projectIdForChannelGroup(parseInt(id));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     await deleteChannelGroup(parseInt(id));
 

--- a/src/pages/api/channel.ts
+++ b/src/pages/api/channel.ts
@@ -5,9 +5,17 @@ import {
   reorderChannels,
   updateChannel,
 } from "@/lib/beaver/channel";
+import {
+  canAccessProject,
+  canManageProject,
+  forbidden,
+  projectIdForChannel,
+  unauthorized,
+} from "@/lib/beaver/authz";
 import type { APIContext, APIRoute } from "astro";
 
-export const GET: APIRoute = async ({ request }: APIContext) => {
+export const GET: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const url = new URL(request.url);
 
@@ -19,6 +27,8 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    if (!(await canAccessProject(locals.user, parseInt(project_id)))) return forbidden();
 
     const projects = await getChannels(parseInt(project_id));
 
@@ -41,7 +51,8 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { name, project_id, description } = await request.json();
 
@@ -51,6 +62,8 @@ export const POST: APIRoute = async ({ request }) => {
     if (!project_id) {
       return new Response(JSON.stringify({ error: "project_id is required to create channel." }));
     }
+
+    if (!(await canManageProject(locals.user, parseInt(project_id)))) return forbidden();
 
     const splitName = name.replace(" ", "-");
 
@@ -77,7 +90,8 @@ export const POST: APIRoute = async ({ request }) => {
   }
 };
 
-export const PATCH: APIRoute = async ({ request }) => {
+export const PATCH: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { channels } = await request.json();
 
@@ -86,6 +100,17 @@ export const PATCH: APIRoute = async ({ request }) => {
         status: 400,
         headers: { "Content-Type": "application/json" },
       });
+    }
+
+    // Every channel referenced must belong to a project the user can manage.
+    const projectIds = new Set<number>();
+    for (const item of channels) {
+      const pid = await projectIdForChannel(parseInt(item.id));
+      if (pid === null) return forbidden();
+      projectIds.add(pid);
+    }
+    for (const pid of projectIds) {
+      if (!(await canManageProject(locals.user, pid))) return forbidden();
     }
 
     await reorderChannels(channels);
@@ -109,7 +134,8 @@ export const PATCH: APIRoute = async ({ request }) => {
   }
 };
 
-export const PUT: APIRoute = async ({ request }) => {
+export const PUT: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { channelId, name, description } = await request.json();
 
@@ -119,6 +145,10 @@ export const PUT: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    const projectId = await projectIdForChannel(parseInt(channelId));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     const channel = await updateChannel(parseInt(channelId), { name, description });
 
@@ -141,7 +171,8 @@ export const PUT: APIRoute = async ({ request }) => {
   }
 };
 
-export const DELETE: APIRoute = async ({ request }) => {
+export const DELETE: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { channelID } = await request.json();
 
@@ -151,6 +182,10 @@ export const DELETE: APIRoute = async ({ request }) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    const projectId = await projectIdForChannel(parseInt(channelID));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     const channel = await deleteChannel(parseInt(channelID));
 

--- a/src/pages/api/channel/coalesce.ts
+++ b/src/pages/api/channel/coalesce.ts
@@ -1,4 +1,5 @@
 import { coalesceChannels } from "@/lib/beaver/channel";
+import { canManageProject, forbidden, projectIdForChannel } from "@/lib/beaver/authz";
 import type { APIContext, APIRoute } from "astro";
 
 export const POST: APIRoute = async ({ request, locals }: APIContext) => {
@@ -25,6 +26,14 @@ export const POST: APIRoute = async ({ request, locals }: APIContext) => {
         headers: { "Content-Type": "application/json" },
       });
     }
+
+    // Both channels must live in the same project, and the user must manage it.
+    const sourceProject = await projectIdForChannel(parseInt(sourceId));
+    const targetProject = await projectIdForChannel(parseInt(targetId));
+    if (sourceProject === null || targetProject === null || sourceProject !== targetProject) {
+      return forbidden();
+    }
+    if (!(await canManageProject(locals.user, sourceProject))) return forbidden();
 
     const channel = await coalesceChannels(sourceId, targetId, survivingName.trim());
 

--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -1,8 +1,16 @@
 import { createMetric, deleteMetric, getMetrics, updateMetric } from "@/lib/beaver/metric";
 import type { MetricType, ChartType } from "@/lib/beaver/metric";
+import {
+  canAccessProject,
+  canManageProject,
+  forbidden,
+  projectIdForMetric,
+  unauthorized,
+} from "@/lib/beaver/authz";
 import type { APIContext, APIRoute } from "astro";
 
-export const GET: APIRoute = async ({ request }: APIContext) => {
+export const GET: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const url = new URL(request.url);
     const projectId = url.searchParams.get("projectId");
@@ -11,6 +19,8 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
       return json({ error: "projectId is a required query parameter." }, 400);
     }
 
+    if (!(await canAccessProject(locals.user, parseInt(projectId)))) return forbidden();
+
     const metrics = await getMetrics(parseInt(projectId));
     return json(metrics);
   } catch (err) {
@@ -18,13 +28,16 @@ export const GET: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const POST: APIRoute = async ({ request }: APIContext) => {
+export const POST: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { projectId, name, description, unit, type, chartType } = await request.json();
 
     if (!projectId) return json({ error: "projectId is required." }, 400);
     if (!name) return json({ error: "name is required." }, 400);
     if (!type) return json({ error: "type is required." }, 400);
+
+    if (!(await canManageProject(locals.user, parseInt(projectId)))) return forbidden();
 
     const validTypes: MetricType[] = ["gauge", "counter", "timeseries"];
     if (!validTypes.includes(type)) {
@@ -52,11 +65,16 @@ export const POST: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const PUT: APIRoute = async ({ request }: APIContext) => {
+export const PUT: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { metricId, name, description, unit } = await request.json();
 
     if (!metricId) return json({ error: "metricId is required." }, 400);
+
+    const projectId = await projectIdForMetric(parseInt(metricId));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     const metric = await updateMetric(parseInt(metricId), {
       name: name ? name.trim().toLowerCase().replace(/\s+/g, "-") : undefined,
@@ -70,11 +88,16 @@ export const PUT: APIRoute = async ({ request }: APIContext) => {
   }
 };
 
-export const DELETE: APIRoute = async ({ request }: APIContext) => {
+export const DELETE: APIRoute = async ({ request, locals }: APIContext) => {
+  if (!locals.user) return unauthorized();
   try {
     const { metricId } = await request.json();
 
     if (!metricId) return json({ error: "metricId is required." }, 400);
+
+    const projectId = await projectIdForMetric(parseInt(metricId));
+    if (projectId === null) return forbidden();
+    if (!(await canManageProject(locals.user, projectId))) return forbidden();
 
     await deleteMetric(parseInt(metricId));
     return json({ ok: true });

--- a/src/pages/api/project-members.ts
+++ b/src/pages/api/project-members.ts
@@ -31,6 +31,15 @@ export const GET: APIRoute = async (context: APIContext) => {
     });
   }
 
+  // Member management (and the full user list it returns) is owner-only.
+  const viewerRole = await getUserProjectRole(projectId, context.locals.user.id);
+  if (!canManage(viewerRole, context.locals.user.isAdmin)) {
+    return new Response(JSON.stringify({ error: "Forbidden" }), {
+      status: 403,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   try {
     const [members, allUsers] = await Promise.all([getProjectMembers(projectId), getAllUsers()]);
 


### PR DESCRIPTION
## Summary

Fully closes the broken-access-control bug in #241: any authenticated user could read — and in several cases mutate — any project's data regardless of membership. Targets `main` as a patch to the 2.0.x line (bug present v2.0.0–v2.1.0).

## What was exposed

Authentication was enforced everywhere, but **authorization (project membership) was not**:

- **Pages:** `/dashboard/{id}/*` rendered any project for any logged-in user (`layout.astro` degraded non-members to a `"guest"` role but still loaded the data).
- **Read APIs:** `/api/events/project/{id}/*`, `/api/events/channel/{channelId}/*`, `/api/tags/project|channel/{id}`, `/api/metrics/{metricId}/values` all returned cross-tenant data.
- **Mutation APIs with no auth at all:** `/api/channel`, `/api/channel-group`, `/api/metrics`, `/api/channel/coalesce` let any logged-in user create/rename/delete/reorder channels, groups, and metrics in **any** project.
- **Info leak:** `GET /api/project-members` returned a project's members **and the full user list** to any authenticated user.

## Fix

Two layers:

**1. Central enforcement in `src/middleware.ts`** — for every project-scoped *path*, resolve the owning project and require membership (admins bypass; non-members get `403` for APIs, redirect for pages):
- `/dashboard/{id}/...`
- `/api/.../project/{id}/...`
- `/api/.../channel/{id}/...` → channel resolved to its project
- `/api/metrics/{id}/...` → metric resolved to its project

**2. Per-handler authorization** for routes that carry the id in the body/query (middleware can't read those) via a new shared helper `src/lib/beaver/authz.ts` (`canAccessProject`, `canManageProject`, and `projectIdFor{Channel,ChannelGroup,Metric}`):
- `channel.ts` / `channel-group.ts` — read requires membership; create/rename/delete/reorder require owner/maintainer (reorder verifies **every** referenced id).
- `metrics.ts` — same model.
- `channel/coalesce.ts` — both channels must share a project the user manages.
- `project-members.ts` GET — now owner-only (matches the existing owner-only mutations on that route).

`project.ts` and the `project-members.ts` mutations were already owner-gated and are unchanged.

## Authorization model

- **Read** (view a project's data): membership (any role).
- **Mutate** (channels/groups/metrics): owner or maintainer — matches the existing `canEdit` model the UI already uses.
- **Admins**: full access, unchanged.

## Version

Patch bump 2.0.2 → 2.0.3.

## Test plan

As a user who is **not** a member of project 1:
- [ ] `/dashboard/1/feed` → redirected away
- [ ] `GET /api/events/project/1`, `GET /api/events/channel/{a channel in project 1}` → `403`
- [ ] `GET /api/metrics/{metric in project 1}/values` → `403`
- [ ] `POST/PUT/DELETE /api/channel`, `/api/channel-group`, `/api/metrics` targeting project 1's resources → `403`
- [ ] `POST /api/channel/coalesce` on project 1's channels → `403`
- [ ] `GET /api/project-members?projectId=1` → `403`

Regression (member/owner of project 1):
- [ ] Feed, channels, metrics all load and behave normally
- [ ] Create/rename/delete/reorder channels and groups still works for owner/maintainer
- [ ] Admin retains access to all projects

Closes #241