### PR TITLE
refactor: plot each timeseries value instead of bucketing by day

### DIFF
--- a/src/components/metric-detail.tsx
+++ b/src/components/metric-detail.tsx
@@ -7,16 +7,7 @@ import { Label } from "./ui/label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "./ui/dialog";
 import { DatePicker } from "./ui/date-picker";
 import { ArrowLeftIcon, PencilIcon, Trash2Icon } from "lucide-react";
-import {
-  formatDistanceToNow,
-  format,
-  subDays,
-  startOfDay,
-  startOfHour,
-  startOfWeek,
-  differenceInHours,
-  differenceInDays,
-} from "date-fns";
+import { formatDistanceToNow, format, subDays, startOfDay, differenceInHours } from "date-fns";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -31,7 +22,6 @@ type SerializedValue = Omit<MetricValue, "timestamp" | "createdAt"> & {
 };
 
 type Range = "today" | "7d" | "30d" | "custom";
-type BucketGranularity = "hour" | "day" | "week";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -45,39 +35,6 @@ function getRangeDates(range: Range, customFrom?: Date, customTo?: Date): { from
   if (range === "7d") return { from: subDays(now, 7), to: now };
   if (range === "30d") return { from: subDays(now, 30), to: now };
   return { from: customFrom ?? subDays(now, 30), to: customTo ?? now };
-}
-
-function getBucketGranularity(from: Date, to: Date): BucketGranularity {
-  const days = differenceInDays(to, from);
-  if (days <= 2) return "hour";
-  if (days <= 60) return "day";
-  return "week";
-}
-
-function bucketLabel(d: Date, granularity: BucketGranularity): string {
-  if (granularity === "hour") return format(startOfHour(d), "MM/dd HH:mm");
-  if (granularity === "day") return format(d, "MM/dd");
-  return format(startOfWeek(d), "MM/dd");
-}
-
-function bucketValues(
-  values: { value: number; timestamp: Date }[],
-  granularity: BucketGranularity,
-  mode: "sum" | "avg" = "sum",
-): { label: string; value: number }[] {
-  const sums = new Map<string, number>();
-  const counts = new Map<string, number>();
-  for (const v of values) {
-    const key = bucketLabel(v.timestamp, granularity);
-    sums.set(key, (sums.get(key) ?? 0) + v.value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return Array.from(sums.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([label, sum]) => ({
-      label,
-      value: mode === "avg" ? Math.round((sum / (counts.get(label) ?? 1)) * 10) / 10 : sum,
-    }));
 }
 
 function formatValue(value: number | null, unit?: string | null): string {
@@ -535,13 +492,13 @@ export default function MetricDetail({
 
   // ── Derived chart data ────────────────────────────────────────────────────────
 
-  const { from: rangeFrom, to: rangeTo } = getRangeDates(range, customFrom, customTo);
-  const granularity = getBucketGranularity(rangeFrom, rangeTo);
-
   const isBarChart = metric.chartType === "bar";
-  const timeseriesData = isBarChart
-    ? bucketValues(values, granularity, "avg")
-    : values.map((v) => ({ label: format(v.timestamp, "MM/dd HH:mm"), value: v.value }));
+  // Every posted value is its own point/bar (#248): no day-bucketing, so dozens
+  // of same-day instances stay visible instead of collapsing into one.
+  const timeseriesData = values.map((v) => ({
+    label: format(v.timestamp, "MM/dd HH:mm"),
+    value: v.value,
+  }));
 
   const stats =
     values.length > 0

--- a/src/pages/dashboard/[projectID]/metrics.astro
+++ b/src/pages/dashboard/[projectID]/metrics.astro
@@ -25,22 +25,6 @@ const TYPE_LABELS: Record<string, string> = {
   timeseries: "Timeseries",
 };
 
-function bucketSparkline(
-  data: { value: number; timestamp: Date }[],
-  chartType: string,
-): { value: number }[] {
-  if (chartType !== "bar") return data.map((d) => ({ value: d.value }));
-  const sums = new Map<string, number>();
-  const counts = new Map<string, number>();
-  for (const d of data) {
-    const key = new Date(d.timestamp).toISOString().slice(0, 10);
-    sums.set(key, (sums.get(key) ?? 0) + d.value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return Array.from(sums.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, sum]) => ({ value: Math.round((sum / (counts.get(key) ?? 1)) * 10) / 10 }));
-}
 ---
 
 <Layout projectID={projectID!}>
@@ -70,10 +54,8 @@ function bucketSparkline(
         {metrics.map((metric) => {
           const isClickable = metric.type === "timeseries";
           const isTweenable = metric.type === "gauge" || metric.type === "counter";
-          const sparklineData = bucketSparkline(
-            sparklines[metric.id] ?? [],
-            metric.chartType ?? "line",
-          );
+          // One point per posted value (#248) — no day-bucketing.
+          const sparklineData = (sparklines[metric.id] ?? []).map((d) => ({ value: d.value }));
           const Wrapper = isClickable ? "a" : "div";
           return (
             <Wrapper


### PR DESCRIPTION
Closes #248. Targets the `v2.2.0` release branch.

## Problem

Bar-chart timeseries bucketed values by day and **averaged** them, so posting dozens of instances in one day collapsed into a single averaged bar — the volume of individual posts was invisible ("not acting as a single unit metric"). Line charts already plotted each value; only bar charts bucketed.

## Change

Every posted value is now its own point/bar, plotted by timestamp — bar charts behave like line charts. No day/hour/week bucketing.

- `metric-detail.tsx`: chart data is a direct map of values; removed the now-dead `bucketValues` / `bucketLabel` / `getBucketGranularity` helpers and their unused `date-fns` imports.
- `metrics.astro`: the list-page sparkline no longer buckets bar-type by day either; removed `bucketSparkline` (it reduced to a trivial map).

Net −70 / +9 lines.

## Tradeoff

Chosen behavior (confirmed): many posts in a day render as many bars, which can get dense. The chart already thins x-axis labels (~6 shown) and sizes bars to fit, so it stays readable.

## Testing

Manual — chart rendering needs a browser. The change is a straight data mapping (no new branching logic), and I confirmed no dangling references to the removed helpers remain.