### PR TITLE
chore: bump version to 2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaver",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "type": "module",
   "scripts": {
     "format": "bun oxfmt",


### PR DESCRIPTION
Patch release. Bumps `package.json` 2.1.3 → 2.1.4.

Includes since v2.1.3:
- fix: keep project switcher (and user menu) clickable after client-side navigation (#250, #256)