### PR TITLE
fix: unread fetch fires twice on page load

### DIFF
--- a/src/components/unread-counts-poller.tsx
+++ b/src/components/unread-counts-poller.tsx
@@ -17,6 +17,11 @@ export default function UnreadCountsPoller({
   const isLeader = useTabLeader(`unread:${projectId}`);
   const channelsRef = useRef(initialChannels);
   const countsRef = useRef<Record<number, number>>({});
+  // Tracks which project we've already done the initial /api/unread fetch for.
+  // The main effect re-runs when isLeader flips false→true on mount, which would
+  // otherwise fire the initial fetch twice (once per branch); this keys it to
+  // projectId so it happens once per project but still refetches on navigation.
+  const initialFetchedFor = useRef<number | null>(null);
 
   // Sync channels list as channels are added/removed
   useEffect(() => {
@@ -80,7 +85,10 @@ export default function UnreadCountsPoller({
       };
 
       const start = async () => {
-        await fetchUnread();
+        if (initialFetchedFor.current !== projectId) {
+          initialFetchedFor.current = projectId;
+          await fetchUnread();
+        }
         resync = setInterval(fetchUnread, 60_000);
 
         let maxId = 0;
@@ -108,15 +116,18 @@ export default function UnreadCountsPoller({
 
       start();
     } else {
-      fetch(`/api/unread?projectId=${projectId}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          if (data) {
-            countsRef.current = data.counts;
-            dispatch(data.counts);
-          }
-        })
-        .catch(() => {});
+      if (initialFetchedFor.current !== projectId) {
+        initialFetchedFor.current = projectId;
+        fetch(`/api/unread?projectId=${projectId}`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => {
+            if (data) {
+              countsRef.current = data.counts;
+              dispatch(data.counts);
+            }
+          })
+          .catch(() => {});
+      }
 
       bc.onmessage = (e: MessageEvent) => {
         if (e.data.type === "unread-snapshot") {


### PR DESCRIPTION
Closes #184. Targets the `v2.2.0` release branch.

## Root cause (updated from the issue)

The issue points at `side-panel.tsx:718`, but that code was refactored into `unread-counts-poller.tsx` since #184 was filed, and the real cause isn't React StrictMode — it's leader election:

`useTabLeader` returns `isLeader` starting at `false`, and the poller's main effect has deps `[projectId, isLeader]`. On mount the effect runs once as **non-leader** (fires `GET /api/unread`), then `useTabLeader` claims leadership → `setIsLeader(true)` → the effect tears down and re-runs as **leader** (fires `GET /api/unread` again). Two back-to-back requests, exactly as reported.

## Fix

Guard the *initial* fetch with a `projectId`-keyed ref (`initialFetchedFor`) so it runs once per project regardless of the `isLeader` transition. The leader branch still sets up its 60s interval + SSE; it just skips the redundant immediate fetch when the initial one already happened. Because the ref is keyed to `projectId` (and not reset in cleanup), navigating to a different project still refetches, and React StrictMode's dev double-invoke is deduped too.

## Testing

- tsc clean for the changed file (only pre-existing `astro:*` env errors remain); lint + format pass.
- The actual "one request on load" behavior is **manual** — it needs `bun run dev` + DevTools Network (per the issue's repro), and the dev server needs Node ≥18.20.8 which isn't available in my environment. Traced the effect/leader-election timing by hand; the guard makes the initial fetch fire exactly once per project.