### PR TITLE
feat: stream reaction updates via SSE

### DIFF
--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -22,7 +22,13 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
+import {
+  EmojiPicker,
+  ReactionBar,
+  postReaction,
+  applyToggle,
+  useReactionStream,
+} from "./event-reactions";
 
 // Only http(s) so a tag value like `javascript:…` can never become a clickable link.
 function httpUrl(value: string | number | boolean): string | null {
@@ -83,6 +89,10 @@ export default function EventDetail({
     const updated = await postReaction(event.id, emoji);
     if (updated) setReactions((prev) => applyToggle(prev, updated));
   };
+
+  // Live-update reactions as other users react. Merges are idempotent, so this
+  // also reconciles the actor's own optimistic update above.
+  useReactionStream(event.id, (updated) => setReactions((prev) => applyToggle(prev, updated)));
 
   const handleBookmark = async () => {
     setBookmarking(true);

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -1,6 +1,6 @@
 import type { ReactionSummary } from "@/lib/beaver/event";
 import type { EmojiMartData } from "@emoji-mart/data";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import emojiData from "@emoji-mart/data";
 import { Input } from "./ui/input";
@@ -51,6 +51,24 @@ export function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): 
   const filtered = prev.filter((r) => r.emoji !== updated.emoji);
   if (updated.count === 0) return filtered;
   return [...filtered, updated];
+}
+
+// Subscribe to live reaction updates for an event. The server personalizes
+// `userReacted` per viewer, so merging each frame with applyToggle is enough.
+export function useReactionStream(eventId: number, onUpdate: (r: ReactionSummary) => void) {
+  const cbRef = useRef(onUpdate);
+  cbRef.current = onUpdate;
+  useEffect(() => {
+    const es = new EventSource(`/api/events/${eventId}/reactions/stream`);
+    es.onmessage = (e) => {
+      try {
+        cbRef.current(JSON.parse(e.data) as ReactionSummary);
+      } catch {
+        // ignore malformed frames
+      }
+    };
+    return () => es.close();
+  }, [eventId]);
 }
 
 export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {

--- a/src/lib/beaver/reaction-bus.ts
+++ b/src/lib/beaver/reaction-bus.ts
@@ -1,0 +1,29 @@
+// In-process pub/sub for reaction updates, mirroring comment-bus. Carries the
+// full reactor set for an emoji so each SSE connection can personalize
+// `userReacted` for its own viewer before sending.
+export type ReactionBusMessage = {
+  eventId: number;
+  emoji: string;
+  count: number;
+  users: string[]; // reactor userNames
+  reactorIds: number[]; // reactor userIds — used to personalize userReacted per viewer
+};
+
+type Subscriber = (msg: ReactionBusMessage) => void;
+
+const subscribers = new Set<Subscriber>();
+
+export function publishReaction(msg: ReactionBusMessage): void {
+  for (const sub of subscribers) {
+    try {
+      sub(msg);
+    } catch (err) {
+      console.error("reaction-bus subscriber threw:", err);
+    }
+  }
+}
+
+export function subscribeReactions(fn: Subscriber): () => void {
+  subscribers.add(fn);
+  return () => subscribers.delete(fn);
+}

--- a/src/lib/beaver/reaction.ts
+++ b/src/lib/beaver/reaction.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventReactions, users } from "../db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import type { ReactionSummary } from "./event";
+import { publishReaction } from "./reaction-bus";
 
 export async function toggleReaction(
   userId: number,
@@ -31,6 +32,15 @@ export async function toggleReaction(
     .from(eventReactions)
     .innerJoin(users, eq(eventReactions.userId, users.id))
     .where(and(eq(eventReactions.eventId, eventId), eq(eventReactions.emoji, emoji)));
+
+  // Broadcast the full reactor set; each SSE connection personalizes userReacted.
+  publishReaction({
+    eventId,
+    emoji,
+    count: reactors.length,
+    users: reactors.map((r) => r.userName),
+    reactorIds: reactors.map((r) => r.userId),
+  });
 
   return {
     emoji,

--- a/src/pages/api/events/[eventID]/reactions/stream.ts
+++ b/src/pages/api/events/[eventID]/reactions/stream.ts
@@ -1,0 +1,76 @@
+import { subscribeReactions } from "@/lib/beaver/reaction-bus";
+import { canAccessProject, forbidden, projectIdForEvent } from "@/lib/beaver/authz";
+import type { APIContext } from "astro";
+
+const KEEPALIVE_MS = 15000;
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export async function GET({ params, locals }: APIContext) {
+  const user = locals.user;
+  if (!user) return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+
+  const eventId = parseInt(params.eventID!);
+
+  const projectId = await projectIdForEvent(eventId);
+  if (projectId === null || !(await canAccessProject(user, projectId))) return forbidden();
+
+  const encoder = new TextEncoder();
+
+  let unsubscribe: (() => void) | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  function cleanup() {
+    closed = true;
+    unsubscribe?.();
+    unsubscribe = null;
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(": ok\n\n"));
+
+      unsubscribe = subscribeReactions((msg) => {
+        if (msg.eventId !== eventId || closed) return;
+        // Personalize userReacted for this connection's viewer.
+        const summary = {
+          emoji: msg.emoji,
+          count: msg.count,
+          userReacted: msg.reactorIds.includes(user.id),
+          users: msg.users,
+        };
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(summary)}\n\n`));
+        } catch {
+          cleanup();
+        }
+      });
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(": keepalive\n\n"));
+        } catch {
+          cleanup();
+        }
+      }, KEEPALIVE_MS);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+
+export const prerender = false;


### PR DESCRIPTION
Closes #237. Targets the `v2.2.0` release branch.

## What

Reactions on the **event detail** page now update live for all viewers — no refresh needed. Mirrors the existing comment SSE stream.

## How
- **`reaction-bus.ts`** — in-process pub/sub (same shape as `comment-bus.ts`). The message carries the full reactor set (`count`, `users`, `reactorIds`).
- **`toggleReaction`** publishes to the bus after recomputing the emoji's reactors.
- **`/api/events/[eventID]/reactions/stream.ts`** — SSE endpoint mirroring `comments/stream.ts`, but it **personalizes `userReacted` per connection** (`reactorIds.includes(viewer.id)`) before sending, since that field is viewer-specific.
- **`useReactionStream`** hook (in `event-reactions.tsx`) subscribes and merges each frame via the existing `applyToggle` (which already drops an emoji at count 0). Wired into `event-detail.tsx`; merges are idempotent so they reconcile the actor's own optimistic update too.

## Scope
Scoped to the event **detail** page, matching the comments precedent. Feed cards (`event-card.tsx`) also show reactions but aren't streamed — a virtualized list would open dozens of `EventSource` connections; the feed already refreshes. Can revisit with a channel-level stream if wanted.

## Testing
- `tsc` clean for all changed files (only the pre-existing `astro:*` env errors remain); `lint` + `format:check` pass.
- **DB-layer test passed**: subscribing to the bus and calling `toggleReaction` published `count:1, reactorIds:[1]`; personalization gave the reactor `userReacted:true` and a non-reactor `false`; untoggling published `count:0` (client drops the emoji).
- Full two-browser live-update check is **manual** (dev server needs Node ≥18.20.8, unavailable here): open an event in two sessions, react in one, confirm the other updates without refresh.