### PR TITLE
docs: document release branch and no-attribution conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,9 @@ Always use `bun`/`bunx` — never `npm`/`npx`.
 
 **Colors.** The project uses oklch via CSS variables. Never use `hsl(var(--chart-N))` — it's invalid. Use `var(--chart-N)` directly, or pass `{ light: "...", dark: "..." }` to chart theme props.
 
-**Commits.** Conventional commit format (`feat:`, `fix:`, `refactor:`, etc.). No issue references in commit messages — this is a squash-merge project, so issue refs go in the PR body only.
+**Commits.** Conventional commit format (`feat:`, `fix:`, `refactor:`, etc.). No issue references in commit messages — this is a squash-merge project, so issue refs go in the PR body only. Do not add co-author or attribution trailers (`Co-Authored-By`, `Generated with …`, session links) to commits or PR bodies.
+
+**Releases.** Each release has a branch named `v<version>` (e.g. `v2.2.0`) cut from `main`; feature work for that release branches off it and PRs back into it. Shipping a release: bump `package.json` (only at release time, not in feature PRs), merge to `main`, then tag `v<version>` and publish a GitHub release with "## What's Changed" notes.
 
 **shadcn/ui.** Components are in `src/components/ui/`. Add new ones with `bunx shadcn@latest add <component>`.
 


### PR DESCRIPTION
Adds two existing conventions to `CLAUDE.md` so they're written down:

- **No attribution trailers** — commits and PR bodies must not include `Co-Authored-By`, "Generated with …", or session links. (Added to the Commits section.)
- **Release branches** — each release lives on a `v<version>` branch cut from `main`; feature work branches off it and merges back. Version bumps happen only at release time, followed by merge to `main`, tag, and a GitHub release with "## What's Changed" notes. (New Releases section.)

Docs-only.