### PR TITLE
chore: bump version to 2.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaver",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "type": "module",
   "scripts": {
     "format": "bun oxfmt",


### PR DESCRIPTION
Patch release. Bumps `package.json` 2.1.2 → 2.1.3.

Includes since v2.1.2:
- fix: preserve sidebar scroll position across navigation (#246, #253)
- fix: mobile responsiveness pass across pages (#247, #254)