### PR TITLE
feat: email notifications for event comments

### DIFF
--- a/src/lib/beaver/comment-email.ts
+++ b/src/lib/beaver/comment-email.ts
@@ -1,0 +1,82 @@
+import { db } from "../db/db";
+import { events, channels, projects, projectMembers, eventComments, users } from "../db/schema";
+import { and, eq, ne } from "drizzle-orm";
+import { sendCommentNotification } from "../email/send";
+
+const uniq = (emails: string[]) => [...new Set(emails)];
+
+// Email the people relevant to a new comment: @mentioned project members and
+// prior participants in the same thread. Mirrors the in-app recipient model
+// (see notification.ts if present); mentions win over replies. Best-effort —
+// callers should not let email failures affect commenting.
+export async function notifyCommentByEmail(opts: {
+  eventId: number;
+  actorId: number;
+  actorName: string;
+  body: string;
+}): Promise<void> {
+  const { eventId, actorId, actorName, body } = opts;
+
+  const [ctx] = await db
+    .select({
+      projectId: events.projectId,
+      title: events.title,
+      channelName: channels.name,
+      projectName: projects.name,
+    })
+    .from(events)
+    .innerJoin(channels, eq(events.channelId, channels.id))
+    .innerJoin(projects, eq(events.projectId, projects.id))
+    .where(eq(events.id, eventId));
+  if (!ctx) return;
+
+  // Mentions — @handle tokens (mirrors the UI's @\w+) resolved to project members.
+  const handles = new Set(Array.from(body.matchAll(/@(\w+)/g)).map((m) => m[1].toLowerCase()));
+  const mentionedIds = new Set<number>();
+  const mentionEmails: string[] = [];
+  if (handles.size > 0) {
+    const members = await db
+      .select({ userId: projectMembers.userId, userName: users.userName, email: users.email })
+      .from(projectMembers)
+      .innerJoin(users, eq(projectMembers.userId, users.id))
+      .where(eq(projectMembers.projectId, ctx.projectId));
+    for (const m of members) {
+      if (m.userId !== actorId && m.email && handles.has(m.userName.toLowerCase())) {
+        mentionedIds.add(m.userId);
+        mentionEmails.push(m.email);
+      }
+    }
+  }
+
+  // Thread participants — anyone else who has commented on this event (excluding
+  // the actor and anyone already emailed as a mention).
+  const commenters = await db
+    .selectDistinct({ userId: eventComments.userId, email: users.email })
+    .from(eventComments)
+    .innerJoin(users, eq(eventComments.userId, users.id))
+    .where(and(eq(eventComments.eventId, eventId), ne(eventComments.userId, actorId)));
+  const replyEmails = commenters
+    .filter((c) => c.email && !mentionedIds.has(c.userId))
+    .map((c) => c.email as string);
+
+  // ponytail: optional absolute link for the "View thread" button; omitted if
+  // PUBLIC_APP_URL isn't set (matches the app's other emails, which don't link).
+  const base = process.env.PUBLIC_APP_URL?.replace(/\/$/, "");
+  const eventUrl = base ? `${base}/dashboard/${ctx.projectId}/events/${eventId}` : null;
+
+  const common = {
+    actorName,
+    eventTitle: ctx.title,
+    channelName: ctx.channelName,
+    projectName: ctx.projectName,
+    commentBody: body,
+    eventUrl,
+  };
+
+  if (mentionEmails.length > 0) {
+    await sendCommentNotification({ ...common, reason: "mention" }, uniq(mentionEmails));
+  }
+  if (replyEmails.length > 0) {
+    await sendCommentNotification({ ...common, reason: "reply" }, uniq(replyEmails));
+  }
+}

--- a/src/lib/beaver/comment.ts
+++ b/src/lib/beaver/comment.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventComments, users } from "../db/schema";
 import { eq, asc } from "drizzle-orm";
 import { publishComment, type Comment } from "./comment-bus";
+import { notifyCommentByEmail } from "./comment-email";
 
 export type { Comment };
 
@@ -45,6 +46,15 @@ export async function createComment(
 
   const comment = withUser as Comment;
   publishComment({ eventId, comment });
+
+  // Best-effort: email @mentioned members and prior thread participants. Never
+  // let an email failure break commenting.
+  try {
+    await notifyCommentByEmail({ eventId, actorId: userId, actorName: comment.userName, body });
+  } catch (err) {
+    console.error("Failed to send comment notification emails:", err);
+  }
+
   return comment;
 }
 

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,6 +1,12 @@
 import { Resend } from "resend";
 import type { EventWithChannelName } from "../beaver/event";
