### PR TITLE
fix: recover from stuck body pointer-events left by Radix overlays

### DIFF
--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -62,6 +62,25 @@ const themePalette = dbUser?.themePalette ?? "default";
       document.addEventListener("astro:before-preparation", () => {
         sessionStorage.setItem("beaver:hasInAppNav", "1");
       });
+
+      // Radix overlays (Select, Dialog, Popover, dropdown/context menus) set
+      // `body { pointer-events: none }` while open and occasionally fail to
+      // restore it on close. When that leaks, the whole page — nav included —
+      // is unclickable, so the user can't navigate to recover and is stuck
+      // until a full reload. If nothing is actually open, unstick the body.
+      // ponytail: recovery, not prevention; drop it if Radix ever fixes the leak upstream.
+      document.addEventListener(
+        "pointerdown",
+        () => {
+          if (
+            document.body.style.pointerEvents === "none" &&
+            !document.querySelector('[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"]')
+          ) {
+            document.body.style.pointerEvents = "";
+          }
+        },
+        true,
+      );
     </script>
     <script is:inline define:vars={{ projectID }}>
       localStorage.setItem("lastProjectId", projectID);


### PR DESCRIPTION
Closes #250.

## Problem

The project dropdown (and eventually the whole page) becomes unclickable after using the app for a while — hard to reproduce reliably, and once it happens the user is stuck until a full reload.

## Root cause

Radix modal overlays — the project `Select`, plus every `Dialog` / `Popover` / dropdown / context menu — set `body { pointer-events: none }` while open and, via a known Radix race, occasionally never restore it on close. Once that leaks, the entire page is non-interactive **including the nav links**, so the user can't navigate to self-heal. The project dropdown is just what tends to get noticed first.

## Fix

A single global `pointerdown` handler in `layout.astro`: if `body` is stuck with `pointer-events: none` while no Radix overlay is actually open, unstick it. One choke point, covers every overlay, no per-component patching.

Trade-off: recovery (not prevention) — the click that unsticks the page doesn't also register on its target, so it costs one wasted click. Preventing the leak would mean patching Radix internals, which isn't worth it. Marked with a `ponytail:` comment to remove if Radix fixes the leak upstream.

## Testing

Manual only. Reproducing the underlying Radix body-lock race needs a real browser with timing control, not jsdom — not worth a bespoke harness for a one-file guard.