### PR TITLE
fix: mobile responsiveness pass across pages

### DIFF
--- a/src/components/admin-email-settings-view.tsx
+++ b/src/components/admin-email-settings-view.tsx
@@ -122,8 +122,8 @@ export default function AdminEmailSettingsView({
 
           {provider === "smtp" && (
             <div className="space-y-4 border rounded-md p-4">
-              <div className="grid grid-cols-3 gap-4">
-                <div className="col-span-2 space-y-2">
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <div className="sm:col-span-2 space-y-2">
                   <Label htmlFor="smtp-host">Host</Label>
                   <Input
                     id="smtp-host"

--- a/src/components/api-playground.tsx
+++ b/src/components/api-playground.tsx
@@ -91,7 +91,7 @@ export default function ApiPlayground({
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       {/* Form */}
       <div className="space-y-4">
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="pg-name">
               Name <span className="text-destructive">*</span>
@@ -145,7 +145,7 @@ export default function ApiPlayground({
           />
         </div>
 
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
           <div className="space-y-1.5">
             <Label htmlFor="pg-icon">Icon</Label>
             <Input

--- a/src/pages/dashboard/create-project.astro
+++ b/src/pages/dashboard/create-project.astro
@@ -21,7 +21,7 @@ const projects = user!.isAdmin
   <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <title>Beaver - Create Project</title>
     <script is:inline>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ if (projects.length === 0) {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/png" href="/beaver.png" />
     <title>Beaver</title>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -14,7 +14,7 @@ if (adminUsers.length === 0) {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/png" href="/beaver.png" />
     <title>Beaver - Sign In</title>

--- a/src/pages/onboarding.astro
+++ b/src/pages/onboarding.astro
@@ -14,7 +14,7 @@ if (adminUsers.length > 0) {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <link rel="icon" type="image/png" href="/beaver.png" />
     <title>Beaver - Onboarding</title>


### PR DESCRIPTION
Addresses #247.

A targeted responsiveness pass. Most of the app already uses responsive patterns (`p-4 md:p-8`, `grid-cols-1 md:grid-cols-*`); this fixes the concrete offenders that made mobile render badly.

## Changes

**Viewport (the big one):** `login`, `onboarding`, `index`, and `create-project` were missing `initial-scale=1` in their viewport meta, so mobile browsers rendered them at the wrong zoom (everything oversized / "hard to see"). Now consistent with the rest of the app.

**Non-responsive grids:**
- API playground form (`grid-cols-2` → `grid-cols-1 sm:grid-cols-2`) — inputs were crammed side-by-side on mobile.
- Admin email SMTP settings (`grid-cols-3` → `grid-cols-1 sm:grid-cols-3`, and the Host field's `col-span-2` → `sm:col-span-2` so it doesn't force a stray column when stacked).

## Scope / testing

Manual, code-level audit — I can't see the rendered mobile view, so this targets clear structural problems (wrong viewport, non-collapsing grids) rather than pixel-level polish. Pages that already had responsive padding/grids (feed, metrics, settings, api-docs, admin users) were left as-is; api-docs tables are already wrapped in `overflow-x-auto`.

If specific screens still look off, send screenshots and I'll do a second pass against them.