-import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
+import {
+  buildEmailHtml,
+  buildAlertEmailHtml,
+  buildCommentEmailHtml,
+  type AlertEmailParams,
+  type CommentEmailParams,
+} from "./template";
 
 const apiKey = process.env.RESEND_API_KEY;
 const fromEmail = process.env.RESEND_FROM_EMAIL ?? "notifications@beaver.app";
@@ -35,6 +41,27 @@ export async function sendAlertEmail(
     to: recipientEmails,
     subject: `🚨 ${params.ruleName} — ${params.projectName}`,
     html: buildAlertEmailHtml(params),
+  });
+}
+
+export async function sendCommentNotification(
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!apiKey || recipientEmails.length === 0) return;
+
+  const resend = new Resend(apiKey);
+
+  const subject =
+    params.reason === "mention"
+      ? `${params.actorName} mentioned you — ${params.projectName}`
+      : `${params.actorName} replied on ${params.eventTitle} — ${params.projectName}`;
+
+  await resend.emails.send({
+    from: fromEmail,
+    to: recipientEmails,
+    subject,
+    html: buildCommentEmailHtml(params),
   });
 }
 

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -1,11 +1,12 @@
 import type { EventWithChannelName } from "../beaver/event";
 import { getEmailSettings } from "../beaver/email-settings";
-import type { AlertEmailParams } from "./template";
+import type { AlertEmailParams, CommentEmailParams } from "./template";
 import {
   sendEventNotification as sendViaResend,
   sendAlertEmail as sendAlertEmailViaResend,
+  sendCommentNotification as sendCommentViaResend,
 } from "./resend";
-import { sendEventNotificationSmtp, sendAlertEmailSmtp } from "./smtp";
+import { sendEventNotificationSmtp, sendAlertEmailSmtp, sendCommentNotificationSmtp } from "./smtp";
 
 export async function sendEventNotification(
   event: EventWithChannelName,
@@ -34,4 +35,18 @@ export async function sendAlertEmail(
   }
 
   await sendAlertEmailViaResend(params, recipientEmails);
+}
+
+export async function sendCommentNotification(
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  const settings = await getEmailSettings();
+
+  if (settings?.provider === "smtp") {
+    await sendCommentNotificationSmtp(settings, params, recipientEmails);
+    return;
+  }
+
+  await sendCommentViaResend(params, recipientEmails);
 }

--- a/src/lib/email/smtp.ts
+++ b/src/lib/email/smtp.ts
@@ -1,7 +1,13 @@
 import nodemailer from "nodemailer";
 import type { EventWithChannelName } from "../beaver/event";
 import type { EmailSettings } from "../beaver/email-settings";
-import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
+import {
+  buildEmailHtml,
+  buildAlertEmailHtml,
+  buildCommentEmailHtml,
+  type AlertEmailParams,
+  type CommentEmailParams,
+} from "./template";
 
 function buildTransport(settings: EmailSettings) {
   return nodemailer.createTransport({
@@ -46,6 +52,28 @@ export async function sendAlertEmailSmtp(
     to: recipientEmails,
     subject: `🚨 ${params.ruleName} — ${params.projectName}`,
     html: buildAlertEmailHtml(params),
+  });
+}
+
+export async function sendCommentNotificationSmtp(
+  settings: EmailSettings,
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!settings.smtpHost || !settings.smtpPort || recipientEmails.length === 0) return;
+
+  const transport = buildTransport(settings);
+
+  const subject =
+    params.reason === "mention"
+      ? `${params.actorName} mentioned you — ${params.projectName}`
+      : `${params.actorName} replied on ${params.eventTitle} — ${params.projectName}`;
+
+  await transport.sendMail({
+    from: settings.smtpFromEmail ?? "notifications@beaver.app",
+    to: recipientEmails,
+    subject,
+    html: buildCommentEmailHtml(params),
   });
 }
 

