### PR TITLE
refactor: user-controlled channel reads

### DIFF
--- a/src/components/channel-groups-dnd.tsx
+++ b/src/components/channel-groups-dnd.tsx
@@ -81,7 +81,7 @@ function SortableChannel({
         }`}
       >
         <span className="truncate"># {channel.name}</span>
-        {unreadCount > 0 && !isActive && (
+        {unreadCount > 0 && (
           <motion.span
             key={unreadCount}
             initial={{ scale: 0.4, opacity: 0 }}

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -11,7 +11,7 @@ import {
   SmilePlusIcon,
   Trash2Icon,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
 import {
   Dialog,
@@ -93,29 +93,6 @@ export default function EventDetail({
       setConfirmDelete(false);
     }
   };
-
-  useEffect(() => {
-    fetch("/api/unread", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        channelName: event.channelName,
-        projectId: event.projectId,
-      }),
-    })
-      .then((res) => res.json())
-      .then((data) => {
-        window.dispatchEvent(
-          new CustomEvent("channel:read", {
-            detail: {
-              channelId: data.channelId,
-              channelName: event.channelName,
-            },
-          }),
-        );
-      })
-      .catch(() => {});
-  }, [event.id]);
 
   const handleBack = () => {
     if (sessionStorage.getItem("beaver:hasInAppNav") === "1") {

--- a/src/components/event-feed.tsx
+++ b/src/components/event-feed.tsx
@@ -12,7 +12,7 @@ const fetchMaxEventId = async (): Promise<number> => {
 import { useEffect, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import EventCard from "./event-card";
-import { XIcon, ArrowUpDownIcon, DownloadIcon } from "lucide-react";
+import { XIcon, ArrowUpDownIcon, DownloadIcon, CheckCheckIcon, MailIcon } from "lucide-react";
 import { Button } from "./ui/button";
 import { navigate } from "astro:transitions/client";
 import type { Channel } from "@/lib/beaver/channel";
@@ -83,6 +83,8 @@ export default function EventFeed({
   const [loadingMore, setLoadingMore] = useState(false);
   const [eventCount, setEventCount] = useState<number | null>(null);
   const [lastReadDate, setLastReadDate] = useState<Date | null>(null);
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [markingRead, setMarkingRead] = useState(false);
 
   const eventIdsRef = useRef<Set<number>>(new Set());
   const newEventIdsRef = useRef<Set<number>>(new Set());
@@ -354,28 +356,46 @@ export default function EventFeed({
       .catch(() => {});
   }, [projectID, channel, title, object, action, startDate, endDate, tags]);
 
+  // Read the channel's last-read time so we can mark which events are new — but
+  // do NOT mark the channel read on view. Reads are now controlled by the user
+  // via the "Mark as read" action, so opening a channel (or an event) no longer
+  // wipes the unread state and the user keeps their place.
   useEffect(() => {
     if (type !== "channel" || !channel) return;
 
-    fetch("/api/unread", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        channelName: channel.name,
-        projectId: channel.projectId,
-      }),
-    })
+    fetch(`/api/unread?channelId=${channel.id}`)
       .then((res) => res.json())
       .then((data) => {
-        if (data.lastReadAt) setLastReadDate(new Date(data.lastReadAt));
-        window.dispatchEvent(
-          new CustomEvent("channel:read", {
-            detail: { channelId: data.channelId, channelName: channel.name },
-          }),
-        );
+        setLastReadDate(data.lastReadAt ? new Date(data.lastReadAt) : null);
       })
       .catch(() => {});
   }, [channel?.id]);
+
+  const handleMarkAsRead = async () => {
+    if (!channel || markingRead) return;
+    setMarkingRead(true);
+    try {
+      const res = await fetch("/api/unread", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ channelName: channel.name, projectId: channel.projectId }),
+      });
+      const data = await res.json();
+      // Everything currently in the feed predates this moment, so treat now as
+      // the read boundary: the divider clears and unread filtering empties.
+      setLastReadDate(new Date());
+      setUnreadOnly(false);
+      window.dispatchEvent(
+        new CustomEvent("channel:read", {
+          detail: { channelId: data.channelId, channelName: channel.name },
+        }),
+      );
+    } catch {
+      // ignore — user can retry
+    } finally {
+      setMarkingRead(false);
+    }
+  };
 
   useEffect(() => {
     const handler = (e: CustomEvent<{ channelName: string }>) => {
@@ -408,17 +428,29 @@ export default function EventFeed({
     if (sortOrder) p.set("sortOrder", sortOrder);
     return p.toString();
   })();
-  const hasNewEvents =
-    lastReadDate != null && events.some((e) => new Date(e.createdAt) > lastReadDate);
+  const isUnread = (e: EventWithChannelName) =>
+    lastReadDate == null || new Date(e.createdAt) > lastReadDate;
+
+  // Any unread events at all (enables "Mark as read", incl. a never-read channel).
+  const hasUnread = events.some(isUnread);
+  // Unread events that sit *after* a known read point — drives the "New" divider,
+  // which only makes sense once the channel has been read at least once.
+  const hasNewEvents = lastReadDate != null && hasUnread;
+
+  // In "unread only" mode, hide events the user has already read.
+  const displayedEvents = unreadOnly ? events.filter(isUnread) : events;
 
   const rows: Row[] = [];
   let dividerRowIndex = -1;
-  for (let i = 0; i < events.length; i++) {
-    const event = events[i];
+  for (let i = 0; i < displayedEvents.length; i++) {
+    const event = displayedEvents[i];
+    // The "new" divider only makes sense in the full view; in unread-only mode
+    // every shown event is new, so it never triggers.
     const isFirstOld =
+      !unreadOnly &&
       hasNewEvents &&
       new Date(event.createdAt) <= lastReadDate! &&
-      (i === 0 || new Date(events[i - 1].createdAt) > lastReadDate!);
+      (i === 0 || new Date(displayedEvents[i - 1].createdAt) > lastReadDate!);
 
     if (isFirstOld) {
       dividerRowIndex = rows.length;
@@ -606,6 +638,30 @@ export default function EventFeed({
               canManageViews={userRole !== "guest" && userRole != null}
             />
           )}
+          {type === "channel" && channel && (
+            <>
+              <Button
+                variant={unreadOnly ? "default" : "outline"}
+                size="sm"
+                onClick={() => setUnreadOnly((v) => !v)}
+                aria-pressed={unreadOnly}
+                title="Show only unread events"
+              >
+                <MailIcon className="size-4 mr-2" />
+                Unread
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleMarkAsRead}
+                disabled={!hasUnread || markingRead}
+                title="Mark this channel as read"
+              >
+                <CheckCheckIcon className="size-4 mr-2" />
+                Mark as read
+              </Button>
+            </>
+          )}
         </div>
       </div>
 
@@ -648,6 +704,11 @@ export default function EventFeed({
             <h2 className="text-2xl">
               Looks like this {type === "project" ? "project" : "channel"} has no events!
             </h2>
+          </div>
+        ) : unreadOnly && displayedEvents.length === 0 ? (
+          <div className="w-full text-center pt-8">
+            <h2 className="text-2xl">You&rsquo;re all caught up 🎉</h2>
+            <p className="text-muted-foreground mt-2">No unread events in this channel.</p>
           </div>
         ) : (
           <div className="px-4 md:px-8 py-4 md:py-8 w-full lg:w-1/2 mx-auto">

--- a/src/components/unread-counts-poller.tsx
+++ b/src/components/unread-counts-poller.tsx
@@ -16,7 +16,6 @@ export default function UnreadCountsPoller({
 }) {
   const isLeader = useTabLeader(`unread:${projectId}`);
   const channelsRef = useRef(initialChannels);
-  const pathnameRef = useRef("");
   const countsRef = useRef<Record<number, number>>({});
 
   // Sync channels list as channels are added/removed
@@ -32,20 +31,6 @@ export default function UnreadCountsPoller({
     return () => {
       window.removeEventListener("channel:created", onCreated as EventListener);
       window.removeEventListener("channel:deleted", onDeleted as EventListener);
-    };
-  }, []);
-
-  // Track current pathname for "am I viewing this channel?" check
-  useEffect(() => {
-    pathnameRef.current = window.location.pathname;
-    const handleNav = () => {
-      pathnameRef.current = window.location.pathname;
-    };
-    document.addEventListener("astro:page-load", handleNav);
-    window.addEventListener("popstate", handleNav);
-    return () => {
-      document.removeEventListener("astro:page-load", handleNav);
-      window.removeEventListener("popstate", handleNav);
     };
   }, []);
 
@@ -65,17 +50,14 @@ export default function UnreadCountsPoller({
     let eventSource: EventSource | null = null;
     let resync: ReturnType<typeof setInterval> | null = null;
 
-    const activeChannelId = (): number | null => {
-      const m = pathnameRef.current.match(/\/channels\/(\d+)(?:$|[/?])/);
-      return m ? parseInt(m[1]) : null;
-    };
-
+    // Reads are now explicit (the user clicks "Mark as read"), so simply viewing
+    // a channel no longer suppresses its unread badge — every channel, including
+    // the one in view, counts new events until the user marks it read.
     const applyEvents = (events: EventWithChannelName[]) => {
-      const active = activeChannelId();
       const next = { ...countsRef.current };
       for (const ev of events) {
         const channel = channelsRef.current.find((c) => c.name === ev.channelName);
-        if (!channel || channel.id === active) continue;
+        if (!channel) continue;
         next[channel.id] = (next[channel.id] ?? 0) + 1;
       }
       countsRef.current = next;

--- a/src/lib/beaver/channel-read.ts
+++ b/src/lib/beaver/channel-read.ts
@@ -2,6 +2,17 @@ import { db } from "../db/db";
 import { channelReads } from "../db/schema";
 import { eq, and, sql } from "drizzle-orm";
 
+// Read a channel's lastReadAt for a user without modifying it. Returns null if
+// the user has never marked this channel read.
+export async function getChannelLastRead(userId: number, channelId: number): Promise<Date | null> {
+  const rows = await db
+    .select({ lastReadAt: channelReads.lastReadAt })
+    .from(channelReads)
+    .where(and(eq(channelReads.userId, userId), eq(channelReads.channelId, channelId)))
+    .limit(1);
+  return rows[0]?.lastReadAt ?? null;
+}
+
 // Mark a channel as read for a user. Returns the previous lastReadAt (or null
 // if the user has never read this channel before).
 export async function markChannelRead(userId: number, channelId: number): Promise<Date | null> {

--- a/src/pages/api/unread.ts
+++ b/src/pages/api/unread.ts
@@ -1,4 +1,4 @@
-import { markChannelRead, getUnreadCounts } from "@/lib/beaver/channel-read";
+import { markChannelRead, getUnreadCounts, getChannelLastRead } from "@/lib/beaver/channel-read";
 import { db } from "@/lib/db/db";
 import { channels } from "@/lib/db/schema";
 import { and, eq } from "drizzle-orm";
@@ -10,6 +10,19 @@ export async function GET({ locals, url }: APIContext) {
     return new Response(JSON.stringify({ error: "Unauthorized" }), {
       status: 401,
     });
+  }
+
+  // Read-only lookup of a single channel's last-read time (does not mark read).
+  const channelId = url.searchParams.get("channelId");
+  if (channelId) {
+    const lastReadAt = await getChannelLastRead(user.id, parseInt(channelId));
+    return new Response(
+      JSON.stringify({
+        channelId: parseInt(channelId),
+        lastReadAt: lastReadAt?.toISOString() ?? null,
+      }),
+      { headers: { "Content-Type": "application/json" } },
+    );
   }
 
   const projectId = url.searchParams.get("projectId");


### PR DESCRIPTION
## Summary

Fixes #129 — channel reads are no longer marked automatically. Previously, opening an unread event (or even just viewing a channel) immediately marked the **entire** channel read, so users lost track of what was new. Reads are now explicit and user-controlled, with a dedicated unread view.

## Behavior changes

**Before:** Opening a channel feed *or* an event detail page POSTed to `/api/unread`, setting `lastReadAt = now` and wiping the unread state.

**After:**
- Viewing a channel or an event **does not** mark anything read — it only *reads* `lastReadAt` to draw the "New" divider, so your place is preserved.
- A **"Mark as read"** button (channel toolbar) lets the user explicitly mark the channel read when they're done.
- An **"Unread"** toggle filters the feed to just unread events, with a "You're all caught up 🎉" empty state.

The `(user, channel, lastReadAt)` model in `channel_reads` is unchanged — only *when* it's written changed (explicit action instead of on-view). No migration needed.

## Changes

- `src/lib/beaver/channel-read.ts` — `getChannelLastRead()` (read-only fetch, no write)
- `src/pages/api/unread.ts` — `GET ?channelId=` returns a channel's `lastReadAt` without marking it read
- `src/components/event-detail.tsx` — removed the auto-mark-on-open effect
- `src/components/event-feed.tsx` — read-only `lastReadAt` fetch; `unreadOnly` toggle; `handleMarkAsRead`; unread filtering + empty state
- `src/components/unread-counts-poller.tsx` — dropped the "skip the channel you're viewing" rule (it assumed viewing == read); the active channel now counts unread like any other until explicitly read

## Test plan

- [ ] Open a channel with unread events → events load, sidebar badge stays (not auto-zeroed), "New" divider shows your last-read boundary
- [ ] Open an unread event, go back → channel still shows unread (place preserved)
- [ ] Toggle "Unread" → only unread events shown; mark some context read elsewhere and confirm filtering
- [ ] Click "Mark as read" → divider clears, unread toggle empties to "all caught up", sidebar badge zeroes
- [ ] New event streams into the channel you're viewing → unread badge increments (no longer suppressed)
- [ ] Never-read channel → "Mark as read" is enabled (all events count as unread)

Closes #129