### PR TITLE
chore: bump version to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaver",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "type": "module",
   "scripts": {
     "format": "bun oxfmt",


### PR DESCRIPTION
Patch release. Bumps `package.json` 2.1.1 → 2.1.2.

Includes the pointer-events lock recovery fix (#250, merged in #251).