### PR TITLE
fix: keep project switcher clickable after client-side navigation

### DIFF
--- a/src/components/side-panel.astro
+++ b/src/components/side-panel.astro
@@ -63,17 +63,16 @@ const ungroupedChannels = channels.filter((c) => !c.groupId);
 
 <!-- Desktop sidebar — re-renders on each navigation for accurate active states -->
 <div id="sidebar-scroll" class="hidden md:flex flex-col w-[350px] shrink-0 border-r h-screen sticky top-0 overflow-y-auto p-8">
-  <UserMenu
-    client:idle
-    userName={userName}
-    transition:persist="user-menu"
-  />
+  <!-- No transition:persist on these two: they wrap Radix overlays (Popover,
+       Select) whose state desyncs across a View Transition body swap, leaving
+       the trigger unclickable until a hard reload. The sidebar re-renders each
+       nav anyway, so re-hydrating them fresh costs nothing and keeps them working. -->
+  <UserMenu client:idle userName={userName} />
   <ProjectSwitcher
     client:idle
     projects={projects}
     currentProjectId={project.id}
     canCreate={isAdmin || canCreateProjects}
-    transition:persist="project-switcher"
   />
   <!-- Nav links: SSR-only, re-rendered each navigation → active state always correct -->
   <SidePanelNav

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -75,25 +75,6 @@ const themePalette = dbUser?.themePalette ?? "default";
         const top = sessionStorage.getItem("beaver:sidebarScroll");
         if (el && top) el.scrollTop = parseInt(top);
       });
-
-      // Radix overlays (Select, Dialog, Popover, dropdown/context menus) set
-      // `body { pointer-events: none }` while open and occasionally fail to
-      // restore it on close. When that leaks, the whole page — nav included —
-      // is unclickable, so the user can't navigate to recover and is stuck
-      // until a full reload. If nothing is actually open, unstick the body.
-      // ponytail: recovery, not prevention; drop it if Radix ever fixes the leak upstream.
-      document.addEventListener(
-        "pointerdown",
-        () => {
-          if (
-            document.body.style.pointerEvents === "none" &&
-            !document.querySelector('[data-radix-popper-content-wrapper], [role="dialog"][data-state="open"]')
-          ) {
-            document.body.style.pointerEvents = "";
-          }
-        },
-        true,
-      );
     </script>
     <script is:inline define:vars={{ projectID }}>
       localStorage.setItem("lastProjectId", projectID);


### PR DESCRIPTION
Re-fixes #250 (the earlier fix in #251 didn't resolve it).

## Corrected diagnosis

The real symptom: the project dropdown trigger stops *opening* after navigating around client-side, and a hard refresh restores it — the rest of the page still works. That is not a page-wide `pointer-events` lock (my earlier guess in #251); it's the well-known **Radix-overlay-inside-an-Astro-`transition:persist`-island** problem.

`ProjectSwitcher` (Radix `Select`) and `UserMenu` (Radix `Popover`) were pinned with `transition:persist`, so their Radix state survives the View Transition body swap and desyncs — the trigger's open/close stops working. A full page load re-mounts them, which is exactly why refresh "fixes" it.

## Fix

Drop `transition:persist` from both. The desktop sidebar already re-renders on every navigation (for active nav states), so these islands now re-hydrate fresh each nav — no desync, no added flicker beyond the existing initial-load hydration.

Also reverts the `body` `pointer-events` recovery script added in #251: it addressed a misdiagnosis of this same bug and didn't resolve it, so keeping it would just be dead speculative code.

## Notes / follow-up

- Left `ChannelGroupsDnd` persisted — it has the same Radix (ContextMenu) exposure, but un-persisting it would reset its optimistic drag/collapse state on every nav. Its context menu could warrant the same treatment later if it misbehaves.

## Testing

Manual — reproducing needs a browser + client-side navigation (a View Transition), not unit-testable here. Navigate between pages, then open the project dropdown; it should open without a refresh.