### PR TITLE
feat: notifications view

### DIFF
--- a/drizzle/0024_nifty_centennial.sql
+++ b/drizzle/0024_nifty_centennial.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `notifications` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`type` text NOT NULL,
+	`message` text NOT NULL,
+	`link_path` text NOT NULL,
+	`read_at` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `notifications_user_project_created_idx` ON `notifications` (`user_id`,`project_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `notifications_user_project_read_idx` ON `notifications` (`user_id`,`project_id`,`read_at`);

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1602 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "89d6f14c-ea03-4c4b-9ede-341798cf50b4",
+  "prevId": "924b330c-34ab-4796-874d-1461982bf199",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_comments": {
+      "name": "event_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_comments_event_id_events_id_fk": {
+          "name": "event_comments_event_id_events_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_comments_user_id_users_id_fk": {
+          "name": "event_comments_user_id_users_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_reactions": {
+      "name": "event_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_reactions_event_user_emoji_idx": {
+          "name": "event_reactions_event_user_emoji_idx",
+          "columns": ["event_id", "user_id", "emoji"],
+          "isUnique": true
+        },
+        "event_reactions_event_id_idx": {
+          "name": "event_reactions_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_reactions_event_id_events_id_fk": {
+          "name": "event_reactions_event_id_events_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reactions_user_id_users_id_fk": {
+          "name": "event_reactions_user_id_users_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_path": {
+          "name": "link_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "notifications_user_project_created_idx": {
+          "name": "notifications_user_project_created_idx",
+          "columns": ["user_id", "project_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_user_project_read_idx": {
+          "name": "notifications_user_project_read_idx",
+          "columns": ["user_id", "project_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_project_id_projects_id_fk": {
+          "name": "notifications_project_id_projects_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_per_minute": {
+          "name": "rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_views": {
+      "name": "saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_views_project_id_projects_id_fk": {
+          "name": "saved_views_project_id_projects_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_views_user_id_users_id_fk": {
+          "name": "saved_views_user_id_users_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compact_mode": {
+          "name": "compact_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "theme_palette": {
+          "name": "theme_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1782100000000,
       "tag": "0023_theme_palette",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1783369363306,
+      "tag": "0024_nifty_centennial",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -4,6 +4,7 @@ import type { Project } from "@/lib/beaver/project";
 import { MenuIcon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import ChannelGroupsDnd from "./channel-groups-dnd";
+import NotificationsNavLink from "./notifications-nav-link";
 import ProjectSwitcher from "./project-switcher";
 import SidePanelNav from "./side-panel-nav";
 import ThemeToggle from "./theme-toggle";
@@ -113,6 +114,7 @@ export default function MobileDrawer({
           isAdmin={isAdmin}
           onNavigate={close}
         />
+        <NotificationsNavLink projectId={project.id} pathname={pathname} onNavigate={close} />
         <ChannelGroupsDnd
           initialUngrouped={ungroupedChannels}
           initialGroups={groups}

--- a/src/components/notifications-nav-link.tsx
+++ b/src/components/notifications-nav-link.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { BellIcon } from "lucide-react";
+
+// Matches the nav link styling in side-panel-nav.tsx (plus justify-between for the badge).
+const navCss =
+  "flex px-3 py-2 items-center justify-between hover:bg-gray-100 dark:hover:bg-white/8 hover:cursor-pointer hover:font-medium rounded ";
+const activeNavCss = navCss + "bg-gray-100 dark:bg-white/8 font-medium";
+
+export default function NotificationsNavLink({
+  projectId,
+  pathname,
+  onNavigate,
+}: {
+  projectId: number;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const [count, setCount] = useState(0);
+  const href = `/dashboard/${projectId}/notifications`;
+  const isActive = pathname === href;
+
+  // ponytail: plain interval poll, not the SSE + BroadcastChannel-leader setup
+  // used for channel unread counts. Upgrade only if the extra requests matter.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchCount = async () => {
+      try {
+        const res = await fetch(`/api/notifications/unread-count?projectId=${projectId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setCount(data.count ?? 0);
+      } catch {
+        // ignore
+      }
+    };
+    fetchCount();
+    const interval = setInterval(fetchCount, 45_000);
+    const onUpdated = (e: Event) => {
+      const detail = (e as CustomEvent<{ count?: number }>).detail;
+      if (detail && typeof detail.count === "number") setCount(detail.count);
+      else fetchCount();
+    };
+    window.addEventListener("notifications:updated", onUpdated);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      window.removeEventListener("notifications:updated", onUpdated);
+    };
+  }, [projectId]);
+
+  return (
+    <a href={href} onClick={() => onNavigate?.()} className={isActive ? activeNavCss : navCss}>
+      <span className="flex items-center space-x-2">
+        <BellIcon size={20} />
+        <span>Notifications</span>
+      </span>
+      {count > 0 && (
+        <span className="ml-2 shrink-0 text-xs font-semibold bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center leading-tight">
+          {count > 99 ? "99+" : count}
+        </span>
+      )}
+    </a>
+  );
+}

