### PR TITLE
feat: release v2.2.0

### DIFF
--- a/drizzle/0024_nifty_centennial.sql
+++ b/drizzle/0024_nifty_centennial.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `notifications` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`user_id` integer NOT NULL,
+	`project_id` integer NOT NULL,
+	`type` text NOT NULL,
+	`message` text NOT NULL,
+	`link_path` text NOT NULL,
+	`read_at` integer,
+	`created_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `notifications_user_project_created_idx` ON `notifications` (`user_id`,`project_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `notifications_user_project_read_idx` ON `notifications` (`user_id`,`project_id`,`read_at`);

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,1602 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "89d6f14c-ea03-4c4b-9ede-341798cf50b4",
+  "prevId": "924b330c-34ab-4796-874d-1461982bf199",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_comments": {
+      "name": "event_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_comments_event_id_events_id_fk": {
+          "name": "event_comments_event_id_events_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_comments_user_id_users_id_fk": {
+          "name": "event_comments_user_id_users_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_reactions": {
+      "name": "event_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_reactions_event_user_emoji_idx": {
+          "name": "event_reactions_event_user_emoji_idx",
+          "columns": ["event_id", "user_id", "emoji"],
+          "isUnique": true
+        },
+        "event_reactions_event_id_idx": {
+          "name": "event_reactions_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_reactions_event_id_events_id_fk": {
+          "name": "event_reactions_event_id_events_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reactions_user_id_users_id_fk": {
+          "name": "event_reactions_user_id_users_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_path": {
+          "name": "link_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "notifications_user_project_created_idx": {
+          "name": "notifications_user_project_created_idx",
+          "columns": ["user_id", "project_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_user_project_read_idx": {
+          "name": "notifications_user_project_read_idx",
+          "columns": ["user_id", "project_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_project_id_projects_id_fk": {
+          "name": "notifications_project_id_projects_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_per_minute": {
+          "name": "rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_views": {
+      "name": "saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_views_project_id_projects_id_fk": {
+          "name": "saved_views_project_id_projects_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_views_user_id_users_id_fk": {
+          "name": "saved_views_user_id_users_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compact_mode": {
+          "name": "compact_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "theme_palette": {
+          "name": "theme_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1782100000000,
       "tag": "0023_theme_palette",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1783369363306,
+      "tag": "0024_nifty_centennial",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beaver",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "type": "module",
   "scripts": {
     "format": "bun oxfmt",

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -22,7 +22,13 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
-import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
+import {
+  EmojiPicker,
+  ReactionBar,
+  postReaction,
+  applyToggle,
+  useReactionStream,
+} from "./event-reactions";
 
 // Only http(s) so a tag value like `javascript:…` can never become a clickable link.
 function httpUrl(value: string | number | boolean): string | null {
@@ -83,6 +89,10 @@ export default function EventDetail({
     const updated = await postReaction(event.id, emoji);
     if (updated) setReactions((prev) => applyToggle(prev, updated));
   };
+
+  // Live-update reactions as other users react. Merges are idempotent, so this
+  // also reconciles the actor's own optimistic update above.
+  useReactionStream(event.id, (updated) => setReactions((prev) => applyToggle(prev, updated)));
 
   const handleBookmark = async () => {
     setBookmarking(true);

--- a/src/components/event-detail.tsx
+++ b/src/components/event-detail.tsx
@@ -24,14 +24,38 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { EmojiPicker, ReactionBar, postReaction, applyToggle } from "./event-reactions";
 
+// Only http(s) so a tag value like `javascript:…` can never become a clickable link.
+function httpUrl(value: string | number | boolean): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:" ? u.href : null;
+  } catch {
+    return null;
+  }
+}
+
 function TagBadge({ tagKey, value }: { tagKey: string; value: string | number | boolean }) {
   const displayValue = typeof value === "boolean" ? (value ? "true" : "false") : String(value);
+  const url = httpUrl(value);
 
   return (
     <div className="inline-flex items-center gap-1.5 rounded-md bg-gray-100 dark:bg-white/10 px-2.5 py-1 text-sm">
       <span className="font-medium text-foreground/75">{tagKey}</span>
       <span className="text-muted-foreground">=</span>
-      <span className="text-foreground">{displayValue}</span>
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-primary underline underline-offset-2 hover:opacity-80 break-all"
+        >
+          <LinkIcon size={12} className="shrink-0" />
+          {displayValue}
+        </a>
+      ) : (
+        <span className="text-foreground">{displayValue}</span>
+      )}
     </div>
   );
 }

--- a/src/components/event-reactions.tsx
+++ b/src/components/event-reactions.tsx
@@ -1,6 +1,6 @@
 import type { ReactionSummary } from "@/lib/beaver/event";
 import type { EmojiMartData } from "@emoji-mart/data";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import emojiData from "@emoji-mart/data";
 import { Input } from "./ui/input";
@@ -51,6 +51,24 @@ export function applyToggle(prev: ReactionSummary[], updated: ReactionSummary): 
   const filtered = prev.filter((r) => r.emoji !== updated.emoji);
   if (updated.count === 0) return filtered;
   return [...filtered, updated];
+}
+
+// Subscribe to live reaction updates for an event. The server personalizes
+// `userReacted` per viewer, so merging each frame with applyToggle is enough.
+export function useReactionStream(eventId: number, onUpdate: (r: ReactionSummary) => void) {
+  const cbRef = useRef(onUpdate);
+  cbRef.current = onUpdate;
+  useEffect(() => {
+    const es = new EventSource(`/api/events/${eventId}/reactions/stream`);
+    es.onmessage = (e) => {
+      try {
+        cbRef.current(JSON.parse(e.data) as ReactionSummary);
+      } catch {
+        // ignore malformed frames
+      }
+    };
+    return () => es.close();
+  }, [eventId]);
 }
 
 export function EmojiPicker({ onSelect }: { onSelect: (emoji: string) => void }) {

--- a/src/components/metric-detail.tsx
+++ b/src/components/metric-detail.tsx
@@ -7,16 +7,7 @@ import { Label } from "./ui/label";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "./ui/dialog";
 import { DatePicker } from "./ui/date-picker";
 import { ArrowLeftIcon, PencilIcon, Trash2Icon } from "lucide-react";
-import {
-  formatDistanceToNow,
-  format,
-  subDays,
-  startOfDay,
-  startOfHour,
-  startOfWeek,
-  differenceInHours,
-  differenceInDays,
-} from "date-fns";
+import { formatDistanceToNow, format, subDays, startOfDay, differenceInHours } from "date-fns";
 
 // ── Types ──────────────────────────────────────────────────────────────────────
 
@@ -31,7 +22,6 @@ type SerializedValue = Omit<MetricValue, "timestamp" | "createdAt"> & {
 };
 
 type Range = "today" | "7d" | "30d" | "custom";
-type BucketGranularity = "hour" | "day" | "week";
 
 // ── Helpers ────────────────────────────────────────────────────────────────────
 
@@ -45,39 +35,6 @@ function getRangeDates(range: Range, customFrom?: Date, customTo?: Date): { from
   if (range === "7d") return { from: subDays(now, 7), to: now };
   if (range === "30d") return { from: subDays(now, 30), to: now };
   return { from: customFrom ?? subDays(now, 30), to: customTo ?? now };
-}
-
-function getBucketGranularity(from: Date, to: Date): BucketGranularity {
-  const days = differenceInDays(to, from);
-  if (days <= 2) return "hour";
-  if (days <= 60) return "day";
-  return "week";
-}
-
-function bucketLabel(d: Date, granularity: BucketGranularity): string {
-  if (granularity === "hour") return format(startOfHour(d), "MM/dd HH:mm");
-  if (granularity === "day") return format(d, "MM/dd");
-  return format(startOfWeek(d), "MM/dd");
-}
-
-function bucketValues(
-  values: { value: number; timestamp: Date }[],
-  granularity: BucketGranularity,
-  mode: "sum" | "avg" = "sum",
-): { label: string; value: number }[] {
-  const sums = new Map<string, number>();
-  const counts = new Map<string, number>();
-  for (const v of values) {
-    const key = bucketLabel(v.timestamp, granularity);
-    sums.set(key, (sums.get(key) ?? 0) + v.value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return Array.from(sums.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([label, sum]) => ({
-      label,
-      value: mode === "avg" ? Math.round((sum / (counts.get(label) ?? 1)) * 10) / 10 : sum,
-    }));
 }
 
 function formatValue(value: number | null, unit?: string | null): string {
@@ -535,13 +492,13 @@ export default function MetricDetail({
 
   // ── Derived chart data ────────────────────────────────────────────────────────
 
-  const { from: rangeFrom, to: rangeTo } = getRangeDates(range, customFrom, customTo);
-  const granularity = getBucketGranularity(rangeFrom, rangeTo);
-
   const isBarChart = metric.chartType === "bar";
-  const timeseriesData = isBarChart
-    ? bucketValues(values, granularity, "avg")
-    : values.map((v) => ({ label: format(v.timestamp, "MM/dd HH:mm"), value: v.value }));
+  // Every posted value is its own point/bar (#248): no day-bucketing, so dozens
+  // of same-day instances stay visible instead of collapsing into one.
+  const timeseriesData = values.map((v) => ({
+    label: format(v.timestamp, "MM/dd HH:mm"),
+    value: v.value,
+  }));
 
   const stats =
     values.length > 0

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -4,6 +4,7 @@ import type { Project } from "@/lib/beaver/project";
 import { MenuIcon, XIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import ChannelGroupsDnd from "./channel-groups-dnd";
+import NotificationsNavLink from "./notifications-nav-link";
 import ProjectSwitcher from "./project-switcher";
 import SidePanelNav from "./side-panel-nav";
 import ThemeToggle from "./theme-toggle";
@@ -113,6 +114,7 @@ export default function MobileDrawer({
           isAdmin={isAdmin}
           onNavigate={close}
         />
+        <NotificationsNavLink projectId={project.id} pathname={pathname} onNavigate={close} />
         <ChannelGroupsDnd
           initialUngrouped={ungroupedChannels}
           initialGroups={groups}

--- a/src/components/notifications-nav-link.tsx
+++ b/src/components/notifications-nav-link.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { BellIcon } from "lucide-react";
+
+// Matches the nav link styling in side-panel-nav.tsx (plus justify-between for the badge).
+const navCss =
+  "flex px-3 py-2 items-center justify-between hover:bg-gray-100 dark:hover:bg-white/8 hover:cursor-pointer hover:font-medium rounded ";
+const activeNavCss = navCss + "bg-gray-100 dark:bg-white/8 font-medium";
+
+export default function NotificationsNavLink({
+  projectId,
+  pathname,
+  onNavigate,
+}: {
+  projectId: number;
+  pathname: string;
+  onNavigate?: () => void;
+}) {
+  const [count, setCount] = useState(0);
+  const href = `/dashboard/${projectId}/notifications`;
+  const isActive = pathname === href;
+
+  // ponytail: plain interval poll, not the SSE + BroadcastChannel-leader setup
+  // used for channel unread counts. Upgrade only if the extra requests matter.
+  useEffect(() => {
+    let cancelled = false;
+    const fetchCount = async () => {
+      try {
+        const res = await fetch(`/api/notifications/unread-count?projectId=${projectId}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (!cancelled) setCount(data.count ?? 0);
+      } catch {
+        // ignore
+      }
+    };
+    fetchCount();
+    const interval = setInterval(fetchCount, 45_000);
+    const onUpdated = (e: Event) => {
+      const detail = (e as CustomEvent<{ count?: number }>).detail;
+      if (detail && typeof detail.count === "number") setCount(detail.count);
+      else fetchCount();
+    };
+    window.addEventListener("notifications:updated", onUpdated);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+      window.removeEventListener("notifications:updated", onUpdated);
+    };
+  }, [projectId]);
+
+  return (
+    <a href={href} onClick={() => onNavigate?.()} className={isActive ? activeNavCss : navCss}>
+      <span className="flex items-center space-x-2">
+        <BellIcon size={20} />
+        <span>Notifications</span>
+      </span>
+      {count > 0 && (
+        <span className="ml-2 shrink-0 text-xs font-semibold bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center leading-tight">
+          {count > 99 ? "99+" : count}
+        </span>
+      )}
+    </a>
+  );
+}

--- a/src/components/notifications-view.tsx
+++ b/src/components/notifications-view.tsx
@@ -1,0 +1,113 @@
+import { useState } from "react";
+import { AtSignIcon, MessageSquareIcon, TriangleAlertIcon, CheckCheckIcon } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { Button } from "./ui/button";
+import type { NotificationType } from "@/lib/beaver/notification";
+
+type SerializedNotification = {
+  id: number;
+  type: NotificationType;
+  message: string;
+  linkPath: string;
+  readAt: string | null;
+  createdAt: string;
+};
+
+const ICONS: Record<NotificationType, typeof AtSignIcon> = {
+  mention: AtSignIcon,
+  comment_reply: MessageSquareIcon,
+  alert: TriangleAlertIcon,
+};
+
+export default function NotificationsView({
+  projectId,
+  initialNotifications,
+}: {
+  projectId: number;
+  initialNotifications: SerializedNotification[];
+}) {
+  const [items, setItems] = useState(initialNotifications);
+  const [marking, setMarking] = useState(false);
+
+  const unreadCount = items.filter((n) => !n.readAt).length;
+
+  const handleMarkAllRead = async () => {
+    if (unreadCount === 0 || marking) return;
+    setMarking(true);
+    try {
+      const res = await fetch("/api/notifications/read", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ projectId }),
+      });
+      if (!res.ok) return;
+      const now = new Date().toISOString();
+      setItems((prev) => prev.map((n) => (n.readAt ? n : { ...n, readAt: now })));
+      window.dispatchEvent(new CustomEvent("notifications:updated", { detail: { count: 0 } }));
+    } finally {
+      setMarking(false);
+    }
+  };
+
+  return (
+    <div className="px-4 md:px-8 py-4 md:py-8 w-full max-w-3xl">
+      <div className="flex items-center justify-between gap-4 mb-6">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-semibold">Notifications</h1>
+          {unreadCount > 0 && (
+            <span className="text-xs font-semibold bg-primary text-primary-foreground rounded-full px-2 py-0.5 tabular-nums">
+              {unreadCount}
+            </span>
+          )}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleMarkAllRead}
+          disabled={unreadCount === 0 || marking}
+          title="Mark all as read"
+        >
+          <CheckCheckIcon className="size-4 mr-2" />
+          Mark all as read
+        </Button>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="text-center pt-16">
+          <h2 className="text-xl">You&rsquo;re all caught up 🎉</h2>
+          <p className="text-muted-foreground mt-2">No notifications yet.</p>
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {items.map((n) => {
+            const Icon = ICONS[n.type];
+            const unread = !n.readAt;
+            return (
+              <li key={n.id}>
+                <a
+                  href={n.linkPath}
+                  className={`flex items-start gap-3 rounded-md px-3 py-3 transition-colors hover:bg-muted ${
+                    unread ? "bg-primary/5" : ""
+                  }`}
+                >
+                  <Icon
+                    className={`size-4 mt-0.5 shrink-0 ${unread ? "text-primary" : "text-muted-foreground"}`}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className={`text-sm break-words ${unread ? "font-medium" : ""}`}>
+                      {n.message}
+                    </p>
+                    <span className="text-xs text-muted-foreground">
+                      {formatDistanceToNow(new Date(n.createdAt), { addSuffix: true })}
+                    </span>
+                  </div>
+                  {unread && <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" />}
+                </a>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/side-panel.astro
+++ b/src/components/side-panel.astro
@@ -5,6 +5,7 @@ import type { Project } from "@/lib/beaver/project";
 import ChannelGroupsDnd from "./channel-groups-dnd";
 import MobileDrawer from "./mobile-drawer";
 import ProjectSwitcher from "./project-switcher";
+import NotificationsNavLink from "./notifications-nav-link";
 import SidePanelNav from "./side-panel-nav";
 import ThemeToggle from "./theme-toggle";
 import UnreadCountsPoller from "./unread-counts-poller";
@@ -81,6 +82,7 @@ const ungroupedChannels = channels.filter((c) => !c.groupId);
     userRole={userRole}
     isAdmin={isAdmin}
   />
+  <NotificationsNavLink client:idle projectId={project.id} pathname={currentPath} />
   <ChannelGroupsDnd
     client:idle
     initialUngrouped={ungroupedChannels}

--- a/src/components/unread-counts-poller.tsx
+++ b/src/components/unread-counts-poller.tsx
@@ -17,6 +17,11 @@ export default function UnreadCountsPoller({
   const isLeader = useTabLeader(`unread:${projectId}`);
   const channelsRef = useRef(initialChannels);
   const countsRef = useRef<Record<number, number>>({});
+  // Tracks which project we've already done the initial /api/unread fetch for.
+  // The main effect re-runs when isLeader flips false→true on mount, which would
+  // otherwise fire the initial fetch twice (once per branch); this keys it to
+  // projectId so it happens once per project but still refetches on navigation.
+  const initialFetchedFor = useRef<number | null>(null);
 
   // Sync channels list as channels are added/removed
   useEffect(() => {
@@ -80,7 +85,10 @@ export default function UnreadCountsPoller({
       };
 
       const start = async () => {
-        await fetchUnread();
+        if (initialFetchedFor.current !== projectId) {
+          initialFetchedFor.current = projectId;
+          await fetchUnread();
+        }
         resync = setInterval(fetchUnread, 60_000);
 
         let maxId = 0;
@@ -108,15 +116,18 @@ export default function UnreadCountsPoller({
 
       start();
     } else {
-      fetch(`/api/unread?projectId=${projectId}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((data) => {
-          if (data) {
-            countsRef.current = data.counts;
-            dispatch(data.counts);
-          }
-        })
-        .catch(() => {});
+      if (initialFetchedFor.current !== projectId) {
+        initialFetchedFor.current = projectId;
+        fetch(`/api/unread?projectId=${projectId}`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then((data) => {
+            if (data) {
+              countsRef.current = data.counts;
+              dispatch(data.counts);
+            }
+          })
+          .catch(() => {});
+      }
 
       bc.onmessage = (e: MessageEvent) => {
         if (e.data.type === "unread-snapshot") {

--- a/src/lib/beaver/alert-rule.ts
+++ b/src/lib/beaver/alert-rule.ts
@@ -3,7 +3,11 @@ import { alertRules, channels, events } from "../db/schema";
 import { eq, and, gt, gte, count } from "drizzle-orm";
 import type { Channel } from "./channel";
 import type { Project } from "./project";
-import { getNotificationEmailsForChannel } from "./channel-notification";
+import {
+  getNotificationEmailsForChannel,
+  getNotificationSubscriberIdsForChannel,
+} from "./channel-notification";
+import { createAlertNotifications } from "./notification";
 import { sendAlertEmail } from "../email/send";
 
 export type AlertRule = {
@@ -142,6 +146,18 @@ export async function checkAndDispatchAlerts(
   for (const rule of rules) {
     const matchedCount = await checkAlertRule(rule);
     if (matchedCount === null) continue;
+
+    // In-app notifications for every channel subscriber (independent of whether
+    // they have an email set).
+    await createAlertNotifications({
+      projectId: project.id,
+      channelId: channel.id,
+      channelName: channel.name,
+      ruleName: rule.name,
+      count: matchedCount,
+      windowMinutes: rule.windowMinutes,
+      recipientIds: await getNotificationSubscriberIdsForChannel(channel.id),
+    });
 
     const emails = await getNotificationEmailsForChannel(channel.id);
     if (emails.length === 0) continue;

--- a/src/lib/beaver/channel-notification.ts
+++ b/src/lib/beaver/channel-notification.ts
@@ -72,3 +72,12 @@ export async function getNotificationEmailsForChannel(channelId: number): Promis
 
   return rows.flatMap((r) => (r.email ? [r.email] : []));
 }
+
+export async function getNotificationSubscriberIdsForChannel(channelId: number): Promise<number[]> {
+  const rows = await db
+    .select({ userId: channelNotificationSubscriptions.userId })
+    .from(channelNotificationSubscriptions)
+    .where(eq(channelNotificationSubscriptions.channelId, channelId));
+
+  return rows.map((r) => r.userId);
+}

--- a/src/lib/beaver/comment-email.ts
+++ b/src/lib/beaver/comment-email.ts
@@ -1,0 +1,82 @@
+import { db } from "../db/db";
+import { events, channels, projects, projectMembers, eventComments, users } from "../db/schema";
+import { and, eq, ne } from "drizzle-orm";
+import { sendCommentNotification } from "../email/send";
+
+const uniq = (emails: string[]) => [...new Set(emails)];
+
+// Email the people relevant to a new comment: @mentioned project members and
+// prior participants in the same thread. Mirrors the in-app recipient model
+// (see notification.ts if present); mentions win over replies. Best-effort —
+// callers should not let email failures affect commenting.
+export async function notifyCommentByEmail(opts: {
+  eventId: number;
+  actorId: number;
+  actorName: string;
+  body: string;
+}): Promise<void> {
+  const { eventId, actorId, actorName, body } = opts;
+
+  const [ctx] = await db
+    .select({
+      projectId: events.projectId,
+      title: events.title,
+      channelName: channels.name,
+      projectName: projects.name,
+    })
+    .from(events)
+    .innerJoin(channels, eq(events.channelId, channels.id))
+    .innerJoin(projects, eq(events.projectId, projects.id))
+    .where(eq(events.id, eventId));
+  if (!ctx) return;
+
+  // Mentions — @handle tokens (mirrors the UI's @\w+) resolved to project members.
+  const handles = new Set(Array.from(body.matchAll(/@(\w+)/g)).map((m) => m[1].toLowerCase()));
+  const mentionedIds = new Set<number>();
+  const mentionEmails: string[] = [];
+  if (handles.size > 0) {
+    const members = await db
+      .select({ userId: projectMembers.userId, userName: users.userName, email: users.email })
+      .from(projectMembers)
+      .innerJoin(users, eq(projectMembers.userId, users.id))
+      .where(eq(projectMembers.projectId, ctx.projectId));
+    for (const m of members) {
+      if (m.userId !== actorId && m.email && handles.has(m.userName.toLowerCase())) {
+        mentionedIds.add(m.userId);
+        mentionEmails.push(m.email);
+      }
+    }
+  }
+
+  // Thread participants — anyone else who has commented on this event (excluding
+  // the actor and anyone already emailed as a mention).
+  const commenters = await db
+    .selectDistinct({ userId: eventComments.userId, email: users.email })
+    .from(eventComments)
+    .innerJoin(users, eq(eventComments.userId, users.id))
+    .where(and(eq(eventComments.eventId, eventId), ne(eventComments.userId, actorId)));
+  const replyEmails = commenters
+    .filter((c) => c.email && !mentionedIds.has(c.userId))
+    .map((c) => c.email as string);
+
+  // ponytail: optional absolute link for the "View thread" button; omitted if
+  // PUBLIC_APP_URL isn't set (matches the app's other emails, which don't link).
+  const base = process.env.PUBLIC_APP_URL?.replace(/\/$/, "");
+  const eventUrl = base ? `${base}/dashboard/${ctx.projectId}/events/${eventId}` : null;
+
+  const common = {
+    actorName,
+    eventTitle: ctx.title,
+    channelName: ctx.channelName,
+    projectName: ctx.projectName,
+    commentBody: body,
+    eventUrl,
+  };
+
+  if (mentionEmails.length > 0) {
+    await sendCommentNotification({ ...common, reason: "mention" }, uniq(mentionEmails));
+  }
+  if (replyEmails.length > 0) {
+    await sendCommentNotification({ ...common, reason: "reply" }, uniq(replyEmails));
+  }
+}

--- a/src/lib/beaver/comment.ts
+++ b/src/lib/beaver/comment.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventComments, users } from "../db/schema";
 import { eq, asc } from "drizzle-orm";
 import { publishComment, type Comment } from "./comment-bus";
+import { notifyCommentByEmail } from "./comment-email";
 
 export type { Comment };
 
@@ -45,6 +46,15 @@ export async function createComment(
 
   const comment = withUser as Comment;
   publishComment({ eventId, comment });
+
+  // Best-effort: email @mentioned members and prior thread participants. Never
+  // let an email failure break commenting.
+  try {
+    await notifyCommentByEmail({ eventId, actorId: userId, actorName: comment.userName, body });
+  } catch (err) {
+    console.error("Failed to send comment notification emails:", err);
+  }
+
   return comment;
 }
 

--- a/src/lib/beaver/comment.ts
+++ b/src/lib/beaver/comment.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventComments, users } from "../db/schema";
 import { eq, asc } from "drizzle-orm";
 import { publishComment, type Comment } from "./comment-bus";
+import { createNotificationsForComment } from "./notification";
 import { notifyCommentByEmail } from "./comment-email";
 
 export type { Comment };
@@ -47,8 +48,19 @@ export async function createComment(
   const comment = withUser as Comment;
   publishComment({ eventId, comment });
 
-  // Best-effort: email @mentioned members and prior thread participants. Never
-  // let an email failure break commenting.
+  // Best-effort: create in-app notifications and email mentioned members and
+  // prior thread participants. Never let a notification failure break commenting.
+  try {
+    await createNotificationsForComment({
+      eventId,
+      actorId: userId,
+      actorName: comment.userName,
+      body,
+    });
+  } catch (err) {
+    console.error("Failed to create comment notifications:", err);
+  }
+
   try {
     await notifyCommentByEmail({ eventId, actorId: userId, actorName: comment.userName, body });
   } catch (err) {

--- a/src/lib/beaver/notification.ts
+++ b/src/lib/beaver/notification.ts
@@ -1,0 +1,150 @@
+import { db } from "../db/db";
+import { notifications, events, eventComments } from "../db/schema";
+import { and, count, desc, eq, isNull, ne } from "drizzle-orm";
+import { getProjectMembers } from "./project-member";
+
+export type NotificationType = "comment_reply" | "mention" | "alert";
+
+export type Notification = {
+  id: number;
+  type: NotificationType;
+  message: string;
+  linkPath: string;
+  readAt: Date | null;
+  createdAt: Date;
+};
+
+function truncate(s: string, max = 80): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+// Generate notifications for a freshly created comment: @mentions of project
+// members, plus replies to everyone else who has commented on the same event.
+// Mentions win over replies, and the comment author is never notified.
+export async function createNotificationsForComment(opts: {
+  eventId: number;
+  actorId: number;
+  actorName: string;
+  body: string;
+}): Promise<void> {
+  const { eventId, actorId, actorName, body } = opts;
+
+  const [ev] = await db
+    .select({ projectId: events.projectId, title: events.title })
+    .from(events)
+    .where(eq(events.id, eventId));
+  if (!ev) return;
+
+  const linkPath = `/dashboard/${ev.projectId}/events/${eventId}`;
+  const recipients = new Map<number, NotificationType>();
+
+  // Mentions — resolve @handle tokens (mirrors the UI's @\w+) against members.
+  const handles = new Set(Array.from(body.matchAll(/@(\w+)/g)).map((m) => m[1].toLowerCase()));
+  if (handles.size > 0) {
+    const members = await getProjectMembers(ev.projectId);
+    for (const m of members) {
+      if (m.userId !== actorId && handles.has(m.userName.toLowerCase())) {
+        recipients.set(m.userId, "mention");
+      }
+    }
+  }
+
+  // Replies — other users who have commented on this event.
+  const priorCommenters = await db
+    .selectDistinct({ userId: eventComments.userId })
+    .from(eventComments)
+    .where(and(eq(eventComments.eventId, eventId), ne(eventComments.userId, actorId)));
+  for (const c of priorCommenters) {
+    if (!recipients.has(c.userId)) recipients.set(c.userId, "comment_reply");
+  }
+
+  if (recipients.size === 0) return;
+
+  const rows = Array.from(recipients.entries()).map(([userId, type]) => ({
+    userId,
+    projectId: ev.projectId,
+    type,
+    message:
+      type === "mention"
+        ? `@${actorName} mentioned you: “${truncate(body)}”`
+        : `@${actorName} replied on “${ev.title}”`,
+    linkPath,
+  }));
+
+  await db.insert(notifications).values(rows);
+}
+
+// One alert notification per subscriber when an alert rule fires.
+export async function createAlertNotifications(opts: {
+  projectId: number;
+  channelId: number;
+  channelName: string;
+  ruleName: string;
+  count: number;
+  windowMinutes: number;
+  recipientIds: number[];
+}): Promise<void> {
+  const { projectId, channelId, channelName, ruleName, count, windowMinutes, recipientIds } = opts;
+  if (recipientIds.length === 0) return;
+
+  const linkPath = `/dashboard/${projectId}/channels/${channelId}`;
+  const message = `Alert “${ruleName}” triggered in #${channelName} — ${count} events in ${windowMinutes}m`;
+
+  await db.insert(notifications).values(
+    recipientIds.map((userId) => ({
+      userId,
+      projectId,
+      type: "alert" as const,
+      message,
+      linkPath,
+    })),
+  );
+}
+
+export async function getNotifications(
+  userId: number,
+  projectId: number,
+  { limit = 50 }: { limit?: number } = {},
+): Promise<Notification[]> {
+  const rows = await db
+    .select({
+      id: notifications.id,
+      type: notifications.type,
+      message: notifications.message,
+      linkPath: notifications.linkPath,
+      readAt: notifications.readAt,
+      createdAt: notifications.createdAt,
+    })
+    .from(notifications)
+    .where(and(eq(notifications.userId, userId), eq(notifications.projectId, projectId)))
+    .orderBy(desc(notifications.createdAt))
+    .limit(limit);
+  return rows as Notification[];
+}
+
+export async function getUnreadCount(userId: number, projectId: number): Promise<number> {
+  const [row] = await db
+    .select({ n: count() })
+    .from(notifications)
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.projectId, projectId),
+        isNull(notifications.readAt),
+      ),
+    );
+  return row?.n ?? 0;
+}
+
+export async function markAllRead(userId: number, projectId: number): Promise<void> {
+  await db
+    .update(notifications)
+    .set({ readAt: new Date() })
+    .where(
+      and(
+        eq(notifications.userId, userId),
+        eq(notifications.projectId, projectId),
+        isNull(notifications.readAt),
+      ),
+    );
+}

--- a/src/lib/beaver/reaction-bus.ts
+++ b/src/lib/beaver/reaction-bus.ts
@@ -1,0 +1,29 @@
+// In-process pub/sub for reaction updates, mirroring comment-bus. Carries the
+// full reactor set for an emoji so each SSE connection can personalize
+// `userReacted` for its own viewer before sending.
+export type ReactionBusMessage = {
+  eventId: number;
+  emoji: string;
+  count: number;
+  users: string[]; // reactor userNames
+  reactorIds: number[]; // reactor userIds — used to personalize userReacted per viewer
+};
+
+type Subscriber = (msg: ReactionBusMessage) => void;
+
+const subscribers = new Set<Subscriber>();
+
+export function publishReaction(msg: ReactionBusMessage): void {
+  for (const sub of subscribers) {
+    try {
+      sub(msg);
+    } catch (err) {
+      console.error("reaction-bus subscriber threw:", err);
+    }
+  }
+}
+
+export function subscribeReactions(fn: Subscriber): () => void {
+  subscribers.add(fn);
+  return () => subscribers.delete(fn);
+}

--- a/src/lib/beaver/reaction.ts
+++ b/src/lib/beaver/reaction.ts
@@ -2,6 +2,7 @@ import { db } from "../db/db";
 import { eventReactions, users } from "../db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import type { ReactionSummary } from "./event";
+import { publishReaction } from "./reaction-bus";
 
 export async function toggleReaction(
   userId: number,
@@ -31,6 +32,15 @@ export async function toggleReaction(
     .from(eventReactions)
     .innerJoin(users, eq(eventReactions.userId, users.id))
     .where(and(eq(eventReactions.eventId, eventId), eq(eventReactions.emoji, emoji)));
+
+  // Broadcast the full reactor set; each SSE connection personalizes userReacted.
+  publishReaction({
+    eventId,
+    emoji,
+    count: reactors.length,
+    users: reactors.map((r) => r.userName),
+    reactorIds: reactors.map((r) => r.userId),
+  });
 
   return {
     emoji,

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -547,3 +547,38 @@ export const savedViews = sqliteTable("saved_views", {
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),
 });
+
+// ---- NOTIFICATIONS ----
+// One row per recipient per event. Heterogeneous types share one shape:
+// message/linkPath are denormalized at creation so the list renders join-free.
+export const notifications = sqliteTable(
+  "notifications",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    userId: integer("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    projectId: integer("project_id")
+      .notNull()
+      .references(() => projects.id, { onDelete: "cascade" }),
+    type: text("type", { enum: ["comment_reply", "mention", "alert"] }).notNull(),
+    message: text("message").notNull(),
+    linkPath: text("link_path").notNull(),
+    readAt: integer("read_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .default(sql`(unixepoch() * 1000)`)
+      .notNull(),
+  },
+  (table) => ({
+    userProjectCreatedIdx: index("notifications_user_project_created_idx").on(
+      table.userId,
+      table.projectId,
+      table.createdAt,
+    ),
+    userProjectReadIdx: index("notifications_user_project_read_idx").on(
+      table.userId,
+      table.projectId,
+      table.readAt,
+    ),
+  }),
+);

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,6 +1,12 @@
 import { Resend } from "resend";
 import type { EventWithChannelName } from "../beaver/event";
-import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
+import {
+  buildEmailHtml,
+  buildAlertEmailHtml,
+  buildCommentEmailHtml,
+  type AlertEmailParams,
+  type CommentEmailParams,
+} from "./template";
 
 const apiKey = process.env.RESEND_API_KEY;
 const fromEmail = process.env.RESEND_FROM_EMAIL ?? "notifications@beaver.app";
@@ -35,6 +41,27 @@ export async function sendAlertEmail(
     to: recipientEmails,
     subject: `🚨 ${params.ruleName} — ${params.projectName}`,
     html: buildAlertEmailHtml(params),
+  });
+}
+
+export async function sendCommentNotification(
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!apiKey || recipientEmails.length === 0) return;
+
+  const resend = new Resend(apiKey);
+
+  const subject =
+    params.reason === "mention"
+      ? `${params.actorName} mentioned you — ${params.projectName}`
+      : `${params.actorName} replied on ${params.eventTitle} — ${params.projectName}`;
+
+  await resend.emails.send({
+    from: fromEmail,
+    to: recipientEmails,
+    subject,
+    html: buildCommentEmailHtml(params),
   });
 }
 

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -1,11 +1,12 @@
 import type { EventWithChannelName } from "../beaver/event";
 import { getEmailSettings } from "../beaver/email-settings";
-import type { AlertEmailParams } from "./template";
+import type { AlertEmailParams, CommentEmailParams } from "./template";
 import {
   sendEventNotification as sendViaResend,
   sendAlertEmail as sendAlertEmailViaResend,
+  sendCommentNotification as sendCommentViaResend,
 } from "./resend";
-import { sendEventNotificationSmtp, sendAlertEmailSmtp } from "./smtp";
+import { sendEventNotificationSmtp, sendAlertEmailSmtp, sendCommentNotificationSmtp } from "./smtp";
 
 export async function sendEventNotification(
   event: EventWithChannelName,
@@ -34,4 +35,18 @@ export async function sendAlertEmail(
   }
 
   await sendAlertEmailViaResend(params, recipientEmails);
+}
+
+export async function sendCommentNotification(
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  const settings = await getEmailSettings();
+
+  if (settings?.provider === "smtp") {
+    await sendCommentNotificationSmtp(settings, params, recipientEmails);
+    return;
+  }
+
+  await sendCommentViaResend(params, recipientEmails);
 }

--- a/src/lib/email/smtp.ts
+++ b/src/lib/email/smtp.ts
@@ -1,7 +1,13 @@
 import nodemailer from "nodemailer";
 import type { EventWithChannelName } from "../beaver/event";
 import type { EmailSettings } from "../beaver/email-settings";
-import { buildEmailHtml, buildAlertEmailHtml, type AlertEmailParams } from "./template";
+import {
+  buildEmailHtml,
+  buildAlertEmailHtml,
+  buildCommentEmailHtml,
+  type AlertEmailParams,
+  type CommentEmailParams,
+} from "./template";
 
 function buildTransport(settings: EmailSettings) {
   return nodemailer.createTransport({
@@ -46,6 +52,28 @@ export async function sendAlertEmailSmtp(
     to: recipientEmails,
     subject: `🚨 ${params.ruleName} — ${params.projectName}`,
     html: buildAlertEmailHtml(params),
+  });
+}
+
+export async function sendCommentNotificationSmtp(
+  settings: EmailSettings,
+  params: CommentEmailParams,
+  recipientEmails: string[],
+): Promise<void> {
+  if (!settings.smtpHost || !settings.smtpPort || recipientEmails.length === 0) return;
+
+  const transport = buildTransport(settings);
+
+  const subject =
+    params.reason === "mention"
+      ? `${params.actorName} mentioned you — ${params.projectName}`
+      : `${params.actorName} replied on ${params.eventTitle} — ${params.projectName}`;
+
+  await transport.sendMail({
+    from: settings.smtpFromEmail ?? "notifications@beaver.app",
+    to: recipientEmails,
+    subject,
+    html: buildCommentEmailHtml(params),
   });
 }
 

--- a/src/lib/email/template.ts
+++ b/src/lib/email/template.ts
@@ -159,3 +159,83 @@ export function buildAlertEmailHtml(params: AlertEmailParams): string {
 </body>
 </html>`;
 }
+
+export type CommentEmailParams = {
+  actorName: string;
+  reason: "mention" | "reply";
+  eventTitle: string;
+  channelName: string;
+  projectName: string;
+  commentBody: string;
+  eventUrl?: string | null;
+};
+
+// Comment bodies (and, defensively, other fields) are user input rendered into
+// HTML email, so escape before interpolation.
+function esc(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export function buildCommentEmailHtml(params: CommentEmailParams): string {
+  const headline =
+    params.reason === "mention"
+      ? `${esc(params.actorName)} mentioned you`
+      : `${esc(params.actorName)} replied on a thread you’re in`;
+
+  const buttonHtml = params.eventUrl
+    ? `<a href="${esc(params.eventUrl)}" style="display:inline-block;margin-top:20px;background:#171717;color:#ffffff;text-decoration:none;font-size:14px;font-weight:600;padding:10px 18px;border-radius:8px;">View thread</a>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>${headline}</title>
+</head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:40px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="max-width:600px;width:100%;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#171717;padding:24px 32px;border-radius:12px 12px 0 0;">
+              <p style="margin:0;font-size:13px;font-weight:600;color:#a1a1aa;letter-spacing:0.08em;text-transform:uppercase;">Beaver</p>
+              <p style="margin:4px 0 0;font-size:13px;color:#71717a;">
+                ${esc(params.projectName)} &middot; #${esc(params.channelName)}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="background:#ffffff;padding:32px;border-left:1px solid #e5e7eb;border-right:1px solid #e5e7eb;">
+              <h1 style="margin:0;font-size:20px;font-weight:700;color:#111827;line-height:1.3;">${headline}</h1>
+              <p style="margin:6px 0 0;font-size:14px;color:#6b7280;">on <strong style="color:#374151;">${esc(params.eventTitle)}</strong></p>
+              <div style="margin:20px 0 0;padding:16px;background:#f9fafb;border-left:3px solid #d4d4d8;border-radius:4px;font-size:15px;color:#374151;line-height:1.6;white-space:pre-wrap;">${esc(params.commentBody)}</div>
+              ${buttonHtml}
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="background:#f4f4f5;padding:20px 32px;border-radius:0 0 12px 12px;border:1px solid #e5e7eb;border-top:none;">
+              <p style="margin:0;font-size:12px;color:#9ca3af;line-height:1.6;">
+                You're receiving this because you were mentioned in or have participated in this thread.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}

--- a/src/pages/api/events/[eventID]/reactions/stream.ts
+++ b/src/pages/api/events/[eventID]/reactions/stream.ts
@@ -1,0 +1,76 @@
+import { subscribeReactions } from "@/lib/beaver/reaction-bus";
+import { canAccessProject, forbidden, projectIdForEvent } from "@/lib/beaver/authz";
+import type { APIContext } from "astro";
+
+const KEEPALIVE_MS = 15000;
+
+const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+  "X-Accel-Buffering": "no",
+};
+
+export async function GET({ params, locals }: APIContext) {
+  const user = locals.user;
+  if (!user) return new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 });
+
+  const eventId = parseInt(params.eventID!);
+
+  const projectId = await projectIdForEvent(eventId);
+  if (projectId === null || !(await canAccessProject(user, projectId))) return forbidden();
+
+  const encoder = new TextEncoder();
+
+  let unsubscribe: (() => void) | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+  let closed = false;
+
+  function cleanup() {
+    closed = true;
+    unsubscribe?.();
+    unsubscribe = null;
+    if (keepalive) {
+      clearInterval(keepalive);
+      keepalive = null;
+    }
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoder.encode(": ok\n\n"));
+
+      unsubscribe = subscribeReactions((msg) => {
+        if (msg.eventId !== eventId || closed) return;
+        // Personalize userReacted for this connection's viewer.
+        const summary = {
+          emoji: msg.emoji,
+          count: msg.count,
+          userReacted: msg.reactorIds.includes(user.id),
+          users: msg.users,
+        };
+        try {
+          controller.enqueue(encoder.encode(`data: ${JSON.stringify(summary)}\n\n`));
+        } catch {
+          cleanup();
+        }
+      });
+
+      keepalive = setInterval(() => {
+        if (closed) return;
+        try {
+          controller.enqueue(encoder.encode(": keepalive\n\n"));
+        } catch {
+          cleanup();
+        }
+      }, KEEPALIVE_MS);
+    },
+    cancel() {
+      cleanup();
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+
+export const prerender = false;

--- a/src/pages/api/notifications/list.ts
+++ b/src/pages/api/notifications/list.ts
@@ -1,0 +1,24 @@
+import type { APIContext } from "astro";
+import { getNotifications } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function GET({ locals, url }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const projectId = Number(url.searchParams.get("projectId"));
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  const limitParam = Number(url.searchParams.get("limit"));
+  const limit = Number.isFinite(limitParam) && limitParam > 0 ? Math.min(limitParam, 100) : 50;
+
+  const notifications = await getNotifications(user.id, projectId, { limit });
+  return new Response(JSON.stringify({ notifications }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/notifications/read.ts
+++ b/src/pages/api/notifications/read.ts
@@ -1,0 +1,21 @@
+import type { APIContext } from "astro";
+import { markAllRead } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function POST({ locals, request }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const { projectId } = await request.json();
+  if (typeof projectId !== "number") {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  await markAllRead(user.id, projectId);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/api/notifications/unread-count.ts
+++ b/src/pages/api/notifications/unread-count.ts
@@ -1,0 +1,21 @@
+import type { APIContext } from "astro";
+import { getUnreadCount } from "@/lib/beaver/notification";
+import { canAccessProject, forbidden, unauthorized } from "@/lib/beaver/authz";
+
+export async function GET({ locals, url }: APIContext) {
+  const user = locals.user;
+  if (!user) return unauthorized();
+
+  const projectId = Number(url.searchParams.get("projectId"));
+  if (!projectId) {
+    return new Response(JSON.stringify({ error: "projectId is required" }), { status: 400 });
+  }
+  if (!(await canAccessProject(user, projectId))) return forbidden();
+
+  const count = await getUnreadCount(user.id, projectId);
+  return new Response(JSON.stringify({ count }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+export const prerender = false;

--- a/src/pages/dashboard/[projectID]/metrics.astro
+++ b/src/pages/dashboard/[projectID]/metrics.astro
@@ -25,22 +25,6 @@ const TYPE_LABELS: Record<string, string> = {
   timeseries: "Timeseries",
 };
 
-function bucketSparkline(
-  data: { value: number; timestamp: Date }[],
-  chartType: string,
-): { value: number }[] {
-  if (chartType !== "bar") return data.map((d) => ({ value: d.value }));
-  const sums = new Map<string, number>();
-  const counts = new Map<string, number>();
-  for (const d of data) {
-    const key = new Date(d.timestamp).toISOString().slice(0, 10);
-    sums.set(key, (sums.get(key) ?? 0) + d.value);
-    counts.set(key, (counts.get(key) ?? 0) + 1);
-  }
-  return Array.from(sums.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, sum]) => ({ value: Math.round((sum / (counts.get(key) ?? 1)) * 10) / 10 }));
-}
 ---
 
 <Layout projectID={projectID!}>
@@ -70,10 +54,8 @@ function bucketSparkline(
         {metrics.map((metric) => {
           const isClickable = metric.type === "timeseries";
           const isTweenable = metric.type === "gauge" || metric.type === "counter";
-          const sparklineData = bucketSparkline(
-            sparklines[metric.id] ?? [],
-            metric.chartType ?? "line",
-          );
+          // One point per posted value (#248) — no day-bucketing.
+          const sparklineData = (sparklines[metric.id] ?? []).map((d) => ({ value: d.value }));
           const Wrapper = isClickable ? "a" : "div";
           return (
             <Wrapper

--- a/src/pages/dashboard/[projectID]/notifications.astro
+++ b/src/pages/dashboard/[projectID]/notifications.astro
@@ -1,0 +1,24 @@
+---
+import Layout from "@/layouts/layout.astro";
+import NotificationsView from "@/components/notifications-view";
+import { getNotifications } from "@/lib/beaver/notification";
+
+const { projectID } = Astro.params;
+const user = Astro.locals.user!;
+const projectId = parseInt(projectID!);
+
+const initial = await getNotifications(user.id, projectId);
+const initialNotifications = initial.map((n) => ({
+  ...n,
+  readAt: n.readAt ? n.readAt.toISOString() : null,
+  createdAt: n.createdAt.toISOString(),
+}));
+---
+
+<Layout projectID={projectID!}>
+  <NotificationsView
+    client:load
+    projectId={projectId}
+    initialNotifications={initialNotifications}
+  />
+</Layout>


### PR DESCRIPTION
Release **v2.2.0**. Merges the `v2.2.0` release branch into `main`; bumps `package.json` 2.1.4 → 2.2.0.

## What's Changed
- **feat: notifications view** (#239, #261) — project-scoped inbox aggregating comment replies, @mentions, and alert firings, with unread/read state, deep links, mark-all-read, and a live sidebar badge.
- **feat: email notifications for event comments** (#238, #263) — email @mentioned members and prior thread participants on new comments.
- **feat: stream reaction updates via SSE** (#237, #262) — reactions on the event detail page update live for all viewers.
- **feat: clickable URL tag values** (#249, #259) — event tag values that are http(s) URLs render as links.
- **refactor: timeseries plots each value** (#248, #260) — no more day-bucketing/averaging; every posted value is its own point/bar.
- **fix: unread fetch fires twice on load** (#184, #264) — deduped the initial `/api/unread` request.

## After merge
Tag `v2.2.0` on `main` and publish the GitHub release.

## Notes
- Includes a DB migration (`0024`, notifications table) — `bun run migrate` on deploy.
- Optional new env `PUBLIC_APP_URL` enables the "View thread" link in comment emails (degrades gracefully if unset).
- Feature-level testing was DB-layer + tsc/lint/format; full app/browser runs weren't possible in the dev environment (Node < 18.20.8). Worth a manual smoke pass on staging before tagging.