### PR TITLE
fix: preserve sidebar scroll position across navigation

### DIFF
--- a/src/components/side-panel.astro
+++ b/src/components/side-panel.astro
@@ -62,7 +62,7 @@ const ungroupedChannels = channels.filter((c) => !c.groupId);
 />
 
 <!-- Desktop sidebar — re-renders on each navigation for accurate active states -->
-<div class="hidden md:flex flex-col w-[350px] shrink-0 border-r h-screen sticky top-0 overflow-y-auto p-8">
+<div id="sidebar-scroll" class="hidden md:flex flex-col w-[350px] shrink-0 border-r h-screen sticky top-0 overflow-y-auto p-8">
   <UserMenu
     client:idle
     userName={userName}

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -63,6 +63,19 @@ const themePalette = dbUser?.themePalette ?? "default";
         sessionStorage.setItem("beaver:hasInAppNav", "1");
       });
 
+      // The desktop sidebar re-renders (for active states) on each View Transition,
+      // so its scroll container is recreated and scrollTop resets to 0. Carry the
+      // position across the swap so clicking a channel doesn't jump the sidebar.
+      document.addEventListener("astro:before-preparation", () => {
+        const el = document.getElementById("sidebar-scroll");
+        if (el) sessionStorage.setItem("beaver:sidebarScroll", String(el.scrollTop));
+      });
+      document.addEventListener("astro:after-swap", () => {
+        const el = document.getElementById("sidebar-scroll");
+        const top = sessionStorage.getItem("beaver:sidebarScroll");
+        if (el && top) el.scrollTop = parseInt(top);
+      });
+
       // Radix overlays (Select, Dialog, Popover, dropdown/context menus) set
       // `body { pointer-events: none }` while open and occasionally fail to
       // restore it on close. When that leaks, the whole page — nav included —


### PR DESCRIPTION
Closes #246.

## Problem

When the channel list is long enough to scroll, clicking a channel near the bottom navigates and resets the sidebar scroll back to the top — you lose your place.

## Cause

The desktop sidebar re-renders on every View Transition (so nav active states stay correct), which recreates its `overflow-y-auto` container and drops `scrollTop` to 0.

## Fix

Save the sidebar `scrollTop` on `astro:before-preparation` and restore it on `astro:after-swap` — the same save/restore-on-swap pattern already used for the event feed. Keeps the active-state re-render behavior intact.

## Testing

Manual. Needs a browser + a channel list long enough to scroll; not unit-testable without a View Transition harness.