--- a/src/components/notifications-view.tsx
+++ b/src/components/notifications-view.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { AtSignIcon, MessageSquareIcon, TriangleAlertIcon, CheckCheckIcon } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { Button } from "./ui/button";
+import type { NotificationType } from "@/lib/beaver/notification";
+
+type SerializedNotification = {
+  id: number;
+  type: NotificationType;
+  message: string;
+  linkPath: string;
+  readAt: string | null;
+  createdAt: string;
+};
+
+const ICONS: Record<NotificationType, typeof AtSignIcon> = {
+  mention: AtSignIcon,
+  comment_reply: MessageSquareIcon,
+  alert: TriangleAlertIcon,
+};
+
+export default function NotificationsView({
+  projectId,
+  initialNotifications,
+}: {
+  projectId: number;
+  initialNotifications: SerializedNotification[];
+}) {
+  const [items, setItems] = useState(initialNotifications);
+  const [marking, setMarking] = useState(false);
+
+  const unreadCount = items.filter((n) => !n.readAt).length;
+
+  const handleMarkAllRead = async () => {
+    if (unreadCount === 0 || marking) return;
+    setMarking(true);
+    try {
+      const res = await fetch("/api/notifications/read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      if (!res.ok) return;
+      const now = new Date().toISOString();
+      setItems((prev) => prev.map((n) => (n.readAt ? n : { ...n, readAt: now })));
+      window.dispatchEvent(new CustomEvent("notifications:updated", { detail: { count: 0 } }));
+    } finally {
+      setMarking(false);
+    }
+  };
+
+  return (
+    <div className="px-4 md:px-8 py-4 md:py-8 w-full max-w-3xl">
+      <div className="flex items-center justify-between gap-4 mb-6">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-semibold">Notifications</h1>
+          {unreadCount > 0 && (
+            <span className="text-xs font-semibold bg-primary text-primary-foreground rounded-full px-2 py-0.5 tabular-nums">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleMarkAllRead}
+          disabled={unreadCount === 0 || marking}
+          title="Mark all as read"
+        >
+          <CheckCheckIcon className="size-4 mr-2" />
+          Mark all as read
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="text-center pt-16">
+          <h2 className="text-xl">You&rsquo;re all caught up 🎉</h2>
+          <p className="text-muted-foreground mt-2">No notifications yet.</p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {items.map((n) => {
+            const Icon = ICONS[n.type];
+            const unread = !n.readAt;
+            return (
+              <li key={n.id}>
+                <a
+                  href={n.linkPath}
+                  className={`flex items-start gap-3 rounded-md px-3 py-3 transition-colors hover:bg-muted ${
+                    unread ? "bg-primary/5" : ""
+                  }`}
+                >
+                  <Icon
+                    className={`size-4 mt-0.5 shrink-0 ${unread ? "text-primary" : "text-muted-foreground"}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className={`text-sm break-words ${unread ? "font-medium" : ""}`}>
+                      {n.message}
+                    </p>
+                    <span className="text-xs text-muted-foreground">
+                      {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  {unread && <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" />}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/side-panel.astro
+++ b/src/components/side-panel.astro
@@ -5,6 +5,7 @@ import type { Project } from "@/lib/beaver/project";
 import ChannelGroupsDnd from "./channel-groups-dnd";
 import MobileDrawer from "./mobile-drawer";
 import ProjectSwitcher from "./project-switcher";
+import NotificationsNavLink from "./notifications-nav-link";
 import SidePanelNav from "./side-panel-nav";
 import ThemeToggle from "./theme-toggle";
 import UnreadCountsPoller from "./unread-counts-poller";
@@ -81,6 +82,7 @@ const ungroupedChannels = channels.filter((c) => !c.groupId);
     userRole={userRole}
     isAdmin={isAdmin}
   />
+  <NotificationsNavLink client:idle projectId={project.id} pathname={currentPath} />
   <ChannelGroupsDnd
     client:idle
     initialUngrouped={ungroupedChannels}

--- a/src/lib/beaver/alert-rule.ts
+++ b/src/lib/beaver/alert-rule.ts
@@ -3,7 +3,11 @@ import { alertRules, channels, events } from "../db/schema";
 import { eq, and, gt, gte, count } from "drizzle-orm";
 import type { Channel } from "./channel";
 import type { Project } from "./project";
-import { getNotificationEmailsForChannel } from "./channel-notification";
+import {
+  getNotificationEmailsForChannel,
+  getNotificationSubscriberIdsForChannel,
+} from "./channel-notification";
+import { createAlertNotifications } from "./notification";
 import { sendAlertEmail } from "../email/send";
 
 export type AlertRule = {
@@ -142,6 +146,18 @@ export async function checkAndDispatchAlerts(
   for (const rule of rules) {
     const matchedCount = await checkAlertRule(rule);
     if (matchedCount === null) continue;
+
+    // In-app notifications for every channel subscriber (independent of whether
+    // they have an email set).
+    await createAlertNotifications({
+      projectId: project.id,
+      channelId: channel.id,
+      channelName: channel.name,
+      ruleName: rule.name,
+      count: matchedCount,
+      windowMinutes: rule.windowMinutes,
+      recipientIds: await getNotificationSubscriberIdsForChannel(channel.id),
+    });
 
     const emails = await getNotificationEmailsForChannel(channel.id);
     if (emails.length === 0) continue;

--- a/src/lib/beaver/channel-notification.ts
+++ b/src/lib/beaver/channel-notification.ts
@@ -72,3 +72,12 @@ export async function getNotificationEmailsForChannel(channelId: number): Promis
 
   return rows.flatMap((r) => (r.email ? [r.email] : []));
 }
+
+export async function getNotificationSubscriberIdsForChannel(channelId: number): Promise<number[]> {
+  const rows = await db
+    .select({ userId: channelNotificationSubscriptions.userId })
+    .from(channelNotificationSubscriptions)
+    .where(eq(channelNotificationSubscriptions.channelId, channelId));
+
+  return rows.map((r) => r.userId);
+}

--- a/src/lib/beaver/comment.ts
+++ b/src/lib/beaver/comment.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventComments, users } from "../db/schema";
 import { eq, asc } from "drizzle-orm";
 import { publishComment, type Comment } from "./comment-bus";
+import { createNotificationsForComment } from "./notification";
 
 export type { Comment };
 
@@ -45,6 +46,20 @@ export async function createComment(
 
   const comment = withUser as Comment;
   publishComment({ eventId, comment });
+
+  // Best-effort: notify mentioned members and prior thread participants. Never
+  // let a notification failure break commenting.
+  try {
+    await createNotificationsForComment({
+      eventId,
+      actorId: userId,
+      actorName: comment.userName,
+      body,
+    });
+  } catch (err) {
+    console.error("Failed to create comment notifications:", err);
+  }
+
   return comment;
 }
 

--- a/src/lib/beaver/notification.ts
+++ b/src/lib/beaver/notification.ts
@@ -1,0 +1,150 @@
+import { db } from "../db/db";
+import { notifications, events, eventComments } from "../db/schema";
+import { and, count, desc, eq, isNull, ne } from "drizzle-orm";
+import { getProjectMembers } from "./project-member";
+
+export type NotificationType = "comment_reply" | "mention" | "alert";
+
+export type Notification = {
+  id: number;
+  type: NotificationType;
+  message: string;
+  linkPath: string;
+  readAt: Date | null;
+  createdAt: Date;
+};
+
+function truncate(s: string, max = 80): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+// Generate notifications for a freshly created comment: @mentions of project
+// members, plus replies to everyone else who has commented on the same event.
+// Mentions win over replies, and the comment author is never notified.
+export async function createNotificationsForComment(opts: {
+  eventId: number;
+  actorId: number;
+  actorName: string;
+  body: string;
+}): Promise<void> {
+  const { eventId, actorId, actorName, body } = opts;
+
+  const [ev] = await db
+    .select({ projectId: events.projectId, title: events.title })
+    .from(events)
+    .where(eq(events.id, eventId));
+  if (!ev) return;
+
+  const linkPath = `/dashboard/${ev.projectId}/events/${eventId}`;
+  const recipients = new Map<number, NotificationType>();
+
+  // Mentions — resolve @handle tokens (mirrors the UI's @\w+) against members.
+  const handles = new Set(Array.from(body.matchAll(/@(\w+)/g)).map((m) => m[1].toLowerCase()));
+  if (handles.size > 0) {
+    const members = await getProjectMembers(ev.projectId);
+    for (const m of members) {
+      if (m.userId !== actorId && handles.has(m.userName.toLowerCase())) {
+        recipients.set(m.userId, "mention");
+      }
+    }
+  }
+
+  // Replies — other users who have commented on this event.
+  const priorCommenters = await db
+    .selectDistinct({ userId: eventComments.userId })
+    .from(eventComments)
+    .where(and(eq(eventComments.eventId, eventId), ne(eventComments.userId, actorId)));
+  for (const c of priorCommenters) {
+    if (!recipients.has(c.userId)) recipients.set(c.userId, "comment_reply");
+  }
+
+  if (recipients.size === 0) return;
+
+  const rows = Array.from(recipients.entries()).map(([userId, type]) => ({
+    userId,
+    projectId: ev.projectId,
+    type,
+    message:
+      type === "mention"
+        ? `@${actorName} mentioned you: “${truncate(body)}”`
+        : `@${actorName} replied on “${ev.title}”`,
+    linkPath,
+  }));
+
+  await db.insert(notifications).values(rows);
+}
+
+// One alert notification per subscriber when an alert rule fires.
+export async function createAlertNotifications(opts: {
+  projectId: number;
+  channelId: number;
+  channelName: string;
+  ruleName: string;
+  count: number;
+  windowMinutes: number;
+  recipientIds: number[];
+}): Promise<void> {
+  const { projectId, channelId, channelName, ruleName, count, windowMinutes, recipientIds } = opts;
+  if (recipientIds.length === 0) return;
+
+  const linkPath = `/dashboard/${projectId}/channels/${channelId}`;
+  const message = `Alert “${ruleName}” triggered in #${channelName} — ${count} events in ${windowMinutes}m`;
+
+  await db.insert(notifications).values(
+    recipientIds.map((userId) => ({
+      userId,
+      projectId,
+      type: "alert" as const,
+      message,
+      linkPath,
+    })),
+  );
+}
+
+export async function getNotifications(
+  userId: number,
+  projectId: number,
+  { limit = 50 }: { limit?: number } = {},
+): Promise<Notification[]> {
+  const rows = await db
+    .select({
+      id: notifications.id,
+      type: notifications.type,
+      message: notifications.message,
+      linkPath: notifications.linkPath,
+      readAt: notifications.readAt,
+      createdAt: notifications.createdAt,
+    })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), eq(notifications.projectId, projectId)))
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
+  return rows as Notification[];
+}
+
+export async function getUnreadCount(userId: number, projectId: number): Promise<number> {
+  const [row] = await db
+    .select({ n: count() })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.projectId, projectId),
+        isNull(notifications.readAt),
+      ),
+    );
+  return row?.n ?? 0;
+}
+
+export async function markAllRead(userId: number, projectId: number): Promise<void> {
+  await db
+    .update(notifications)
+    .set({ readAt: new Date() })
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.projectId, projectId),
+        isNull(notifications.readAt),
+      ),
+    );
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -547,3 +547,38 @@ export const savedViews = sqliteTable("saved_views", {
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),
 });
