### PR TITLE
feat: clickable URL tag values

### DIFF
--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -48,8 +48,9 @@ function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | 
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-primary underline underline-offset-2 hover:opacity-80 break-all"
+          className="inline-flex items-center gap-1 text-primary underline underline-offset-2 hover:opacity-80 break-all"
         >
+          <LinkIcon size={12} className="shrink-0" />
           {displayValue}
         </a>
       ) : (

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -24,14 +24,37 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
+// Only http(s) so a tag value like `javascript:…` can never become a clickable link.
+function httpUrl(value: string | number | boolean): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:" ? u.href : null;
+  } catch {
+    return null;
+  }
+}
+
 function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | boolean }) {
   const displayValue = typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+  const url = httpUrl(value);
 
   return (
     <div className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-white/10 px-2.5 py-1 text-sm">
       <span className="font-medium text-foreground/75">{tagKey}</span>
       <span className="text-muted-foreground">=</span>
-      <span className="text-foreground">{displayValue}</span>
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary underline underline-offset-2 hover:opacity-80 break-all"
+        >
+          {displayValue}
+        </a>
+      ) : (
+        <span className="text-foreground">{displayValue}</span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #249. Targets the `v2.2.0` release branch.

## What

On the event detail page, a tag whose value is an `http(s)` URL now renders as a clickable link (opens in a new tab) instead of plain text.

## Details

- `TagBadge` parses the value with the `URL` API and only linkifies when the protocol is `http:`/`https:` — a value like `javascript:…` or `mailto:…` stays plain text (no unsafe/clickable protocols).
- Links use `target="_blank"` + `rel="noopener noreferrer"`, and `break-all` so long URLs wrap inside the badge.
- Only string values are considered; numbers/booleans are untouched.

## Testing

Verified the URL-detection allowlist against http(s), `javascript:`, `mailto:`, `ftp:`, bare strings, and non-strings — only http(s) is linkified. UI itself is manual (no test runner set up in the repo).