--- a/src/lib/email/template.ts
+++ b/src/lib/email/template.ts
@@ -159,3 +159,83 @@ export function buildAlertEmailHtml(params: AlertEmailParams): string {
 </body>
 </html>`;
 }
+
+export type CommentEmailParams = {
+  actorName: string;
+  reason: "mention" | "reply";
+  eventTitle: string;
+  channelName: string;
+  projectName: string;
+  commentBody: string;
+  eventUrl?: string | null;
+};
+
+// Comment bodies (and, defensively, other fields) are user input rendered into
+// HTML email, so escape before interpolation.
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function buildCommentEmailHtml(params: CommentEmailParams): string {
+  const headline =
+    params.reason === "mention"
+      ? `${esc(params.actorName)} mentioned you`
+      : `${esc(params.actorName)} replied on a thread you’re in`;
+
+  const buttonHtml = params.eventUrl
+    ? `<a href="${esc(params.eventUrl)}" style="display:inline-block;margin-top:20px;background:#171717;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:10px 18px;border-radius:8px;">View thread</a>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${headline}</title>
+</head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#171717;padding:24px 32px;border-radius:12px 12px 0 0;">
+              <p style="margin:0;font-size:13px;font-weight:600;color:#a1a1aa;letter-spacing:0.08em;text-transform:uppercase;">Beaver</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#71717a;">
+                ${esc(params.projectName)} &middot; #${esc(params.channelName)}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background:#ffffff;padding:32px;border-left:1px solid #e5e7eb;border-right:1px solid #e5e7eb;">
+              <h1 style="margin:0;font-size:20px;font-weight:700;color:#111827;line-height:1.3;">${headline}</h1>
+              <p style="margin:6px 0 0;font-size:14px;color:#6b7280;">on <strong style="color:#374151;">${esc(params.eventTitle)}</strong></p>
+              <div style="margin:20px 0 0;padding:16px;background:#f9fafb;border-left:3px solid #d4d4d8;border-radius:4px;font-size:15px;color:#374151;line-height:1.6;white-space:pre-wrap;">${esc(params.commentBody)}</div>
+              ${buttonHtml}
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f4f4f5;padding:20px 32px;border-radius:0 0 12px 12px;border:1px solid #e5e7eb;border-top:none;">
+              <p style="margin:0;font-size:12px;color:#9ca3af;line-height:1.6;">
+                You're receiving this because you were mentioned in or have participated in this thread.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}


### PR DESCRIPTION
Closes #238. Targets the `v2.2.0` release branch.

## What
When someone comments, email the relevant people:
- **@mentioned** project members → a "mentioned you" email.
- **Prior thread participants** (users who already commented on that event) → a "replied on a thread you're in" email.

Sent best-effort from `createComment`, so an email failure never breaks commenting.

## How
- New comment email across the existing provider layers, mirroring the alert-email triad: `buildCommentEmailHtml` (`template.ts`), `sendCommentNotification` in `resend.ts` / `smtp.ts`, and the provider-selecting `sendCommentNotification` in `send.ts`.
- `comment-email.ts` resolves recipients (mentions vs thread, deduped, actor excluded, mention wins) and sends the two variants. Only users with an email address are contacted.
- **Security:** the comment body (user input) is HTML-escaped before going into the email template.
- **Link:** optional `PUBLIC_APP_URL` env adds a "View thread" button; omitted gracefully if unset (matches the app's other emails, which don't link).

## Notes for review
- **Overlaps #261.** The recipient model (mentions + thread participants) is intentionally the same as the in-app notifications PR. I kept this PR independent of #261 (self-contained `comment-email.ts`) so they can merge in any order; once both land, the recipient resolution could be unified into one shared helper. Both touch the same spot in `createComment`, so expect a trivial merge conflict there (two adjacent best-effort calls).
- "Respect settings" is interpreted as: only users with an email, only when a provider is configured (the send functions no-op otherwise). Mentions/thread participation are themselves the opt-in signal, per the issue's "thread subscription model" — I did not additionally gate on channel subscription. Easy to add if you'd prefer that.

## Testing
- tsc clean for all changed files (only the pre-existing `astro:*` env errors remain); lint + format pass.
- **DB-layer test passed**: with a thread where bob & carol previously commented, alice commenting `@bob …` resolved to — mention email → bob, reply email → carol (bob excluded from reply as already-mentioned, alice excluded as actor). `notifyCommentByEmail` also runs clean and no-ops when no provider is configured.
- Actual email delivery is **manual** (needs a configured Resend/SMTP provider + running app on Node ≥18.20.8, unavailable here).