### PR TITLE
fix: correct server entrypoint path for @astrojs/node 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV PORT=4321
 
 EXPOSE 4321
 
-CMD ["sh", "-c", "bun src/lib/db/migrate.ts && bun ./dist/server/entry.mjs"]
+CMD ["sh", "-c", "bun src/lib/db/migrate.ts && bun ./dist/server/index.mjs"]


### PR DESCRIPTION
Fixes the v2.3.0 restart loop — deploys succeeded but the container never served.

`@astrojs/node` 11 renamed the standalone server entry from `dist/server/entry.mjs` to `dist/server/index.mjs`. The `Dockerfile` CMD still pointed at the old path, so the container ran migrations, exited immediately on the missing module, and restart-looped until max restarts without ever binding :4321.

The adapter bump in #275 was two majors; the `Dockerfile` was last touched in `fab3e03` and was not updated alongside it. `bun run build` does not exercise the CMD, so nothing in the build caught it.

## Verification

Built the image and ran the container rather than relying on the build alone:

- `docker build` — succeeds
- `docker run` with the fixed CMD — `Migrations complete.`, then `[@astrojs/node] Server listening on ... :4321`
- `curl` against the mapped port — `302` from `/login` (expected redirect on a fresh DB with no admin)
- Container still `Up` after 42s, no restart loop
- Migrations applied from scratch in a clean sandbox; `email_settings` has `resend_api_key` and `resend_from_email`

Before the fix, on the same build: `bun ./dist/server/entry.mjs` → `error: Module not found "./dist/server/entry.mjs"`.