+
+// ---- NOTIFICATIONS ----
+// One row per recipient per event. Heterogeneous types share one shape:
+// message/linkPath are denormalized at creation so the list renders join-free.
+export const notifications = sqliteTable(
+  "notifications",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    projectId: integer("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    type: text("type", { enum: ["comment_reply", "mention", "alert"] }).notNull(),
+    message: text("message").notNull(),
+    linkPath: text("link_path").notNull(),
+    readAt: integer("read_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    userProjectCreatedIdx: index("notifications_user_project_created_idx").on(
+      table.userId,
+      table.projectId,
+      table.createdAt,
+    ),
+    userProjectReadIdx: index("notifications_user_project_read_idx").on(
+      table.userId,
+      table.projectId,
+      table.readAt,
+    ),
+  }),
+);

--- a/src/pages/api/notifications/list.ts
+++ b/src/pages/api/notifications/list.ts
@@ -1,0 +1,24 @@
+import type { APIContext } from "astro";
+import { getNotifications } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function GET({ locals, url }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const projectId = Number(url.searchParams.get("projectId"));
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  const limitParam = Number(url.searchParams.get("limit"));
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 100) : 50;
+
+  const notifications = await getNotifications(user.id, projectId, { limit });
+  return new Response(JSON.stringify({ notifications }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/notifications/read.ts
+++ b/src/pages/api/notifications/read.ts
@@ -1,0 +1,21 @@
+import type { APIContext } from "astro";
+import { markAllRead } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function POST({ locals, request }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const { projectId } = await request.json();
+  if (typeof projectId !== "number") {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  await markAllRead(user.id, projectId);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/notifications/unread-count.ts
+++ b/src/pages/api/notifications/unread-count.ts
@@ -1,0 +1,21 @@
+import type { APIContext } from "astro";
+import { getUnreadCount } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function GET({ locals, url }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const projectId = Number(url.searchParams.get("projectId"));
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  const count = await getUnreadCount(user.id, projectId);
+  return new Response(JSON.stringify({ count }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/notifications.astro
+++ b/src/pages/dashboard/[projectID]/notifications.astro
@@ -1,0 +1,24 @@
+---
+import Layout from "@/layouts/layout.astro";
+import NotificationsView from "@/components/notifications-view";
+import { getNotifications } from "@/lib/beaver/notification";
+
+const { projectID } = Astro.params;
+const user = Astro.locals.user!;
+const projectId = parseInt(projectID!);
+
+const initial = await getNotifications(user.id, projectId);
+const initialNotifications = initial.map((n) => ({
+  ...n,
+  readAt: n.readAt ? n.readAt.toISOString() : null,
+  createdAt: n.createdAt.toISOString(),
+}));
+---
+
+<Layout projectID={projectID!}>
+  <NotificationsView
+    client:load
+    projectId={projectId}
+    initialNotifications={initialNotifications}
+  />
+</Layout>


### PR DESCRIPTION
Closes #239. Targets the `v2.2.0` release branch.

## What

A project-scoped notifications inbox that aggregates activity relevant to the current user, per the issue: reverse-chron list with unread/read state, deep links, "mark all as read", and a sidebar badge.

### Notification types (v1)
- **`comment_reply`** — someone comments on an event you've previously commented on.
- **`mention`** — someone `@username`s you in a comment (the @mention UI already existed; this adds backend extraction).
- **`alert`** — an existing per-channel alert rule fires (previously email-only); now also creates in-app notifications for channel subscribers.

Scope was confirmed up front because **events have no author** in beaver (API-ingested, not user-posted) and reactions are event-level — so user-targeted notifications can only come from comment activity + alerts. Reactions were excluded (no user target under the current model).

## How
- **`notifications` table** (migration `0024`): `userId`, `projectId`, `type`, denormalized `message` + `linkPath`, `readAt`, `createdAt`. The denormalization keeps the list query join-free and uniform across types (and future ones).
- **Generation hooks** at single choke points: `createComment` (`comment.ts`) and `checkAndDispatchAlerts` (`alert-rule.ts`). Comment generation is best-effort (never breaks commenting); alerts reuse the debounced `checkAlertRule` so they fire once per window.
- **API**: `GET /api/notifications/list`, `GET /api/notifications/unread-count`, `POST /api/notifications/read` — all guarded by `canAccessProject`.
- **UI**: `notifications.astro` page + `notifications-view.tsx` (per-type icons, unread styling, mark-all-read); `notifications-nav-link.tsx` island shows a polled unread badge in the sidebar.

## Deliberate simplifications
- Badge uses a plain 45s interval poll, not the SSE + BroadcastChannel-leader system used for channel unread counts (marked with a `ponytail:` comment).
- Explicit "mark all as read"; no per-row read-on-click, no realtime inbox SSE.
- `message`/`linkPath` are point-in-time (won't retro-update if an event title later changes).
- Mention matching mirrors the UI's `@\w+` (usernames with `-` are a pre-existing frontend limitation).

## Testing
- `bun run migrate` applies cleanly; `bun run lint` and `format:check` pass; `tsc` clean for all new/changed files (the only `tsc` errors are pre-existing `astro:*` virtual-module resolution, unrelated).
- **DB-layer write-path test passed**: with prior commenters B and C, A commenting `@bob …` produced exactly — A: none (self-excluded), bob: one `mention` (dedup wins over reply), carol: one `comment_reply`.
- Full UI/e2e (dev server, two users, alert firing) is **manual** — the dev server needs Node ≥18.20.8, which isn't available in my environment. Suggested manual checks: reply/mention/alert each generate a notification, links land correctly, and "mark all as read" zeroes the badge.