### PR TITLE
refactor: make Resend API key and from address configurable in app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,8 @@ JWT_SECRET=change-me-to-a-secure-random-string
 PORT=4321
 HOST=0.0.0.0
 
-# Email notifications (optional — powered by Resend)
-# Sign up at https://resend.com to get an API key
-RESEND_API_KEY=re_your_api_key_here
-RESEND_FROM_EMAIL=notifications@yourdomain.com
+# Email notifications are configured under Admin → Email Settings.
+# The variables below are a deprecated fallback, only read when no Resend API
+# key has been saved in the app.
+# RESEND_API_KEY=re_your_api_key_here
+# RESEND_FROM_EMAIL=notifications@yourdomain.com

--- a/README.md
+++ b/README.md
@@ -280,10 +280,11 @@ Keep tag types consistent across events — the filter UI uses the type it sees 
 Set `"notify": true` on an event to send an email to opted-in project members. Requires configuring an email provider:
 
 1. Sign up at [resend.com](https://resend.com) and create an API key
-2. Set `RESEND_API_KEY` in your environment
-3. Optionally set `RESEND_FROM_EMAIL` (defaults to `notifications@beaver.app`)
+2. Paste it under Admin → Email Settings, along with an optional from address (defaults to `notifications@beaver.app`)
 
-Or configure an SMTP provider under Admin → Email Settings.
+Or pick SMTP on the same page and fill in your server details.
+
+> The `RESEND_API_KEY` and `RESEND_FROM_EMAIL` environment variables still work as a fallback when no API key is saved, but they are deprecated — prefer configuring Resend in the app.
 
 ### Metrics
 

--- a/drizzle/0025_resend_settings.sql
+++ b/drizzle/0025_resend_settings.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `email_settings` ADD `resend_api_key` text;--> statement-breakpoint
+ALTER TABLE `email_settings` ADD `resend_from_email` text;

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,1616 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a3653c45-0f13-4d38-81d4-ae75a0b73e9b",
+  "prevId": "89d6f14c-ea03-4c4b-9ede-341798cf50b4",
+  "tables": {
+    "alert_rules": {
+      "name": "alert_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "threshold": {
+          "name": "threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "window_minutes": {
+          "name": "window_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "alert_rules_channel_id_idx": {
+          "name": "alert_rules_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        },
+        "alert_rules_channel_id_event_object_event_action_idx": {
+          "name": "alert_rules_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "alert_rules_channel_id_channels_id_fk": {
+          "name": "alert_rules_channel_id_channels_id_fk",
+          "tableFrom": "alert_rules",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_log": {
+      "name": "audit_log",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_name": {
+          "name": "target_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_log_project_id_projects_id_fk": {
+          "name": "audit_log_project_id_projects_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "audit_log_user_id_users_id_fk": {
+          "name": "audit_log_user_id_users_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "bookmarks": {
+      "name": "bookmarks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "bookmarks_user_event_idx": {
+          "name": "bookmarks_user_event_idx",
+          "columns": ["user_id", "event_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_user_id_users_id_fk": {
+          "name": "bookmarks_user_id_users_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_event_id_events_id_fk": {
+          "name": "bookmarks_event_id_events_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_groups": {
+      "name": "channel_groups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_groups_project_id_idx": {
+          "name": "channel_groups_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_groups_project_id_projects_id_fk": {
+          "name": "channel_groups_project_id_projects_id_fk",
+          "tableFrom": "channel_groups",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_notification_subscriptions": {
+      "name": "channel_notification_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channel_notification_subscriptions_user_channel_idx": {
+          "name": "channel_notification_subscriptions_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        },
+        "channel_notification_subscriptions_channel_id_idx": {
+          "name": "channel_notification_subscriptions_channel_id_idx",
+          "columns": ["channel_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_notification_subscriptions_user_id_users_id_fk": {
+          "name": "channel_notification_subscriptions_user_id_users_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_notification_subscriptions_channel_id_channels_id_fk": {
+          "name": "channel_notification_subscriptions_channel_id_channels_id_fk",
+          "tableFrom": "channel_notification_subscriptions",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_reads": {
+      "name": "channel_reads",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_read_at": {
+          "name": "last_read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "channel_reads_user_channel_idx": {
+          "name": "channel_reads_user_channel_idx",
+          "columns": ["user_id", "channel_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "channel_reads_user_id_users_id_fk": {
+          "name": "channel_reads_user_id_users_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_reads_channel_id_channels_id_fk": {
+          "name": "channel_reads_channel_id_channels_id_fk",
+          "tableFrom": "channel_reads",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "channels_project_id_idx": {
+          "name": "channels_project_id_idx",
+          "columns": ["project_id"],
+          "isUnique": false
+        },
+        "channels_name_idx": {
+          "name": "channels_name_idx",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_project_id_projects_id_fk": {
+          "name": "channels_project_id_projects_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channels_group_id_channel_groups_id_fk": {
+          "name": "channels_group_id_channel_groups_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "channel_groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "email_settings": {
+      "name": "email_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'resend'"
+        },
+        "smtp_host": {
+          "name": "smtp_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_port": {
+          "name": "smtp_port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_username": {
+          "name": "smtp_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_password": {
+          "name": "smtp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "smtp_secure": {
+          "name": "smtp_secure",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "smtp_from_email": {
+          "name": "smtp_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_api_key": {
+          "name": "resend_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "resend_from_email": {
+          "name": "resend_from_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_comments": {
+      "name": "event_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_comments_event_id_events_id_fk": {
+          "name": "event_comments_event_id_events_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_comments_user_id_users_id_fk": {
+          "name": "event_comments_user_id_users_id_fk",
+          "tableFrom": "event_comments",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_reactions": {
+      "name": "event_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "event_reactions_event_user_emoji_idx": {
+          "name": "event_reactions_event_user_emoji_idx",
+          "columns": ["event_id", "user_id", "emoji"],
+          "isUnique": true
+        },
+        "event_reactions_event_id_idx": {
+          "name": "event_reactions_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_reactions_event_id_events_id_fk": {
+          "name": "event_reactions_event_id_events_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reactions_user_id_users_id_fk": {
+          "name": "event_reactions_user_id_users_id_fk",
+          "tableFrom": "event_reactions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "event_tags": {
+      "name": "event_tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "event_tags_event_id_idx": {
+          "name": "event_tags_event_id_idx",
+          "columns": ["event_id"],
+          "isUnique": false
+        },
+        "event_tags_event_id_key_value_idx": {
+          "name": "event_tags_event_id_key_value_idx",
+          "columns": ["event_id", "key", "value"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "event_tags_event_id_events_id_fk": {
+          "name": "event_tags_event_id_events_id_fk",
+          "tableFrom": "event_tags",
+          "tableTo": "events",
+          "columnsFrom": ["event_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "events": {
+      "name": "events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "event_object": {
+          "name": "event_object",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "events_channel_id_created_at_idx": {
+          "name": "events_channel_id_created_at_idx",
+          "columns": ["channel_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_created_at_idx": {
+          "name": "events_project_id_created_at_idx",
+          "columns": ["project_id", "created_at"],
+          "isUnique": false
+        },
+        "events_project_id_event_object_event_action_idx": {
+          "name": "events_project_id_event_object_event_action_idx",
+          "columns": ["project_id", "event_object", "event_action"],
+          "isUnique": false
+        },
+        "events_channel_id_event_object_event_action_idx": {
+          "name": "events_channel_id_event_object_event_action_idx",
+          "columns": ["channel_id", "event_object", "event_action"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "events_project_id_projects_id_fk": {
+          "name": "events_project_id_projects_id_fk",
+          "tableFrom": "events",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "events_channel_id_channels_id_fk": {
+          "name": "events_channel_id_channels_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channels",
+          "columnsFrom": ["channel_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metric_values": {
+      "name": "metric_values",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "metric_id": {
+          "name": "metric_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metric_values_metric_id_timestamp_idx": {
+          "name": "metric_values_metric_id_timestamp_idx",
+          "columns": ["metric_id", "timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "metric_values_metric_id_metrics_id_fk": {
+          "name": "metric_values_metric_id_metrics_id_fk",
+          "tableFrom": "metric_values",
+          "tableTo": "metrics",
+          "columnsFrom": ["metric_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "metrics": {
+      "name": "metrics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chart_type": {
+          "name": "chart_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "metrics_project_id_name_idx": {
+          "name": "metrics_project_id_name_idx",
+          "columns": ["project_id", "name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "metrics_project_id_projects_id_fk": {
+          "name": "metrics_project_id_projects_id_fk",
+          "tableFrom": "metrics",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "link_path": {
+          "name": "link_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "notifications_user_project_created_idx": {
+          "name": "notifications_user_project_created_idx",
+          "columns": ["user_id", "project_id", "created_at"],
+          "isUnique": false
+        },
+        "notifications_user_project_read_idx": {
+          "name": "notifications_user_project_read_idx",
+          "columns": ["user_id", "project_id", "read_at"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_project_id_projects_id_fk": {
+          "name": "notifications_project_id_projects_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_members": {
+      "name": "project_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'guest'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "project_members_project_id_user_id_idx": {
+          "name": "project_members_project_id_user_id_idx",
+          "columns": ["project_id", "user_id"],
+          "isUnique": false
+        },
+        "project_members_user_id_idx": {
+          "name": "project_members_user_id_idx",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "project_members_project_id_projects_id_fk": {
+          "name": "project_members_project_id_projects_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_members_user_id_users_id_fk": {
+          "name": "project_members_user_id_users_id_fk",
+          "tableFrom": "project_members",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "api_key": {
+          "name": "api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "previous_api_key": {
+          "name": "previous_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_api_key_expires_at": {
+          "name": "previous_api_key_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rate_limit_per_minute": {
+          "name": "rate_limit_per_minute",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "projects_name_unique": {
+          "name": "projects_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "projects_api_key_unique": {
+          "name": "projects_api_key_unique",
+          "columns": ["api_key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "projects_owner_id_users_id_fk": {
+          "name": "projects_owner_id_users_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "users",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "saved_views": {
+      "name": "saved_views",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "saved_views_project_id_projects_id_fk": {
+          "name": "saved_views_project_id_projects_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "saved_views_user_id_users_id_fk": {
+          "name": "saved_views_user_id_users_id_fk",
+          "tableFrom": "saved_views",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "columns": ["token"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "can_create_projects": {
+          "name": "can_create_projects",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "must_change_password": {
+          "name": "must_change_password",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "temp_password": {
+          "name": "temp_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compact_mode": {
+          "name": "compact_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "theme_palette": {
+          "name": "theme_palette",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'default'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch() * 1000)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1783369363306,
       "tag": "0024_nifty_centennial",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1785194471196,
+      "tag": "0025_resend_settings",
+      "breakpoints": true
     }
   ]
 }

--- a/src/components/admin-email-settings-view.tsx
+++ b/src/components/admin-email-settings-view.tsx
@@ -3,7 +3,7 @@ import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
-import { ArrowLeftIcon, CheckCircle2Icon, XCircleIcon } from "lucide-react";
+import { ArrowLeftIcon, InfoIcon } from "lucide-react";
 
 type EmailSettingsData = {
   provider: "resend" | "smtp";
@@ -13,16 +13,17 @@ type EmailSettingsData = {
   smtpPasswordSet: boolean;
   smtpSecure: boolean;
   smtpFromEmail: string | null;
+  resendApiKeySet: boolean;
+  resendFromEmail: string | null;
+  resendEnvFallback: boolean;
 };
 
 export default function AdminEmailSettingsView({
   backUrl,
   initialSettings,
-  resendConfigured,
 }: {
   backUrl: string;
   initialSettings: EmailSettingsData;
-  resendConfigured: boolean;
 }) {
   const [provider, setProvider] = useState(initialSettings.provider);
   const [smtpHost, setSmtpHost] = useState(initialSettings.smtpHost ?? "");
@@ -34,6 +35,10 @@ export default function AdminEmailSettingsView({
   const [smtpPasswordSet, setSmtpPasswordSet] = useState(initialSettings.smtpPasswordSet);
   const [smtpSecure, setSmtpSecure] = useState(initialSettings.smtpSecure);
   const [smtpFromEmail, setSmtpFromEmail] = useState(initialSettings.smtpFromEmail ?? "");
+  const [resendApiKey, setResendApiKey] = useState("");
+  const [resendApiKeySet, setResendApiKeySet] = useState(initialSettings.resendApiKeySet);
+  const [resendFromEmail, setResendFromEmail] = useState(initialSettings.resendFromEmail ?? "");
+  const [resendEnvFallback, setResendEnvFallback] = useState(initialSettings.resendEnvFallback);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
   const [error, setError] = useState<string | null>(null);
@@ -55,6 +60,8 @@ export default function AdminEmailSettingsView({
           ...(smtpPassword ? { smtpPassword } : {}),
           smtpSecure,
           smtpFromEmail,
+          ...(resendApiKey ? { resendApiKey } : {}),
+          resendFromEmail,
         }),
       });
       const data = await res.json();
@@ -65,6 +72,9 @@ export default function AdminEmailSettingsView({
       }
       setSmtpPasswordSet(data.smtpPasswordSet);
       setSmtpPassword("");
+      setResendApiKeySet(data.resendApiKeySet);
+      setResendApiKey("");
+      setResendEnvFallback(data.resendEnvFallback);
       setStatus("saved");
       setTimeout(() => setStatus("idle"), 2000);
     } catch {
@@ -106,17 +116,38 @@ export default function AdminEmailSettingsView({
           </div>
 
           {provider === "resend" && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground border rounded-md p-3">
-              {resendConfigured ? (
-                <CheckCircle2Icon size={16} className="text-green-600 shrink-0" />
-              ) : (
-                <XCircleIcon size={16} className="text-destructive shrink-0" />
+            <div className="space-y-4 border rounded-md p-4">
+              <div className="space-y-2">
+                <Label htmlFor="resend-api-key">API Key</Label>
+                <Input
+                  id="resend-api-key"
+                  type="password"
+                  value={resendApiKey}
+                  onChange={(e) => setResendApiKey(e.target.value)}
+                  placeholder={
+                    resendApiKeySet ? "Leave blank to keep current key" : "re_your_api_key_here"
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="resend-from">From Email</Label>
+                <Input
+                  id="resend-from"
+                  type="email"
+                  value={resendFromEmail}
+                  onChange={(e) => setResendFromEmail(e.target.value)}
+                  placeholder="notifications@beaver.app"
+                />
+              </div>
+              {resendEnvFallback && (
+                <div className="flex items-start gap-2 text-sm text-muted-foreground">
+                  <InfoIcon size={16} className="shrink-0 mt-0.5" />
+                  <span>
+                    Currently using the <code>RESEND_API_KEY</code> environment variable. It is
+                    deprecated — set an API key here and it will take precedence.
+                  </span>
+                </div>
               )}
-              <span>
-                {resendConfigured
-                  ? "Resend is configured via the RESEND_API_KEY environment variable."
-                  : "RESEND_API_KEY is not set in the environment."}
-              </span>
             </div>
           )}
 

--- a/src/lib/beaver/email-settings.ts
+++ b/src/lib/beaver/email-settings.ts
@@ -13,6 +13,8 @@ export type EmailSettings = {
   smtpPassword: string | null;
   smtpSecure: boolean;
   smtpFromEmail: string | null;
+  resendApiKey: string | null;
+  resendFromEmail: string | null;
 };
 
 export type EmailSettingsUpdate = {
@@ -23,6 +25,8 @@ export type EmailSettingsUpdate = {
   smtpPassword?: string | null;
   smtpSecure: boolean;
   smtpFromEmail: string | null;
+  resendApiKey?: string | null;
+  resendFromEmail: string | null;
 };
 
 export async function getEmailSettings(): Promise<EmailSettings | null> {
@@ -40,14 +44,20 @@ export async function updateEmailSettings(update: EmailSettingsUpdate): Promise<
     smtpUsername: update.smtpUsername,
     smtpSecure: update.smtpSecure,
     smtpFromEmail: update.smtpFromEmail,
+    resendFromEmail: update.resendFromEmail,
     updatedAt: new Date(),
     ...(update.smtpPassword !== undefined ? { smtpPassword: update.smtpPassword } : {}),
+    ...(update.resendApiKey !== undefined ? { resendApiKey: update.resendApiKey } : {}),
   };
 
   if (!existing) {
     const [row] = await db
       .insert(emailSettings)
-      .values({ ...values, smtpPassword: update.smtpPassword ?? null })
+      .values({
+        ...values,
+        smtpPassword: update.smtpPassword ?? null,
+        resendApiKey: update.resendApiKey ?? null,
+      })
       .returning();
     return row as EmailSettings;
   }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -320,6 +320,8 @@ export const emailSettings = sqliteTable("email_settings", {
   smtpPassword: text("smtp_password"),
   smtpSecure: integer("smtp_secure", { mode: "boolean" }).notNull().default(true),
   smtpFromEmail: text("smtp_from_email"),
+  resendApiKey: text("resend_api_key"),
+  resendFromEmail: text("resend_from_email"),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" })
     .default(sql`(unixepoch() * 1000)`)
     .notNull(),

--- a/src/lib/email/resend.ts
+++ b/src/lib/email/resend.ts
@@ -1,5 +1,6 @@
 import { Resend } from "resend";
 import type { EventWithChannelName } from "../beaver/event";
+import type { EmailSettings } from "../beaver/email-settings";
 import {
   buildEmailHtml,
   buildAlertEmailHtml,
@@ -8,20 +9,39 @@ import {
   type CommentEmailParams,
 } from "./template";
 
-const apiKey = process.env.RESEND_API_KEY;
-const fromEmail = process.env.RESEND_FROM_EMAIL ?? "notifications@beaver.app";
+const DEFAULT_FROM_EMAIL = "notifications@beaver.app";
+
+// Deprecated: configure Resend in the admin email settings instead. These are
+// only read when the corresponding setting is empty, so existing deployments
+// keep working after upgrading.
+const envApiKey = process.env.RESEND_API_KEY;
+const envFromEmail = process.env.RESEND_FROM_EMAIL;
+
+type ResendConfig = { apiKey: string; fromEmail: string };
+
+function resolveConfig(settings: EmailSettings | null): ResendConfig | null {
+  const apiKey = settings?.resendApiKey || envApiKey;
+  if (!apiKey) return null;
+
+  return {
+    apiKey,
+    fromEmail: settings?.resendFromEmail || envFromEmail || DEFAULT_FROM_EMAIL,
+  };
+}
 
 export async function sendEventNotification(
+  settings: EmailSettings | null,
   event: EventWithChannelName,
   projectName: string,
   recipientEmails: string[],
 ): Promise<void> {
-  if (!apiKey || recipientEmails.length === 0) return;
+  const config = resolveConfig(settings);
+  if (!config || recipientEmails.length === 0) return;
 
-  const resend = new Resend(apiKey);
+  const resend = new Resend(config.apiKey);
 
   await resend.emails.send({
-    from: fromEmail,
+    from: config.fromEmail,
     to: recipientEmails,
     subject: `${event.icon ? `${event.icon} ` : ""}${event.title} — ${projectName}`,
     html: buildEmailHtml(event, projectName),
@@ -29,15 +49,17 @@ export async function sendEventNotification(
 }
 
 export async function sendAlertEmail(
+  settings: EmailSettings | null,
   params: AlertEmailParams,
   recipientEmails: string[],
 ): Promise<void> {
-  if (!apiKey || recipientEmails.length === 0) return;
+  const config = resolveConfig(settings);
+  if (!config || recipientEmails.length === 0) return;
 
-  const resend = new Resend(apiKey);
+  const resend = new Resend(config.apiKey);
 
   await resend.emails.send({
-    from: fromEmail,
+    from: config.fromEmail,
     to: recipientEmails,
     subject: `🚨 ${params.ruleName} — ${params.projectName}`,
     html: buildAlertEmailHtml(params),
@@ -45,12 +67,14 @@ export async function sendAlertEmail(
 }
 
 export async function sendCommentNotification(
+  settings: EmailSettings | null,
   params: CommentEmailParams,
   recipientEmails: string[],
 ): Promise<void> {
-  if (!apiKey || recipientEmails.length === 0) return;
+  const config = resolveConfig(settings);
+  if (!config || recipientEmails.length === 0) return;
 
-  const resend = new Resend(apiKey);
+  const resend = new Resend(config.apiKey);
 
   const subject =
     params.reason === "mention"
@@ -58,13 +82,18 @@ export async function sendCommentNotification(
       : `${params.actorName} replied on ${params.eventTitle} — ${params.projectName}`;
 
   await resend.emails.send({
-    from: fromEmail,
+    from: config.fromEmail,
     to: recipientEmails,
     subject,
     html: buildCommentEmailHtml(params),
   });
 }
 
-export function isResendConfigured(): boolean {
-  return !!apiKey;
+export function isResendConfigured(settings: EmailSettings | null): boolean {
+  return !!resolveConfig(settings);
+}
+
+/** True when Resend falls back to the deprecated RESEND_API_KEY env var. */
+export function usesResendEnvFallback(settings: EmailSettings | null): boolean {
+  return !settings?.resendApiKey && !!envApiKey;
 }

--- a/src/lib/email/send.ts
+++ b/src/lib/email/send.ts
@@ -20,7 +20,7 @@ export async function sendEventNotification(
     return;
   }
 
-  await sendViaResend(event, projectName, recipientEmails);
+  await sendViaResend(settings, event, projectName, recipientEmails);
 }
 
 export async function sendAlertEmail(
@@ -34,7 +34,7 @@ export async function sendAlertEmail(
     return;
   }
 
-  await sendAlertEmailViaResend(params, recipientEmails);
+  await sendAlertEmailViaResend(settings, params, recipientEmails);
 }
 
 export async function sendCommentNotification(
@@ -48,5 +48,5 @@ export async function sendCommentNotification(
     return;
   }
 
-  await sendCommentViaResend(params, recipientEmails);
+  await sendCommentViaResend(settings, params, recipientEmails);
 }

--- a/src/pages/admin/settings.astro
+++ b/src/pages/admin/settings.astro
@@ -2,7 +2,7 @@
 import "../../styles/global.css";
 import { getProjects } from "@/lib/beaver/project";
 import { getEmailSettings } from "@/lib/beaver/email-settings";
-import { isResendConfigured } from "@/lib/email/resend";
+import { usesResendEnvFallback } from "@/lib/email/resend";
 import AdminEmailSettingsView from "@/components/admin-email-settings-view";
 
 const user = Astro.locals.user;
@@ -22,6 +22,9 @@ const initialSettings = {
   smtpPasswordSet: !!settings?.smtpPassword,
   smtpSecure: settings?.smtpSecure ?? true,
   smtpFromEmail: settings?.smtpFromEmail ?? null,
+  resendApiKeySet: !!settings?.resendApiKey,
+  resendFromEmail: settings?.resendFromEmail ?? null,
+  resendEnvFallback: usesResendEnvFallback(settings),
 };
 ---
 
@@ -49,7 +52,6 @@ const initialSettings = {
       client:visible
       backUrl={backUrl}
       initialSettings={initialSettings}
-      resendConfigured={isResendConfigured()}
     />
   </body>
 </html>

--- a/src/pages/api/email-settings.ts
+++ b/src/pages/api/email-settings.ts
@@ -4,6 +4,7 @@ import {
   updateEmailSettings,
   type EmailProvider,
 } from "@/lib/beaver/email-settings";
+import { usesResendEnvFallback } from "@/lib/email/resend";
 
 const VALID_PROVIDERS: EmailProvider[] = ["resend", "smtp"];
 
@@ -32,6 +33,9 @@ export const GET: APIRoute = async (context) => {
       smtpPasswordSet: !!settings?.smtpPassword,
       smtpSecure: settings?.smtpSecure ?? true,
       smtpFromEmail: settings?.smtpFromEmail ?? null,
+      resendApiKeySet: !!settings?.resendApiKey,
+      resendFromEmail: settings?.resendFromEmail ?? null,
+      resendEnvFallback: usesResendEnvFallback(settings),
     }),
     { status: 200, headers: { "Content-Type": "application/json" } },
   );
@@ -43,8 +47,17 @@ export const PATCH: APIRoute = async (context) => {
 
   try {
     const body = await context.request.json();
-    const { provider, smtpHost, smtpPort, smtpUsername, smtpPassword, smtpSecure, smtpFromEmail } =
-      body;
+    const {
+      provider,
+      smtpHost,
+      smtpPort,
+      smtpUsername,
+      smtpPassword,
+      smtpSecure,
+      smtpFromEmail,
+      resendApiKey,
+      resendFromEmail,
+    } = body;
 
     if (!VALID_PROVIDERS.includes(provider)) {
       return new Response(JSON.stringify({ error: "Invalid provider." }), {
@@ -68,6 +81,18 @@ export const PATCH: APIRoute = async (context) => {
       }
     }
 
+    if (provider === "resend") {
+      const existing = await getEmailSettings();
+      const keyAfterSave =
+        (typeof resendApiKey === "string" && resendApiKey.trim()) || existing?.resendApiKey;
+      if (!keyAfterSave && !usesResendEnvFallback(existing)) {
+        return new Response(JSON.stringify({ error: "Resend API key is required." }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+
     const updated = await updateEmailSettings({
       provider,
       smtpHost: provider === "smtp" ? smtpHost.trim() : null,
@@ -76,6 +101,10 @@ export const PATCH: APIRoute = async (context) => {
       ...(typeof smtpPassword === "string" && smtpPassword.length > 0 ? { smtpPassword } : {}),
       smtpSecure: !!smtpSecure,
       smtpFromEmail: typeof smtpFromEmail === "string" ? smtpFromEmail.trim() || null : null,
+      ...(typeof resendApiKey === "string" && resendApiKey.trim().length > 0
+        ? { resendApiKey: resendApiKey.trim() }
+        : {}),
+      resendFromEmail: typeof resendFromEmail === "string" ? resendFromEmail.trim() || null : null,
     });
 
     return new Response(
@@ -87,6 +116,9 @@ export const PATCH: APIRoute = async (context) => {
         smtpPasswordSet: !!updated.smtpPassword,
         smtpSecure: updated.smtpSecure,
         smtpFromEmail: updated.smtpFromEmail,
+        resendApiKeySet: !!updated.resendApiKey,
+        resendFromEmail: updated.resendFromEmail,
+        resendEnvFallback: usesResendEnvFallback(updated),
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );

--- a/src/pages/dashboard/[projectID]/api-docs.astro
+++ b/src/pages/dashboard/[projectID]/api-docs.astro
@@ -338,9 +338,9 @@ const apiKey = project.apiKey;
             <p class="text-blue-800 dark:text-blue-300 font-semibold mb-3">Setup</p>
             <ol class="text-blue-700 dark:text-blue-400 text-sm space-y-2 list-decimal list-inside">
               <li>Sign up at <span class="font-mono">resend.com</span> and create an API key</li>
-              <li>Set <code class="bg-white/60 dark:bg-white/10 px-1 rounded">RESEND_API_KEY</code> in your environment</li>
+              <li>Paste it under Admin → Email Settings (or pick SMTP and fill in your server details)</li>
               <li>
-                Optionally set <code class="bg-white/60 dark:bg-white/10 px-1 rounded">RESEND_FROM_EMAIL</code>
+                Optionally set a from address there
                 (defaults to <code class="bg-white/60 dark:bg-white/10 px-1 rounded">notifications@beaver.app</code>)
               </li>
               <li>


### PR DESCRIPTION
Closes #272

Resend was the only email provider still configured through environment variables. It now stores its API key and from address in the `email_settings` table, the same way SMTP already did, and is editable under Admin → Email Settings.

## Changes

- **Schema** — `resend_api_key` / `resend_from_email` columns on `email_settings` (migration `0025_resend_settings`)
- **`src/lib/email/resend.ts`** — send functions now take `EmailSettings` as their first argument, matching the SMTP module. No more module-level env reads, so the key is picked up without a restart
- **API** — `GET`/`PATCH /api/email-settings` handle the new fields. The key is never returned, only `resendApiKeySet`; submitting a blank key keeps the stored one, mirroring `smtpPassword`
- **UI** — the read-only "configured via RESEND_API_KEY" badge is replaced with API key and from-email inputs

## Backwards compatibility

`RESEND_API_KEY` and `RESEND_FROM_EMAIL` are still read as a fallback when no key is saved, so existing deployments keep sending mail after upgrading. They are documented as deprecated in the README and `.env.example`, and the settings page shows a notice when the fallback is in use.

## Verification

- `bun run astro sync && bunx tsc --noEmit` — clean
- `bun run lint` — 0 warnings, 0 errors
- `bun run build` — succeeds
- `bun run migrate` — applies cleanly; confirmed both columns exist on `email_settings`

Not manually exercised in a browser: saving a key and sending a live notification through Resend.