### PR TITLE
feat: better dark mode + theme palettes

### DIFF
--- a/drizzle/0023_theme_palette.sql
+++ b/drizzle/0023_theme_palette.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `theme_palette` text DEFAULT 'default' NOT NULL;

--- a/drizzle/meta/0023_snapshot.json
+++ b/drizzle/meta/0023_snapshot.json
@@ -1,0 +1,1505 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "924b330c-34ab-4796-874d-1461982bf199",
+  "prevId": "74d495ae-f87a-4083-96c4-9501609f8309",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_reactions": {
+      "name": "event_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_reactions_event_user_emoji_idx": {
+          "name": "event_reactions_event_user_emoji_idx",
+          "columns": ["event_id", "user_id", "emoji"],
+          "isUnique": true
+        },
+        "event_reactions_event_id_idx": {
+          "name": "event_reactions_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_reactions_event_id_events_id_fk": {
+          "name": "event_reactions_event_id_events_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reactions_user_id_users_id_fk": {
+          "name": "event_reactions_user_id_users_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_per_minute": {
+          "name": "rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compact_mode": {
+          "name": "compact_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "theme_palette": {
+          "name": "theme_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_views": {
+      "name": "saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_views_project_id_projects_id_fk": {
+          "name": "saved_views_project_id_projects_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_views_user_id_users_id_fk": {
+          "name": "saved_views_user_id_users_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_comments": {
+      "name": "event_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_comments_event_id_events_id_fk": {
+          "name": "event_comments_event_id_events_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_comments_user_id_users_id_fk": {
+          "name": "event_comments_user_id_users_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1782000000000,
       "tag": "0022_event_comments",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1782100000000,
+      "tag": "0023_theme_palette",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/account-settings.tsx
+++ b/src/components/account-settings.tsx
@@ -1,17 +1,28 @@
 import { useState } from "react";
+import { CheckIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Switch } from "./ui/switch";
 import ChangePasswordForm from "./change-password-form";
 
+const PALETTES: { id: string; label: string; swatch: string }[] = [
+  { id: "default", label: "Default", swatch: "oklch(0.45 0 0)" },
+  { id: "blue", label: "Ocean", swatch: "oklch(0.55 0.17 255)" },
+  { id: "violet", label: "Violet", swatch: "oklch(0.53 0.21 290)" },
+  { id: "green", label: "Forest", swatch: "oklch(0.55 0.13 155)" },
+  { id: "rose", label: "Rose", swatch: "oklch(0.58 0.2 18)" },
+];
+
 export default function AccountSettings({
   initialFullName,
   initialCompactMode,
+  initialThemePalette,
   username,
 }: {
   initialFullName: string | null;
   initialCompactMode: boolean;
+  initialThemePalette: string;
   username: string;
 }) {
   const [fullName, setFullName] = useState(initialFullName ?? "");
@@ -20,6 +31,8 @@ export default function AccountSettings({
   const [error, setError] = useState<string | null>(null);
   const [compactMode, setCompactMode] = useState(initialCompactMode);
   const [compactError, setCompactError] = useState<string | null>(null);
+  const [themePalette, setThemePalette] = useState(initialThemePalette);
+  const [paletteError, setPaletteError] = useState<string | null>(null);
 
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -66,6 +79,31 @@ export default function AccountSettings({
     }
   };
 
+  const handlePaletteChange = async (next: string) => {
+    const previous = themePalette;
+    setThemePalette(next);
+    setPaletteError(null);
+    // Apply immediately for instant feedback; persisted server-side below.
+    document.documentElement.dataset.theme = next;
+    try {
+      const res = await fetch("/api/users/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ themePalette: next }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setThemePalette(previous);
+        document.documentElement.dataset.theme = previous;
+        setPaletteError(data.error || "Failed to save.");
+      }
+    } catch {
+      setThemePalette(previous);
+      document.documentElement.dataset.theme = previous;
+      setPaletteError("Failed to save.");
+    }
+  };
+
   const row = "flex flex-col sm:flex-row sm:items-center w-full sm:justify-between gap-2";
   const label = "font-medium shrink-0";
 
@@ -99,6 +137,41 @@ export default function AccountSettings({
 
       <div className="flex flex-col space-y-4">
         <h2 className="font-mono">Preferences</h2>
+
+        <div className="flex flex-col gap-3">
+          <div>
+            <p className={label}>Theme palette</p>
+            <p className="text-sm text-muted-foreground">
+              Accent color used across buttons, links, and charts.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-3">
+            {PALETTES.map((p) => {
+              const selected = themePalette === p.id;
+              return (
+                <button
+                  key={p.id}
+                  type="button"
+                  onClick={() => handlePaletteChange(p.id)}
+                  aria-pressed={selected}
+                  className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm transition-colors ${
+                    selected ? "border-foreground" : "border-border hover:bg-accent"
+                  }`}
+                >
+                  <span
+                    className="flex size-5 items-center justify-center rounded-full"
+                    style={{ backgroundColor: p.swatch }}
+                  >
+                    {selected && <CheckIcon className="size-3 text-white" />}
+                  </span>
+                  {p.label}
+                </button>
+              );
+            })}
+          </div>
+          {paletteError && <p className="text-sm text-destructive">{paletteError}</p>}
+        </div>
+
         <div className={row}>
           <div>
             <p className={label}>Compact UI mode</p>

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -9,6 +9,7 @@ import {
   getProjectsForUser,
   getUserProjectRole,
 } from "@/lib/beaver/project-member";
+import { getUserByUsername } from "@/lib/beaver/user";
 import { ClientRouter, fade } from "astro:transitions";
 
 interface Props {
@@ -30,9 +31,12 @@ const channelGroupsData = await getChannelGroups(project.id);
 const userRole = user.isAdmin
   ? "owner"
   : await getUserProjectRole(project.id, user.id);
+
+const dbUser = await getUserByUsername(user.userName);
+const themePalette = dbUser?.themePalette ?? "default";
 ---
 
-<html lang="en">
+<html lang="en" data-theme={themePalette}>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />

--- a/src/lib/beaver/user.ts
+++ b/src/lib/beaver/user.ts
@@ -13,6 +13,7 @@ export type DatabaseUser = {
   mustChangePassword: boolean;
   tempPassword: string | null;
   compactMode: boolean;
+  themePalette: string;
   createdAt: Date | null;
 };
 
@@ -26,6 +27,7 @@ export type User = {
   mustChangePassword: boolean;
   tempPassword: string | null;
   compactMode: boolean;
+  themePalette: string;
   createdAt: Date | null;
 };
 
@@ -39,6 +41,7 @@ const userSelect = {
   mustChangePassword: users.mustChangePassword,
   tempPassword: users.tempPassword,
   compactMode: users.compactMode,
+  themePalette: users.themePalette,
   createdAt: users.createdAt,
 };
 
@@ -184,4 +187,14 @@ export async function updateUserFullName(id: number, fullName: string | null): P
 
 export async function updateUserCompactMode(id: number, compactMode: boolean): Promise<void> {
   await db.update(users).set({ compactMode }).where(eq(users.id, id));
+}
+
+export const THEME_PALETTES = ["default", "blue", "violet", "green", "rose"] as const;
+export type ThemePalette = (typeof THEME_PALETTES)[number];
+
+export async function updateUserThemePalette(id: number, themePalette: string): Promise<void> {
+  const palette = (THEME_PALETTES as readonly string[]).includes(themePalette)
+    ? themePalette
+    : "default";
+  await db.update(users).set({ themePalette: palette }).where(eq(users.id, id));
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -141,6 +141,7 @@ export const users = sqliteTable("users", {
   mustChangePassword: integer("must_change_password", { mode: "boolean" }).notNull().default(false),
   tempPassword: text("temp_password"),
   compactMode: integer("compact_mode", { mode: "boolean" }).notNull().default(false),
+  themePalette: text("theme_palette").notNull().default("default"),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),

--- a/src/pages/api/users/me.ts
+++ b/src/pages/api/users/me.ts
@@ -1,4 +1,9 @@
-import { updateUserCompactMode, updateUserEmail, updateUserFullName } from "@/lib/beaver/user";
+import {
+  updateUserCompactMode,
+  updateUserEmail,
+  updateUserFullName,
+  updateUserThemePalette,
+} from "@/lib/beaver/user";
 import type { APIContext } from "astro";
 
 export async function PATCH({ locals, request }: APIContext) {
@@ -19,6 +24,9 @@ export async function PATCH({ locals, request }: APIContext) {
   }
   if ("compactMode" in body) {
     await updateUserCompactMode(user.id, !!body.compactMode);
+  }
+  if ("themePalette" in body) {
+    await updateUserThemePalette(user.id, String(body.themePalette));
   }
 
   return new Response(JSON.stringify({ ok: true }), {

--- a/src/pages/dashboard/[projectID]/account.astro
+++ b/src/pages/dashboard/[projectID]/account.astro
@@ -32,6 +32,7 @@ const dbUser = await getUserByUsername(user.userName);
           client:load
           initialFullName={dbUser?.fullName ?? null}
           initialCompactMode={dbUser?.compactMode ?? false}
+          initialThemePalette={dbUser?.themePalette ?? "default"}
           username={user.userName}
         />
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,37 +77,111 @@
 }
 
 .dark {
-  --background: oklch(0.32 0 0);
-  --foreground: oklch(0.88 0 0);
-  --card: oklch(0.37 0 0);
-  --card-foreground: oklch(0.88 0 0);
-  --popover: oklch(0.37 0 0);
-  --popover-foreground: oklch(0.88 0 0);
-  --primary: oklch(0.82 0 0);
-  --primary-foreground: oklch(0.32 0 0);
-  --secondary: oklch(0.42 0 0);
-  --secondary-foreground: oklch(0.88 0 0);
-  --muted: oklch(0.42 0 0);
-  --muted-foreground: oklch(0.65 0 0);
-  --accent: oklch(0.42 0 0);
-  --accent-foreground: oklch(0.88 0 0);
-  --destructive: oklch(0.65 0.18 22.216);
-  --border: oklch(0.48 0 0);
-  --input: oklch(0.48 0 0);
-  --ring: oklch(0.55 0 0);
+  --background: oklch(0.205 0.005 285);
+  --foreground: oklch(0.92 0.004 285);
+  --card: oklch(0.245 0.006 285);
+  --card-foreground: oklch(0.92 0.004 285);
+  --popover: oklch(0.245 0.006 285);
+  --popover-foreground: oklch(0.92 0.004 285);
+  --primary: oklch(0.92 0.004 285);
+  --primary-foreground: oklch(0.235 0.006 285);
+  --secondary: oklch(0.27 0.006 285);
+  --secondary-foreground: oklch(0.92 0.004 285);
+  --muted: oklch(0.27 0.006 285);
+  --muted-foreground: oklch(0.705 0.015 285);
+  --accent: oklch(0.3 0.007 285);
+  --accent-foreground: oklch(0.92 0.004 285);
+  --destructive: oklch(0.65 0.19 22.216);
+  --border: oklch(0.31 0.006 285);
+  --input: oklch(0.31 0.006 285);
+  --ring: oklch(0.5 0.01 285);
   --chart-1: oklch(0.488 0.243 264.376);
   --chart-2: oklch(0.696 0.17 162.48);
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.37 0 0);
-  --sidebar-foreground: oklch(0.88 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.88 0 0);
-  --sidebar-accent: oklch(0.42 0 0);
-  --sidebar-accent-foreground: oklch(0.88 0 0);
-  --sidebar-border: oklch(0.48 0 0);
-  --sidebar-ring: oklch(0.55 0 0);
+  --sidebar: oklch(0.19 0.005 285);
+  --sidebar-foreground: oklch(0.92 0.004 285);
+  --sidebar-primary: oklch(0.92 0.004 285);
+  --sidebar-primary-foreground: oklch(0.235 0.006 285);
+  --sidebar-accent: oklch(0.27 0.006 285);
+  --sidebar-accent-foreground: oklch(0.92 0.004 285);
+  --sidebar-border: oklch(0.3 0.006 285);
+  --sidebar-ring: oklch(0.5 0.01 285);
+}
+
+/* ── Theme palettes ───────────────────────────────────────────────────────────
+   Presets only shift the accent identity (primary / ring / focus / chart-1);
+   neutrals come from :root (light) and .dark (dark). Each palette has a light
+   block ([data-theme="x"]) and a dark block ([data-theme="x"].dark); the dark
+   block's higher specificity guarantees it wins when .dark is also present. */
+
+[data-theme="blue"] {
+  --primary: oklch(0.55 0.17 255);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.55 0.17 255);
+  --sidebar-primary: oklch(0.55 0.17 255);
+  --sidebar-ring: oklch(0.55 0.17 255);
+  --chart-1: oklch(0.55 0.17 255);
+}
+[data-theme="blue"].dark {
+  --primary: oklch(0.62 0.16 255);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.62 0.16 255);
+  --sidebar-primary: oklch(0.62 0.16 255);
+  --sidebar-ring: oklch(0.62 0.16 255);
+  --chart-1: oklch(0.62 0.16 255);
+}
+
+[data-theme="violet"] {
+  --primary: oklch(0.53 0.21 290);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.53 0.21 290);
+  --sidebar-primary: oklch(0.53 0.21 290);
+  --sidebar-ring: oklch(0.53 0.21 290);
+  --chart-1: oklch(0.53 0.21 290);
+}
+[data-theme="violet"].dark {
+  --primary: oklch(0.62 0.19 290);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.62 0.19 290);
+  --sidebar-primary: oklch(0.62 0.19 290);
+  --sidebar-ring: oklch(0.62 0.19 290);
+  --chart-1: oklch(0.62 0.19 290);
+}
+
+[data-theme="green"] {
+  --primary: oklch(0.55 0.13 155);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.55 0.13 155);
+  --sidebar-primary: oklch(0.55 0.13 155);
+  --sidebar-ring: oklch(0.55 0.13 155);
+  --chart-1: oklch(0.55 0.13 155);
+}
+[data-theme="green"].dark {
+  --primary: oklch(0.62 0.14 155);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.62 0.14 155);
+  --sidebar-primary: oklch(0.62 0.14 155);
+  --sidebar-ring: oklch(0.62 0.14 155);
+  --chart-1: oklch(0.62 0.14 155);
+}
+
+[data-theme="rose"] {
+  --primary: oklch(0.58 0.2 18);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.58 0.2 18);
+  --sidebar-primary: oklch(0.58 0.2 18);
+  --sidebar-ring: oklch(0.58 0.2 18);
+  --chart-1: oklch(0.58 0.2 18);
+}
+[data-theme="rose"].dark {
+  --primary: oklch(0.64 0.19 18);
+  --primary-foreground: oklch(0.985 0 0);
+  --ring: oklch(0.64 0.19 18);
+  --sidebar-primary: oklch(0.64 0.19 18);
+  --sidebar-ring: oklch(0.64 0.19 18);
+  --chart-1: oklch(0.64 0.19 18);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Addresses #133 — refreshes the dark mode palette and adds selectable accent **theme palettes**, persisted per-user in the backend and chosen from account settings.

## Changes

### Refreshed dark mode
Replaced the flat medium-gray dark palette with a deeper, more modern neutral that has a subtle cool tint (oklch hue ~285). Backgrounds are darker with proper elevation between surface levels (background → sidebar → card), softer borders, and better-contrast muted text.

### Theme palettes
Five presets: **Default** (neutral), **Ocean** (blue), **Violet**, **Forest** (green), and **Rose**. Each preset only shifts the accent identity — `--primary`, `--ring`, `--sidebar-primary`, and `--chart-1` — so the refined neutrals are shared. Light and dark variants are defined for each; the dark block's higher specificity (`[data-theme="x"].dark`) guarantees it wins.

The palette is applied **server-side** as `data-theme` on `<html>` in the layout, so there's no flash of the wrong color on load. Light/dark and palette are independent axes (you can run Ocean in either light or dark).

### Persistence + settings UI
- New `theme_palette` column on `users` (migration `0023`, defaults to `default`) — mirrors the existing `compactMode` pattern.
- `PATCH /api/users/me` accepts `themePalette` (validated against the known set).
- Account settings gets a **Theme palette** picker with color swatches; selecting one applies it instantly and saves to the backend.

## Files
- `src/styles/global.css` — refreshed `.dark`, added `[data-theme]` presets
- `src/lib/db/schema.ts` + `drizzle/0023_theme_palette.sql` — `theme_palette` column
- `src/lib/beaver/user.ts` — `THEME_PALETTES`, `updateUserThemePalette`, type/select updates
- `src/pages/api/users/me.ts` — handle `themePalette`
- `src/layouts/layout.astro` — fetch palette, set `data-theme` on `<html>`
- `src/components/account-settings.tsx` — palette picker
- `src/pages/dashboard/[projectID]/account.astro` — pass `initialThemePalette`

## Test plan
- [ ] Run `bun run migrate` to apply `0023`
- [ ] Account settings → Theme palette: pick each preset, confirm accent (buttons/links/charts) updates instantly
- [ ] Reload — selection persists (no flash of default on load)
- [ ] Toggle light/dark with a non-default palette — both render correctly
- [ ] Confirm the refreshed default dark mode across feed, sidebar, cards, dialogs

> Note: palette colors are a taste call — easy to tweak the oklch values in `global.css` if any feel off in practice.

Closes #133